### PR TITLE
AP-4633: Remove word status

### DIFF
--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -749,8 +749,8 @@ en:
         single_non_specific_item: "Use this page to provide %{item}."
         list_text: 'Use this page to upload:'
         benefit_evidence: evidence that your client receives %{benefit}
-        client_employment_evidence: evidence of your client's employment status
-        partner_employment_evidence: evidence of the partner's employment status
+        client_employment_evidence: evidence of your client's employment
+        partner_employment_evidence: evidence of the partner's employment
         gateway_evidence: gateway evidence for Section 8 proceedings (optional)
         court_application: the application to court for Section 8 proceedings (optional)
         court_order: the court order for Section 8 proceedings

--- a/features/providers/check_single_employment.feature
+++ b/features/providers/check_single_employment.feature
@@ -138,7 +138,7 @@ Feature: Check single employment
 
     When I click 'Save and continue'
     Then I should be on a page showing "Upload supporting evidence"
-    And I should see "Use this page to provide evidence of your client's employment status."
+    And I should see "Use this page to provide evidence of your client's employment."
 
     When I upload an evidence file named 'hello_world.pdf'
     And I sleep for 2 seconds

--- a/features/providers/partner_means_assessment/upload_partner_employment_evidence.feature
+++ b/features/providers/partner_means_assessment/upload_partner_employment_evidence.feature
@@ -8,8 +8,8 @@ Feature: Check partner employment evidence upload
     And I visit "uploaded evidence collection"
 
     Then I should see "Use this page to upload:"
-    And I should see "evidence of your client's employment status"
-    And I should see "evidence of the partner's employment status"
+    And I should see "evidence of your client's employment"
+    And I should see "evidence of the partner's employment"
 
     When I click "Save and continue"
     Then I should see "Upload your client's employment evidence"
@@ -31,4 +31,4 @@ Feature: Check partner employment evidence upload
     And I have completed an application where client and partner are both employed and "partner" has additional information
     And I visit "uploaded evidence collection"
 
-    Then I should see "Use this page to provide evidence of the partner's employment status"
+    Then I should see "Use this page to provide evidence of the partner's employment"


### PR DESCRIPTION

## What

[When prompted for employment evidence, the word status is potentially confusing](https://dsdmoj.atlassian.net/browse/AP-4633)

After review, the word "status" seems to have crept in by mistake, so this is to remove it from the end of the client and partner evidence request.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
