### PR TITLE
AP-4592: Fix "involved child for proceeding" save as draft

### DIFF
--- a/app/forms/providers/proceeding_merits_task/linked_children_form.rb
+++ b/app/forms/providers/proceeding_merits_task/linked_children_form.rb
@@ -5,7 +5,7 @@ module Providers
 
       attr_accessor :linked_children
 
-      validate :one_selected_child?
+      validate :one_selected_child?, unless: :draft?
 
       def value_list
         @value_list ||= legal_aid_application.involved_children.map do |child|

--- a/spec/forms/providers/proceeding_merits_task/linked_children_form_spec.rb
+++ b/spec/forms/providers/proceeding_merits_task/linked_children_form_spec.rb
@@ -86,5 +86,39 @@ RSpec.describe Providers::ProceedingMeritsTask::LinkedChildrenForm, type: :form 
         end
       end
     end
+
+    context "when no linked_children selected" do
+      let(:linked_children_params) { ["", ""] }
+
+      it "adds expected error messages" do
+        expect(form.errors).to be_empty
+        save_form
+        expect(form.errors.messages.values.flatten).to include("At least one child must be covered under this proceeding")
+      end
+    end
+  end
+
+  describe ".save_as_draft" do
+    subject(:save_as_draft) { form.save_as_draft }
+
+    context "when no linked_children selected" do
+      let(:linked_children_params) { [""] }
+
+      it "does not validate the form, adding error messages" do
+        expect(form.errors.messages).to be_empty
+        save_as_draft
+        expect(form.errors.messages).to be_empty
+      end
+    end
+
+    context "when linked_children selected" do
+      let(:linked_children_params) do
+        [legal_aid_application.involved_children.first.id, ""]
+      end
+
+      it "saves the record" do
+        expect { save_as_draft }.to change(proceeding.proceeding_linked_children, :count).by(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What
Fix save as draft functionality for "Children involved in this proceeding" task page

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4592)

Allow save as draft button to function as expected. Namely,
to save the checked items/children if checked but not to enforce 
this, via validation, as a requirement for returning to the "home" page.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
