### PR TITLE
FactoryBot/Fix: remove primary key generation from factories and specs

### DIFF
--- a/spec/factories/employments.rb
+++ b/spec/factories/employments.rb
@@ -4,12 +4,10 @@ FactoryBot.define do
     sequence(:name) { |n| sprintf("Job %05d", n) }
 
     trait :example1_usecase1 do
-      id { "12345678-1234-1234-1234-123456789abc" }
       name { "Job 788" }
 
       after(:create) do |employment|
         create(:employment_payment,
-               id: "20211128-0000-0000-0000-123456789abc",
                employment:,
                date: Date.new(2021, 11, 28),
                gross: 1868.98,
@@ -19,7 +17,6 @@ FactoryBot.define do
                net_employment_income: 1578.54)
 
         create(:employment_payment,
-               id: "20211028-0000-0000-0000-123456789abc",
                employment:,
                date: Date.new(2021, 10, 28),
                gross: 1868.98,
@@ -29,7 +26,6 @@ FactoryBot.define do
                net_employment_income: 1629.34)
 
         create(:employment_payment,
-               id: "20210928-0000-0000-0000-123456789abc",
                employment:,
                date: Date.new(2021, 9, 28),
                gross: 2492.61,
@@ -39,7 +35,6 @@ FactoryBot.define do
                net_employment_income: 2002.54)
 
         create(:employment_payment,
-               id: "20210828-0000-0000-0000-123456789abc",
                employment:,
                date: Date.new(2021, 8, 28),
                gross: 2345.29,
@@ -50,12 +45,10 @@ FactoryBot.define do
       end
     end
     trait :example2_usecase1 do
-      id { "87654321-1234-1234-1234-123456789abc" }
       name { "Job 877" }
 
       after(:create) do |employment|
         create(:employment_payment,
-               id: "20231024-0000-0000-0000-123456789abc",
                employment:,
                date: Date.new(2021, 11, 28),
                gross: 1868.98,
@@ -65,7 +58,6 @@ FactoryBot.define do
                net_employment_income: 1578.54)
 
         create(:employment_payment,
-               id: "20230924-0000-0000-0000-123456789abc",
                employment:,
                date: Date.new(2021, 10, 28),
                gross: 1868.98,
@@ -75,7 +67,6 @@ FactoryBot.define do
                net_employment_income: 1629.34)
 
         create(:employment_payment,
-               id: "20230824-0000-0000-0000-123456789abc",
                employment:,
                date: Date.new(2021, 9, 28),
                gross: 2492.61,
@@ -85,7 +76,6 @@ FactoryBot.define do
                net_employment_income: 2002.54)
 
         create(:employment_payment,
-               id: "20230724-0000-0000-0000-123456789abc",
                employment:,
                date: Date.new(2021, 8, 28),
                gross: 2345.29,

--- a/spec/services/cfe_civil/components/employments_spec.rb
+++ b/spec/services/cfe_civil/components/employments_spec.rb
@@ -34,14 +34,16 @@ RSpec.describe CFECivil::Components::Employments do
 
     context "and no owner type is specified" do
       it "renders the expected JSON for just the client" do
-        expect(call).to eq({
+        result = JSON.parse(call, symbolize_names: true)
+
+        expect(result).to match hash_including({
           employment_income: [
             {
               name: "Job 788",
-              client_id: "12345678-1234-1234-1234-123456789abc",
+              client_id: kind_of(String),
               payments: [
                 {
-                  client_id: "20211128-0000-0000-0000-123456789abc",
+                  client_id: kind_of(String),
                   date: "2021-11-28",
                   gross: 1868.98,
                   benefits_in_kind: 0.0,
@@ -50,7 +52,7 @@ RSpec.describe CFECivil::Components::Employments do
                   net_employment_income: 1578.54,
                 },
                 {
-                  client_id: "20211028-0000-0000-0000-123456789abc",
+                  client_id: kind_of(String),
                   date: "2021-10-28",
                   gross: 1868.98,
                   benefits_in_kind: 0.0,
@@ -59,7 +61,7 @@ RSpec.describe CFECivil::Components::Employments do
                   net_employment_income: 1629.34,
                 },
                 {
-                  client_id: "20210928-0000-0000-0000-123456789abc",
+                  client_id: kind_of(String),
                   date: "2021-09-28",
                   gross: 2492.61,
                   benefits_in_kind: 0.0,
@@ -68,7 +70,7 @@ RSpec.describe CFECivil::Components::Employments do
                   net_employment_income: 2002.54,
                 },
                 {
-                  client_id: "20210828-0000-0000-0000-123456789abc",
+                  client_id: kind_of(String),
                   date: "2021-08-28",
                   gross: 2345.29,
                   benefits_in_kind: 0.0,
@@ -79,7 +81,7 @@ RSpec.describe CFECivil::Components::Employments do
               ],
             },
           ],
-        }.to_json)
+        })
       end
     end
 
@@ -87,14 +89,16 @@ RSpec.describe CFECivil::Components::Employments do
       subject(:call) { described_class.call(legal_aid_application, "Partner") }
 
       it "renders the expected JSON for just the partner" do
-        expect(call).to eq({
+        result = JSON.parse(call, symbolize_names: true)
+
+        expect(result).to match hash_including({
           employments: [
             {
               name: "Job 877",
-              client_id: "87654321-1234-1234-1234-123456789abc",
+              client_id: kind_of(String),
               payments: [
                 {
-                  client_id: "20231024-0000-0000-0000-123456789abc",
+                  client_id: kind_of(String),
                   date: "2021-11-28",
                   gross: 1868.98,
                   benefits_in_kind: 0.0,
@@ -103,7 +107,7 @@ RSpec.describe CFECivil::Components::Employments do
                   net_employment_income: 1578.54,
                 },
                 {
-                  client_id: "20230924-0000-0000-0000-123456789abc",
+                  client_id: kind_of(String),
                   date: "2021-10-28",
                   gross: 1868.98,
                   benefits_in_kind: 0.0,
@@ -112,7 +116,7 @@ RSpec.describe CFECivil::Components::Employments do
                   net_employment_income: 1629.34,
                 },
                 {
-                  client_id: "20230824-0000-0000-0000-123456789abc",
+                  client_id: kind_of(String),
                   date: "2021-09-28",
                   gross: 2492.61,
                   benefits_in_kind: 0.0,
@@ -121,7 +125,7 @@ RSpec.describe CFECivil::Components::Employments do
                   net_employment_income: 2002.54,
                 },
                 {
-                  client_id: "20230724-0000-0000-0000-123456789abc",
+                  client_id: kind_of(String),
                   date: "2021-08-28",
                   gross: 2345.29,
                   benefits_in_kind: 0.0,
@@ -132,7 +136,7 @@ RSpec.describe CFECivil::Components::Employments do
               ],
             },
           ],
-        }.to_json)
+        })
       end
     end
   end

--- a/spec/services/cfe_civil/components/partner_spec.rb
+++ b/spec/services/cfe_civil/components/partner_spec.rb
@@ -168,7 +168,9 @@ RSpec.describe CFECivil::Components::Partner do
       end
 
       it "returns json in the expected format" do
-        expect(call).to eq({
+        result = JSON.parse(call, symbolize_names: true)
+
+        expect(result).to match hash_including({
           partner: {
             partner: {
               date_of_birth: legal_aid_application.partner.date_of_birth.strftime("%Y-%m-%d"),
@@ -182,10 +184,10 @@ RSpec.describe CFECivil::Components::Partner do
             employments: [
               {
                 name: "Job 877",
-                client_id: "87654321-1234-1234-1234-123456789abc",
+                client_id: kind_of(String),
                 payments: [
                   {
-                    client_id: "20231024-0000-0000-0000-123456789abc",
+                    client_id: kind_of(String),
                     date: "2021-11-28",
                     gross: 1868.98,
                     benefits_in_kind: 0.0,
@@ -194,7 +196,7 @@ RSpec.describe CFECivil::Components::Partner do
                     net_employment_income: 1578.54,
                   },
                   {
-                    client_id: "20230924-0000-0000-0000-123456789abc",
+                    client_id: kind_of(String),
                     date: "2021-10-28",
                     gross: 1868.98,
                     benefits_in_kind: 0.0,
@@ -203,7 +205,7 @@ RSpec.describe CFECivil::Components::Partner do
                     net_employment_income: 1629.34,
                   },
                   {
-                    client_id: "20230824-0000-0000-0000-123456789abc",
+                    client_id: kind_of(String),
                     date: "2021-09-28",
                     gross: 2492.61,
                     benefits_in_kind: 0.0,
@@ -212,7 +214,7 @@ RSpec.describe CFECivil::Components::Partner do
                     net_employment_income: 2002.54,
                   },
                   {
-                    client_id: "20230724-0000-0000-0000-123456789abc",
+                    client_id: kind_of(String),
                     date: "2021-08-28",
                     gross: 2345.29,
                     benefits_in_kind: 0.0,
@@ -229,7 +231,7 @@ RSpec.describe CFECivil::Components::Partner do
               non_liquid_capital: [],
             },
           },
-        }.to_json)
+        })
       end
     end
   end


### PR DESCRIPTION
## What
Remove factory attributes and tests that rely on PK ids

Split from [factory_bot_rails bump PR](https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/6014)

Problem with factory_bot_rails include a default config option that 
seeks to prevent setting of PK ids in factories.  The `config.factory_bot.reject_primary_key_attributes`
is set to true AND setting to false is not working currently (possibly due to loading bugs with factory_bot
and factory_bot_rails). However this is probably for the best as tests reliant on PK Ids are not
ideal.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
