### PR TITLE
AP-4629: Update policy-disregards error handling

### DIFF
--- a/app/views/providers/means/policy_disregards/show.html.erb
+++ b/app/views/providers/means/policy_disregards/show.html.erb
@@ -7,8 +7,12 @@
 
     <%= form.govuk_check_boxes_fieldset :policy_disregards,
                                         legend: { text: page_title, size: "xl", tag: "h1" },
-                                        hint: { text: t("generic.select_all_that_apply") } do %>
-
+                                        hint: { text: t("generic.select_all_that_apply") },
+                                        form_group: { class: @form.errors[:england_infected_blood_support].any? ? "govuk-form-group--error" : "" } do %>
+      <% if @form.errors[:england_infected_blood_support].any? %>
+        <p class="govuk-error-message" id="savings-amount-cash-error">
+          <span class="govuk-visually-hidden">Error: </span><%= @form.errors[:england_infected_blood_support].first %></p>
+      <% end %>
     <div class="deselect-group" data-deselect-ctrl="#policy-disregards-none-selected-true-field">
       <% Providers::PolicyDisregardsForm::SINGLE_VALUE_ATTRIBUTES.each do |checkbox| %>
         <%= form.govuk_check_box checkbox, true, "", multiple: false, link_errors: true, label: { text: t(".#{checkbox}") } %>


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4629)

Implement the work-around for displaying an error block when nothing is selected

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
