### PR TITLE
AP-4575 [EXT]: Allow whitespace and case-insensitive searching

### DIFF
--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -34,9 +34,9 @@ class BaseForm
     end
 
     def normalizes(name, with:)
-      send(:before_validation, proc {
+      before_validation do
         send("#{name}=", with.call(send(name)))
-      })
+      end
     end
   end
 

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -32,6 +32,12 @@ class BaseForm
     def locally_assigned
       @locally_assigned ||= []
     end
+
+    def normalizes(name, with:)
+      send(:before_validation, proc {
+        send("#{name}=", with.call(send(name)))
+      })
+    end
   end
 
   def initialize(*args)

--- a/app/forms/copy_case/search_form.rb
+++ b/app/forms/copy_case/search_form.rb
@@ -6,6 +6,8 @@ module CopyCase
 
     attr_accessor :search_ref, :copiable_case
 
+    normalizes :search_ref, with: ->(search_ref) { search_ref.strip.upcase }
+
     validates :search_ref,
               presence: true,
               format: { with: APPLICATION_REF_REGEXP },

--- a/app/forms/link_case/search_form.rb
+++ b/app/forms/link_case/search_form.rb
@@ -6,6 +6,8 @@ module LinkCase
 
     APPLICATION_REF_REGEXP = /\AL-[0-9ABCDEFHIJKLMNPRTUVWXY]{3}-[0-9ABCDEFHIJKLMNPRTUVWXY]{3}\z/
 
+    normalizes :search_ref, with: ->(search_ref) { search_ref.strip.upcase }
+
     validates :search_ref,
               presence: true,
               format: { with: APPLICATION_REF_REGEXP },

--- a/spec/forms/copy_case/search_form_spec.rb
+++ b/spec/forms/copy_case/search_form_spec.rb
@@ -67,6 +67,22 @@ RSpec.describe CopyCase::SearchForm, type: :form do
       end
     end
 
+    context "with a mixed case and whitespace including but otherwise valid application reference" do
+      let(:search_ref) { " \t l-TVH-u0t  \t" }
+
+      let(:source_application) do
+        create(:legal_aid_application,
+               application_ref: "L-TVH-U0T",
+               provider: legal_aid_application.provider)
+      end
+
+      before { source_application }
+
+      it "finds the application id" do
+        expect { call_save }.to change(instance, :copiable_case).from(nil).to(source_application)
+      end
+    end
+
     context "with a valid format but non-existant application reference" do
       let(:search_ref) { "L-FFF-FFF" }
 

--- a/spec/forms/link_case/search_form_spec.rb
+++ b/spec/forms/link_case/search_form_spec.rb
@@ -37,6 +37,20 @@ RSpec.describe LinkCase::SearchForm, type: :form do
       end
     end
 
+    context "with a mixed case and whitespace including but otherwise valid application reference" do
+      let(:search_ref) { " \t l-TVH-u0t  \t" }
+
+      let(:source_application) do
+        create(:legal_aid_application, application_ref: "L-TVH-U0T")
+      end
+
+      before { source_application }
+
+      it "finds the application id" do
+        expect { call_save }.to change(instance, :linkable_case).from(nil).to(source_application)
+      end
+    end
+
     context "with a valid format but non-existant application reference" do
       let(:search_ref) { "L-FFF-FFF" }
 


### PR DESCRIPTION
## What
Allow whitespace and case-insenstive search for copy and link of cases

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4575)

So inadvertent whitespace or character case use does
not prevent users from finding otherwise valid case
references for copying or linking.

The addition of the class method to the base_form
means this could be used for other form attributes, such
as postcode (BaseAddressLookupForm)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
