### PR TITLE
AP-4651: Update dependant error messaging with partner

### DIFF
--- a/app/controllers/providers/means/has_other_dependants_controller.rb
+++ b/app/controllers/providers/means/has_other_dependants_controller.rb
@@ -19,7 +19,13 @@ module Providers
           journey: :provider,
           radio_buttons_input_name: :has_other_dependant,
           form_params:,
+          error: error_message,
         )
+      end
+
+      def error_message
+        key_name = legal_aid_application&.applicant&.has_partner_with_no_contrary_interest? ? "error_with_partner" : "error"
+        I18n.t("providers.has_other_dependants.show.#{key_name}")
       end
 
       def form_params

--- a/app/forms/legal_aid_applications/has_dependants_form.rb
+++ b/app/forms/legal_aid_applications/has_dependants_form.rb
@@ -4,6 +4,6 @@ module LegalAidApplications
 
     attr_accessor :has_dependants, :draft
 
-    validates :has_dependants, presence: true, unless: :draft?
+    validates :has_dependants, presence_partner_optional: { partner_labels: :has_partner_with_no_contrary_interest? }, unless: :draft?
   end
 end

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -423,6 +423,7 @@ en:
               blank: Confirm the date you used delegated functions
             has_dependants:
               blank: Select yes if your client has any dependants
+              blank_with_partner: Select yes if your client or their partner has any dependants
             has_other_proceeding:
               blank: Select yes if you want to add another proceeding
               must_add_domestic_abuse: You must add at least one domestic abuse proceeding

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -804,7 +804,8 @@ en:
         update: Update
     has_other_dependants:
       show:
-        error: Select yes if they have other dependants
+        error: Select yes if your client has any other dependants
+        error_with_partner: Select yes if your client or their partner have any other dependants
     remove_state_benefits:
       show:
         error: Select yes if you wish to remove this benefit


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4651)

When the applicant has a partner, the on screen questions were updated to include specific partner prompts, but the error messages were not updated, this added partner specific error handling and messages to has_dependants and has_other_dependants

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
