### PR TITLE
delete any PVC named after the release [long named branch]

### DIFF
--- a/bin/delete_dependabot_deployment
+++ b/bin/delete_dependabot_deployment
@@ -14,6 +14,8 @@ if [[ $UAT_RELEASES == *"$RELEASE_NAME"* ]]
 then
   helm delete $RELEASE_NAME --namespace=${K8S_NAMESPACE}
 
+  echo "Searching for PVCs matching $RELEASE_NAME..."
+
   for pvc in $(kubectl --namespace=${K8S_NAMESPACE} get pvc -o custom-columns=":metadata.name" | grep $RELEASE_NAME)
   do
     kubectl --namespace=${K8S_NAMESPACE} delete pvc $pvc

--- a/bin/delete_dependabot_deployment
+++ b/bin/delete_dependabot_deployment
@@ -18,8 +18,8 @@ then
 
   for pvc in $(kubectl --namespace=${K8S_NAMESPACE} get pvc -o custom-columns=":metadata.name" | grep $RELEASE_NAME)
   do
-    echo "Would delete PVC $pvc"
-    # kubectl --namespace=${K8S_NAMESPACE} delete pvc $pvc
+    echo "Deleting PVC $pvc"
+    kubectl --namespace=${K8S_NAMESPACE} delete pvc $pvc
   done
 
   echo "Deleted UAT dependabot release $RELEASE_NAME"

--- a/bin/delete_dependabot_deployment
+++ b/bin/delete_dependabot_deployment
@@ -13,12 +13,12 @@ echo "$UAT_RELEASES"
 if [[ $UAT_RELEASES == *"$RELEASE_NAME"* ]]
 then
   helm delete $RELEASE_NAME --namespace=${K8S_NAMESPACE}
-  kubectl --namespace=${K8S_NAMESPACE} delete pvc data-$RELEASE_NAME-postgresql-0
-  if [[ $RELEASE_NAME == *"redis"* ]]; then
-    kubectl --namespace=${K8S_NAMESPACE} delete pvc redis-data-$RELEASE_NAME-master-0
-  else
-    kubectl --namespace=${K8S_NAMESPACE} delete pvc redis-data-$RELEASE_NAME-redis-master-0
-  fi
+
+  for pvc in $(kubectl --namespace=${K8S_NAMESPACE} get pvc -o custom-columns=":metadata.name" | grep $RELEASE_NAME)
+  do
+    kubectl --namespace=${K8S_NAMESPACE} delete pvc $pvc
+  done
+
   echo "Deleted UAT dependabot release $RELEASE_NAME"
 else
   echo "UAT dependabot release $RELEASE_NAME was not found"

--- a/bin/delete_dependabot_deployment
+++ b/bin/delete_dependabot_deployment
@@ -18,7 +18,8 @@ then
 
   for pvc in $(kubectl --namespace=${K8S_NAMESPACE} get pvc -o custom-columns=":metadata.name" | grep $RELEASE_NAME)
   do
-    kubectl --namespace=${K8S_NAMESPACE} delete pvc $pvc
+    echo "Would delete PVC $pvc"
+    # kubectl --namespace=${K8S_NAMESPACE} delete pvc $pvc
   done
 
   echo "Deleted UAT dependabot release $RELEASE_NAME"


### PR DESCRIPTION
## What
delete any dependabot persistent volume claims after build and deploy of branch

we have too many PVCs sitting around and have been asked to tidy them up. This mechanism is looking to use something that is not dependant on the PVC name so as to decouple if from the complex naming logic.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
