### PR TITLE
AP-3811 partner means assessment

### DIFF
--- a/app/models/cfe/v4/result.rb
+++ b/app/models/cfe/v4/result.rb
@@ -35,7 +35,7 @@ module CFE
         overall_result[:income_contribution]
       end
 
-      def capital_summary
+      def capital_summary(**)
         result_summary[:capital]
       end
 
@@ -51,11 +51,11 @@ module CFE
         assessment[:capital]
       end
 
-      def gross_income_breakdown
+      def gross_income_breakdown(**)
         assessment[:gross_income]
       end
 
-      def gross_income_summary
+      def gross_income_summary(**)
         result_summary[:gross_income]
       end
 
@@ -63,11 +63,11 @@ module CFE
         min_threshold(gross_income_summary[:proceeding_types], :upper_threshold)
       end
 
-      def total_disposable_income_assessed
+      def total_disposable_income_assessed(**)
         disposable_income_summary[:total_disposable_income]
       end
 
-      def total_gross_income_assessed
+      def total_gross_income_assessed(**)
         gross_income_summary[:total_gross_income]
       end
 
@@ -75,11 +75,11 @@ module CFE
         gross_income_summary[:proceeding_types]
       end
 
-      def disposable_income_summary
+      def disposable_income_summary(**)
         result_summary[:disposable_income]
       end
 
-      def disposable_income_breakdown
+      def disposable_income_breakdown(**)
         assessment[:disposable_income]
       end
 
@@ -211,35 +211,35 @@ module CFE
       #                                                              #
       ################################################################
 
-      def monthly_state_benefits
+      def monthly_state_benefits(**)
         gross_income_breakdown[:state_benefits][:monthly_equivalents][:all_sources]
       end
 
-      def mei_friends_or_family
+      def mei_friends_or_family(**)
         monthly_income_equivalents[:friends_or_family]
       end
 
-      def mei_maintenance_in
+      def mei_maintenance_in(**)
         monthly_income_equivalents[:maintenance_in]
       end
 
-      def mei_property_or_lodger
+      def mei_property_or_lodger(**)
         monthly_income_equivalents[:property_or_lodger]
       end
 
-      def mei_student_loan
+      def mei_student_loan(**)
         gross_income_breakdown[:irregular_income][:monthly_equivalents][:student_loan]
       end
 
-      def mei_pension
+      def mei_pension(**)
         monthly_income_equivalents[:pension]
       end
 
-      def total_monthly_income
+      def total_monthly_income(**)
         mei_pension + mei_student_loan + mei_property_or_lodger + mei_maintenance_in + mei_friends_or_family + monthly_state_benefits
       end
 
-      def total_monthly_income_including_employment_income
+      def total_monthly_income_including_employment_income(**)
         total_monthly_income + employment_income_gross_income
       end
 
@@ -249,27 +249,27 @@ module CFE
       #                                                              #
       ################################################################
 
-      def moe_housing
+      def moe_housing(**)
         disposable_income_summary[:net_housing_costs].abs
       end
 
-      def moe_childcare
+      def moe_childcare(**)
         monthly_outgoing_equivalents[:child_care].abs
       end
 
-      def moe_maintenance_out
+      def moe_maintenance_out(**)
         monthly_outgoing_equivalents[:maintenance_out].abs
       end
 
-      def moe_legal_aid
+      def moe_legal_aid(**)
         monthly_outgoing_equivalents[:legal_aid].abs
       end
 
-      def total_monthly_outgoings
+      def total_monthly_outgoings(**)
         moe_housing + moe_childcare + moe_maintenance_out + moe_legal_aid
       end
 
-      def total_monthly_outgoings_including_tax_and_ni
+      def total_monthly_outgoings_including_tax_and_ni(**)
         total_monthly_outgoings - employment_income_tax - employment_income_national_insurance
       end
 
@@ -301,31 +301,31 @@ module CFE
       #                                                              #
       ################################################################
 
-      def employment_income
+      def employment_income(**)
         disposable_income_summary[:employment_income]
       end
 
-      def employment_income_gross_income
+      def employment_income_gross_income(**)
         employment_income[:gross_income] || 0.0
       end
 
-      def employment_income_benefits_in_kind
+      def employment_income_benefits_in_kind(**)
         employment_income[:benefits_in_kind] || 0.0
       end
 
-      def employment_income_tax
+      def employment_income_tax(**)
         employment_income[:tax] || 0.0
       end
 
-      def employment_income_national_insurance
+      def employment_income_national_insurance(**)
         employment_income[:national_insurance] || 0.0
       end
 
-      def employment_income_fixed_employment_deduction
+      def employment_income_fixed_employment_deduction(**)
         employment_income[:fixed_employment_deduction] || 0.0
       end
 
-      def employment_income_net_employment_income
+      def employment_income_net_employment_income(**)
         employment_income[:net_employment_income] || 0.0
       end
 
@@ -344,11 +344,11 @@ module CFE
         threshold == MAX_VALUE ? "N/a" : threshold
       end
 
-      def monthly_income_equivalents
+      def monthly_income_equivalents(**)
         gross_income_breakdown[:other_income][:monthly_equivalents][:all_sources]
       end
 
-      def monthly_outgoing_equivalents
+      def monthly_outgoing_equivalents(**)
         disposable_income_breakdown[:monthly_equivalents][:all_sources]
       end
 

--- a/app/models/cfe/v6/result.rb
+++ b/app/models/cfe/v6/result.rb
@@ -28,6 +28,56 @@ module CFE
       def ineligible_disposable_capital?
         capital_results.all?("ineligible")
       end
+
+      def partner_gross_income_breakdown
+        assessment[:partner_gross_income]
+      end
+
+      ################################################################
+      #                                                              #
+      #  EMPLOYMENT_INCOME                                           #
+      #                                                              #
+      ################################################################
+
+      def disposable_income_summary(partner: false)
+        partner ? result_summary[:partner_disposable_income] : result_summary[:disposable_income]
+      end
+
+      def employment_income(partner: false)
+        disposable_income_summary(partner:)[:employment_income]
+      end
+
+      def employment_income_gross_income(partner: false)
+        employment_income(partner:)[:gross_income] || 0.0
+      end
+
+      def employment_income_benefits_in_kind(partner: false)
+        employment_income(partner:)[:benefits_in_kind] || 0.0
+      end
+
+      def employment_income_tax(partner: false)
+        employment_income(partner:)[:tax] || 0.0
+      end
+
+      def employment_income_national_insurance(partner: false)
+        employment_income(partner:)[:national_insurance] || 0.0
+      end
+
+      def employment_income_fixed_employment_deduction(partner: false)
+        employment_income(partner:)[:fixed_employment_deduction] || 0.0
+      end
+
+      def employment_income_net_employment_income(partner: false)
+        employment_income(partner:)[:net_employment_income] || 0.0
+      end
+
+      def partner_jobs
+        partner_gross_income_breakdown[:employment_income]
+      end
+
+      def partner_jobs?
+        partner_jobs&.any?
+      end
     end
   end
 end

--- a/app/models/cfe/v6/result.rb
+++ b/app/models/cfe/v6/result.rb
@@ -206,6 +206,55 @@ module CFE
         total_deductions - employment_income_fixed_employment_deduction
       end
 
+      ################################################################
+      #                                                              #
+      #  CAPITAL                                                     #
+      #                                                              #
+      ################################################################
+
+      def capital_summary(partner: false)
+        partner ? result_summary[:partner_capital] : result_summary[:capital]
+      end
+
+      def partner_capital
+        assessment[:partner_capital]
+      end
+
+      def partner_capital?
+        assessment.has_key?(:partner_capital)
+      end
+
+      def current_accounts
+        accounts = liquid_capital_items.select{ |item| item[:description].downcase!.include?('current accounts') }
+        accounts.sum { |account| account[:value] }
+      end
+
+      def savings_accounts
+        accounts = liquid_capital_items.select{ |item| item[:description].downcase!.include?('savings accounts') }
+        accounts.sum { |account| account[:value] }
+      end
+
+      def non_liquid_capital_items
+        client_items = capital[:capital_items][:non_liquid].sort_by { |item| item[:description] }
+        partner_items = partner_capital? ? partner_capital[:capital_items][:non_liquid] : []
+        client_items.concat(partner_items).sort_by { |item| item[:description] }
+      end
+
+      def liquid_capital_items
+        client_items = capital[:capital_items][:liquid].sort_by { |item| item[:description] }
+        partner_items = partner_capital? ? partner_capital[:capital_items][:liquid] : []
+        client_items.concat(partner_items).sort_by { |item| item[:description] }
+      end
+
+      def total_savings(partner: false)
+        client_savings = capital_summary[:total_liquid]
+        partner_savings = partner ? capital_summary(partner:true)[:total_liquid] : 0.0
+        client_savings + partner_savings
+      end
+
+      def total_capital
+        capital = result_summary[:capital][:total_capital]
+        partner_capital? ? capital += result_summary[:partner_capital][:total_capital] : capital
       end
     end
   end

--- a/app/models/cfe/v6/result.rb
+++ b/app/models/cfe/v6/result.rb
@@ -187,6 +187,25 @@ module CFE
         partner_total = partner ? (total_monthly_outgoings(partner:) - employment_income_tax(partner:) - employment_income_national_insurance(partner:)) : 0.0
         client_total + partner_total
       end
+
+      ################################################################
+      #                                                              #
+      #  DEDUCTIONS                                                  #
+      #                                                              #
+      ################################################################
+
+      def partner_allowance
+        disposable_income_summary[:partner_allowance]
+      end
+
+      def total_deductions
+        dependants_allowance + disregarded_state_benefits + partner_allowance
+      end
+
+      def total_deductions_including_fixed_employment_allowance
+        total_deductions - employment_income_fixed_employment_deduction
+      end
+
       end
     end
   end

--- a/app/models/cfe/v6/result.rb
+++ b/app/models/cfe/v6/result.rb
@@ -41,12 +41,18 @@ module CFE
         partner ? result_summary[:partner_gross_income] : result_summary[:gross_income]
       end
 
+      def total_gross_income(partner: false)
+        total_gross_income_assessed(partner:)
+      end
+
       def total_gross_income_assessed(partner: false)
         gross_income_summary(partner:)[:total_gross_income]
       end
 
-      def total_gross_income(partner: false)
-        total_gross_income_assessed(partner:)
+      def total_disposable_income_assessed(partner: false)
+        client_total = disposable_income_summary[:total_disposable_income]
+        partner_total = partner ? disposable_income_summary(partner:)[:total_disposable_income] : 0.0
+        client_total + partner_total
       end
 
       ################################################################
@@ -140,9 +146,7 @@ module CFE
       end
 
       def total_monthly_income(partner: false)
-        mei_pension(partner:) + mei_student_loan(partner:)
-        + mei_property_or_lodger(partner:) + mei_maintenance_in(partner:)
-        + mei_friends_or_family(partner:) + monthly_state_benefits(partner:)
+        mei_pension(partner:) + mei_student_loan(partner:) + mei_property_or_lodger(partner:) + mei_maintenance_in(partner:) + mei_friends_or_family(partner:) + monthly_state_benefits(partner:)
       end
 
       def total_monthly_income_including_employment_income(partner: false)
@@ -150,7 +154,6 @@ module CFE
         partner_total = partner ? total_monthly_income(partner:) + employment_income_gross_income(partner:) : 0.0
         client_total + partner_total
       end
-
 
       ################################################################
       #                                                              #
@@ -221,16 +224,16 @@ module CFE
       end
 
       def partner_capital?
-        assessment.has_key?(:partner_capital)
+        assessment.key?(:partner_capital)
       end
 
       def current_accounts
-        accounts = liquid_capital_items.select{ |item| item[:description].downcase!.include?('current accounts') }
+        accounts = liquid_capital_items.select { |item| item[:description].downcase!.include?("current accounts") }
         accounts.sum { |account| account[:value] }
       end
 
       def savings_accounts
-        accounts = liquid_capital_items.select{ |item| item[:description].downcase!.include?('savings accounts') }
+        accounts = liquid_capital_items.select { |item| item[:description].downcase!.include?("savings accounts") }
         accounts.sum { |account| account[:value] }
       end
 
@@ -248,13 +251,28 @@ module CFE
 
       def total_savings(partner: false)
         client_savings = capital_summary[:total_liquid]
-        partner_savings = partner ? capital_summary(partner:true)[:total_liquid] : 0.0
+        partner_savings = partner ? capital_summary(partner: true)[:total_liquid] : 0.0
         client_savings + partner_savings
       end
 
       def total_capital
-        capital = result_summary[:capital][:total_capital]
-        partner_capital? ? capital += result_summary[:partner_capital][:total_capital] : capital
+        client_total = result_summary[:capital][:total_capital]
+        partner_total = partner_capital? ? result_summary[:partner_capital][:total_capital] : 0.0
+        client_total + partner_total
+      end
+
+      ################################################################
+      #                                                              #
+      #  TOTALS                                                      #
+      #                                                              #
+      ################################################################
+
+      def total_capital_before_pensioner_disregard(partner: false)
+        total_property + total_savings(partner:) + total_vehicles + total_other_assets
+      end
+
+      def total_disposable_capital(partner: false)
+        [0, (total_capital_before_pensioner_disregard(partner:) + pensioner_capital_disregard)].max
       end
     end
   end

--- a/app/models/cfe/v6/result.rb
+++ b/app/models/cfe/v6/result.rb
@@ -104,6 +104,10 @@ module CFE
       end
 
       def partner_jobs
+        unless assessment.key?(:partner_gross_income)
+          return []
+        end
+
         gross_income_breakdown(partner: true)[:employment_income]
       end
 
@@ -198,15 +202,19 @@ module CFE
       ################################################################
 
       def partner_allowance
-        disposable_income_summary[:partner_allowance]
+        disposable_income_summary.key?(:partner_allowance) ? disposable_income_summary[:partner_allowance] : 0.0
       end
 
       def total_deductions
         dependants_allowance + disregarded_state_benefits + partner_allowance
       end
 
-      def total_deductions_including_fixed_employment_allowance(partner: false)
-        total_deductions - employment_income_fixed_employment_deduction - employment_income_fixed_employment_deduction(partner:)
+      def total_deductions_including_fixed_employment_allowance
+        employment_deduction = employment_income_fixed_employment_deduction
+        if partner_jobs?
+          employment_deduction * 2
+        end
+        total_deductions - employment_deduction
       end
 
       ################################################################

--- a/app/models/cfe/v6/result.rb
+++ b/app/models/cfe/v6/result.rb
@@ -210,10 +210,7 @@ module CFE
       end
 
       def total_deductions_including_fixed_employment_allowance
-        employment_deduction = employment_income_fixed_employment_deduction
-        if partner_jobs?
-          employment_deduction * 2
-        end
+        employment_deduction = partner_jobs? ? employment_income_fixed_employment_deduction * 2 : employment_income_fixed_employment_deduction
         total_deductions - employment_deduction
       end
 

--- a/app/models/cfe/v6/result.rb
+++ b/app/models/cfe/v6/result.rb
@@ -205,8 +205,8 @@ module CFE
         dependants_allowance + disregarded_state_benefits + partner_allowance
       end
 
-      def total_deductions_including_fixed_employment_allowance
-        total_deductions - employment_income_fixed_employment_deduction
+      def total_deductions_including_fixed_employment_allowance(partner: false)
+        total_deductions - employment_income_fixed_employment_deduction - employment_income_fixed_employment_deduction(partner:)
       end
 
       ################################################################
@@ -237,21 +237,15 @@ module CFE
         accounts.sum { |account| account[:value] }
       end
 
-      def non_liquid_capital_items
-        client_items = capital[:capital_items][:non_liquid].sort_by { |item| item[:description] }
-        partner_items = partner_capital? ? partner_capital[:capital_items][:non_liquid] : []
-        client_items.concat(partner_items).sort_by { |item| item[:description] }
-      end
-
       def liquid_capital_items
         client_items = capital[:capital_items][:liquid].sort_by { |item| item[:description] }
         partner_items = partner_capital? ? partner_capital[:capital_items][:liquid] : []
         client_items.concat(partner_items).sort_by { |item| item[:description] }
       end
 
-      def total_savings(partner: false)
+      def total_savings
         client_savings = capital_summary[:total_liquid]
-        partner_savings = partner ? capital_summary(partner: true)[:total_liquid] : 0.0
+        partner_savings = partner_capital? ? capital_summary(partner: true)[:total_liquid] : 0.0
         client_savings + partner_savings
       end
 
@@ -267,12 +261,12 @@ module CFE
       #                                                              #
       ################################################################
 
-      def total_capital_before_pensioner_disregard(partner: false)
-        total_property + total_savings(partner:) + total_vehicles + total_other_assets
+      def total_capital_before_pensioner_disregard
+        total_property + total_savings + total_vehicles + total_other_assets
       end
 
-      def total_disposable_capital(partner: false)
-        [0, (total_capital_before_pensioner_disregard(partner:) + pensioner_capital_disregard)].max
+      def total_disposable_capital
+        [0, (total_capital_before_pensioner_disregard + pensioner_capital_disregard)].max
       end
     end
   end

--- a/app/models/cfe/v6/result.rb
+++ b/app/models/cfe/v6/result.rb
@@ -33,15 +33,23 @@ module CFE
         assessment[:partner_gross_income]
       end
 
+      def gross_income_breakdown(partner: false)
+        partner ? assessment[:partner_gross_income] : assessment[:gross_income]
+      end
+
+      def disposable_income_summary(partner: false)
+        partner ? result_summary[:partner_disposable_income] : result_summary[:disposable_income]
+      end
+
+      def disposable_income_breakdown(partner: false)
+        partner ? assessment[:partner_disposable_income] : assessment[:disposable_income]
+      end
+
       ################################################################
       #                                                              #
       #  EMPLOYMENT_INCOME                                           #
       #                                                              #
       ################################################################
-
-      def disposable_income_summary(partner: false)
-        partner ? result_summary[:partner_disposable_income] : result_summary[:disposable_income]
-      end
 
       def employment_income(partner: false)
         disposable_income_summary(partner:)[:employment_income]
@@ -72,11 +80,89 @@ module CFE
       end
 
       def partner_jobs
-        partner_gross_income_breakdown[:employment_income]
+        gross_income_breakdown(partner: true)[:employment_income]
       end
 
       def partner_jobs?
         partner_jobs&.any?
+      end
+
+      ################################################################
+      #                                                              #
+      #  MONTHLY INCOME EQUIVALENTS                                  #
+      #                                                              #
+      ################################################################
+
+      def monthly_income_equivalents(partner: false)
+        gross_income_breakdown(partner:)[:other_income][:monthly_equivalents][:all_sources]
+      end
+
+      def monthly_state_benefits(partner: false)
+        gross_income_breakdown(partner:)[:state_benefits][:monthly_equivalents][:all_sources]
+      end
+
+      def mei_friends_or_family(partner: false)
+        monthly_income_equivalents(partner:)[:friends_or_family]
+      end
+
+      def mei_maintenance_in(partner: false)
+        monthly_income_equivalents(partner:)[:maintenance_in]
+      end
+
+      def mei_property_or_lodger(partner: false)
+        monthly_income_equivalents(partner:)[:property_or_lodger]
+      end
+
+      def mei_student_loan(partner: false)
+        gross_income_breakdown(partner:)[:irregular_income][:monthly_equivalents][:student_loan]
+      end
+
+      def mei_pension(partner: false)
+        monthly_income_equivalents(partner:)[:pension]
+      end
+
+      # def total_monthly_income(partner: false)
+      #   mei_pension(partner:) + mei_student_loan(partner:)
+      #   + mei_property_or_lodger(partner:) + mei_maintenance_in(partner:)
+      #   + mei_friends_or_family(partner:) + monthly_state_benefits(partner:)
+      # end
+      #
+      # def total_monthly_income_including_employment_income(partner: false)
+      #   total_monthly_income(partner:) + employment_income_gross_income(partner:)
+      # end
+
+      ################################################################
+      #                                                              #
+      #  MONTHLY_OUTGOING_EQUIVALENTS                                #
+      #                                                              #
+      ################################################################
+
+      def monthly_outgoing_equivalents(partner: false)
+        disposable_income_breakdown(partner:)[:monthly_equivalents][:all_sources]
+      end
+
+      def moe_housing(partner: false)
+        disposable_income_summary(partner:)[:net_housing_costs].abs
+      end
+
+      def moe_childcare(partner: false)
+        monthly_outgoing_equivalents(partner:)[:child_care].abs
+      end
+
+      def moe_maintenance_out(partner: false)
+        monthly_outgoing_equivalents(partner:)[:maintenance_out].abs
+      end
+
+      def moe_legal_aid(partner: false)
+        monthly_outgoing_equivalents(partner:)[:legal_aid].abs
+      end
+
+      def total_monthly_outgoings(partner: false)
+        moe_housing(partner:) + moe_childcare(partner:) + moe_maintenance_out(partner:) + moe_legal_aid(partner:)
+      end
+
+      def total_monthly_outgoings_including_tax_and_ni(partner: false)
+        total_monthly_outgoings(partner:) - employment_income_tax(partner:) - employment_income_national_insurance(partner:)
       end
     end
   end

--- a/app/models/cfe/v6/result.rb
+++ b/app/models/cfe/v6/result.rb
@@ -37,6 +37,24 @@ module CFE
         partner ? assessment[:partner_gross_income] : assessment[:gross_income]
       end
 
+      def gross_income_summary(partner: false)
+        partner ? result_summary[:partner_gross_income] : result_summary[:gross_income]
+      end
+
+      def total_gross_income_assessed(partner: false)
+        gross_income_summary(partner:)[:total_gross_income]
+      end
+
+      def total_gross_income(partner: false)
+        total_gross_income_assessed(partner:)
+      end
+
+      ################################################################
+      #                                                              #
+      #  DISPOSABLE INCOME                                           #
+      #                                                              #
+      ################################################################
+
       def disposable_income_summary(partner: false)
         partner ? result_summary[:partner_disposable_income] : result_summary[:disposable_income]
       end
@@ -121,15 +139,18 @@ module CFE
         monthly_income_equivalents(partner:)[:pension]
       end
 
-      # def total_monthly_income(partner: false)
-      #   mei_pension(partner:) + mei_student_loan(partner:)
-      #   + mei_property_or_lodger(partner:) + mei_maintenance_in(partner:)
-      #   + mei_friends_or_family(partner:) + monthly_state_benefits(partner:)
-      # end
-      #
-      # def total_monthly_income_including_employment_income(partner: false)
-      #   total_monthly_income(partner:) + employment_income_gross_income(partner:)
-      # end
+      def total_monthly_income(partner: false)
+        mei_pension(partner:) + mei_student_loan(partner:)
+        + mei_property_or_lodger(partner:) + mei_maintenance_in(partner:)
+        + mei_friends_or_family(partner:) + monthly_state_benefits(partner:)
+      end
+
+      def total_monthly_income_including_employment_income(partner: false)
+        client_total = total_monthly_income + employment_income_gross_income
+        partner_total = partner ? total_monthly_income(partner:) + employment_income_gross_income(partner:) : 0.0
+        client_total + partner_total
+      end
+
 
       ################################################################
       #                                                              #
@@ -162,7 +183,10 @@ module CFE
       end
 
       def total_monthly_outgoings_including_tax_and_ni(partner: false)
-        total_monthly_outgoings(partner:) - employment_income_tax(partner:) - employment_income_national_insurance(partner:)
+        client_total = total_monthly_outgoings - employment_income_tax - employment_income_national_insurance
+        partner_total = partner ? (total_monthly_outgoings(partner:) - employment_income_tax(partner:) - employment_income_national_insurance(partner:)) : 0.0
+        client_total + partner_total
+      end
       end
     end
   end

--- a/app/views/providers/capital_assessment_results/_result_details.html.erb
+++ b/app/views/providers/capital_assessment_results/_result_details.html.erb
@@ -10,7 +10,6 @@
       <%= render "shared/savings_and_investments" %>
       <%= render "shared/other_assets" %>
       <%= render "shared/total_capital" %>
-      <%= render "shared/restrictions" %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/providers/capital_income_assessment_results/_bank_statements.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_bank_statements.html.erb
@@ -1,7 +1,8 @@
-<h3 class="govuk-heading-m"><%= t(".title") %></h3>
+<h3 class="govuk-heading-m"><%= t(".title", individual:) %></h3>
 <%= govuk_table do |table| %>
   <%= table.with_body do |body| %>
     <%= body.with_row do |row| %>
+      <p><%= individual %></p>
       <%= row.with_cell(header: true, text: t(".uploaded")) %>
       <%= row.with_cell(numeric: true) do %>
         <ul class="govuk-list">

--- a/app/views/providers/capital_income_assessment_results/_deductions.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_deductions.html.erb
@@ -15,6 +15,12 @@
           row.with_cell(header: true, text: t(".dependants_allowance"))
           row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.dependants_allowance))
         end
+        if @legal_aid_application.applicant.has_partner_with_no_contrary_interest?
+          body.with_row do |row|
+            row.with_cell(header: true, text: t(".partner_allowance"))
+            row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.partner_allowance))
+          end
+        end
         unless @legal_aid_application.uploading_bank_statements?
           body.with_row do |row|
             row.with_cell(header: true, text: t(".excluded_benefits"))

--- a/app/views/providers/capital_income_assessment_results/_deductions.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_deductions.html.erb
@@ -1,3 +1,4 @@
+<% partner = @legal_aid_application.applicant.has_partner_with_no_contrary_interest? %>
 <h2 class="govuk-heading-m"><%= t(".title") %></h2>
 
 <%= govuk_table do |table|

--- a/app/views/providers/capital_income_assessment_results/_disposable_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_disposable_income.html.erb
@@ -22,7 +22,7 @@
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".total_deductions"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_deductions_including_fixed_employment_allowance))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_deductions_including_fixed_employment_allowance(partner:)))
         end
       end
 

--- a/app/views/providers/capital_income_assessment_results/_disposable_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_disposable_income.html.erb
@@ -1,3 +1,4 @@
+<% partner = individual == "Partner" %>
 <h2 class="govuk-heading-m"><%= t(".title") %></h2>
 
 <%= govuk_table do |table|
@@ -13,11 +14,11 @@
       table.with_body do |body|
         body.with_row do |row|
           row.with_cell(header: true, text: t(".total_income"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_monthly_income_including_employment_income))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_monthly_income_including_employment_income(partner:)))
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".total_outgoings"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_monthly_outgoings_including_tax_and_ni))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_monthly_outgoings_including_tax_and_ni(partner:)))
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".total_deductions"))

--- a/app/views/providers/capital_income_assessment_results/_disposable_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_disposable_income.html.erb
@@ -29,7 +29,7 @@
       table.with_foot do |foot|
         foot.with_row do |row|
           row.with_cell(header: true, text: t(".total_disposable"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_disposable_income_assessed))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_disposable_income_assessed(partner:)))
         end
       end
     end %>

--- a/app/views/providers/capital_income_assessment_results/_disposable_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_disposable_income.html.erb
@@ -22,7 +22,7 @@
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".total_deductions"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_deductions_including_fixed_employment_allowance(partner:)))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_deductions_including_fixed_employment_allowance))
         end
       end
 

--- a/app/views/providers/capital_income_assessment_results/_employment_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_employment_income.html.erb
@@ -1,3 +1,4 @@
+<% partner = individual == "Partner" %>
 <h2 class="govuk-heading-m"><%= t(".title", individual:) %></h2>
 
 <%= govuk_table do |table|
@@ -13,30 +14,30 @@
       table.with_body do |body|
         body.with_row do |row|
           row.with_cell(header: true, text: t(".monthly_income_before_tax"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.employment_income_gross_income))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.employment_income_gross_income(partner:)))
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".benefits_in_kind"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.employment_income_benefits_in_kind))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.employment_income_benefits_in_kind(partner:)))
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".tax"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.employment_income_tax))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.employment_income_tax(partner:)))
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".national_insurance"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.employment_income_national_insurance))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.employment_income_national_insurance(partner:)))
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".fixed_employment_deduction"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.employment_income_fixed_employment_deduction))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.employment_income_fixed_employment_deduction(partner:)))
         end
       end
 
       table.with_foot do |foot|
         foot.with_row do |row|
           row.with_cell(header: true, text: t(".total"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.employment_income_net_employment_income))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.employment_income_net_employment_income(partner:)))
         end
       end
     end %>

--- a/app/views/providers/capital_income_assessment_results/_employment_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_employment_income.html.erb
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-m"><%= t(".title") %></h2>
+<h2 class="govuk-heading-m"><%= t(".title", individual:) %></h2>
 
 <%= govuk_table do |table|
       table.with_caption(html_attributes: { class: "govuk-visually-hidden" }, text: t(".table_caption"))

--- a/app/views/providers/capital_income_assessment_results/_other_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_other_income.html.erb
@@ -1,6 +1,6 @@
 <% partner = individual == "Partner" %>
 <h2 class="govuk-heading-m">
-  <%= @cfe_result.jobs? ? t(".title", individual:) : t(".income") %>
+  <%= @cfe_result.jobs? ? t(".title", individual:) : t(".income", individual:) %>
 </h2>
 
 <%= govuk_table do |table|

--- a/app/views/providers/capital_income_assessment_results/_other_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_other_income.html.erb
@@ -43,7 +43,7 @@
       table.with_foot do |foot|
         foot.with_row do |row|
           row.with_cell(header: true, text: t(".total"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_gross_income))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_monthly_income(partner:)))
         end
       end
     end %>

--- a/app/views/providers/capital_income_assessment_results/_other_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_other_income.html.erb
@@ -16,27 +16,27 @@
       table.with_body do |body|
         body.with_row do |row|
           row.with_cell(header: true, text: t(".benefits"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.monthly_state_benefits))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.monthly_state_benefits(partner:)))
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".friends_or_family"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.mei_friends_or_family))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.mei_friends_or_family(partner:)))
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".maintenance"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.mei_maintenance_in))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.mei_maintenance_in(partner:)))
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".property_or_lodger"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.mei_property_or_lodger))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.mei_property_or_lodger(partner:)))
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".student_loan_or_grant"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.mei_student_loan))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.mei_student_loan(partner:)))
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".pension"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.mei_pension))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.mei_pension(partner:)))
         end
       end
 

--- a/app/views/providers/capital_income_assessment_results/_other_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_other_income.html.erb
@@ -1,5 +1,6 @@
+<% partner = individual == "Partner" %>
 <h2 class="govuk-heading-m">
-  <%= @cfe_result.jobs? ? t(".title") : t(".income") %>
+  <%= @cfe_result.jobs? ? t(".title", individual:) : t(".income") %>
 </h2>
 
 <%= govuk_table do |table|

--- a/app/views/providers/capital_income_assessment_results/_outgoings.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_outgoings.html.erb
@@ -1,3 +1,4 @@
+<% partner = individual == "Partner" %>
 <h2 class="govuk-heading-m"><%= t(".title", individual:) %></h2>
 
 <%= govuk_table do |table|
@@ -13,26 +14,26 @@
       table.with_body do |body|
         body.with_row do |row|
           row.with_cell(header: true, text: t(".housing_costs"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.moe_housing))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.moe_housing(partner:)))
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".childcare_costs"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.moe_childcare))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.moe_childcare(partner:)))
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".maintenance_out"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.moe_maintenance_out))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.moe_maintenance_out(partner:)))
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".legal_aid"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.moe_legal_aid))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.moe_legal_aid(partner:)))
         end
       end
 
       table.with_foot do |foot|
         foot.with_row do |row|
           row.with_cell(header: true, text: t(".total_outgoings"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_monthly_outgoings))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_monthly_outgoings(partner:)))
         end
       end
     end %>

--- a/app/views/providers/capital_income_assessment_results/_outgoings.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_outgoings.html.erb
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-m"><%= t(".title") %></h2>
+<h2 class="govuk-heading-m"><%= t(".title", individual:) %></h2>
 
 <%= govuk_table do |table|
       table.with_caption(html_attributes: { class: "govuk-visually-hidden" }, text: t(".table_caption"))

--- a/app/views/providers/capital_income_assessment_results/_result_details.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_result_details.html.erb
@@ -22,15 +22,19 @@
         <%= render("bank_statements", bank_statements: @legal_aid_application.attachments.partner_bank_statement_evidence, individual: "Partner", read_only: true) %>
 
         <% if @cfe_result.partner_jobs? %>
-        <%= render("employment_income", individual: "Partner") %>
+          <%= render("employment_income", individual: "Partner") %>
         <% end %>
 
         <%= render("other_income", individual: "Partner") %>
         <%= render("outgoings", individual: "Partner") %>
-      <% end %>
 
-      <%= render "deductions" %>
-      <%= render("disposable_income", individual: "Partner") %>
+        <%= render "deductions" %>
+        <%= render("disposable_income", individual: "Partner") %>
+      <% else %>
+
+        <%= render "deductions" %>
+        <%= render("disposable_income", individual: "Client") %>
+      <% end %>
     <% end %>
 
     <%= accordion.with_section(heading_text: t(".capital_calculation")) do %>

--- a/app/views/providers/capital_income_assessment_results/_result_details.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_result_details.html.erb
@@ -5,7 +5,7 @@
 
   <%= govuk_accordion do |accordion| %>
     <% accordion.with_section(heading_text: t(".income_calculation")) do %>
-      <p class="govuk-hint"><%= t(".hint_text") %></p>
+      <p class="govuk-hint"><%= t(".income_hint_text") %></p>
 
       <% if @legal_aid_application.uploading_bank_statements? %>
         <%= render("bank_statements", bank_statements: @legal_aid_application.attachments.bank_statement_evidence, individual: "Client", read_only: true) %>
@@ -38,12 +38,14 @@
     <% end %>
 
     <%= accordion.with_section(heading_text: t(".capital_calculation")) do %>
+      <% if @legal_aid_application.applicant.has_partner_with_no_contrary_interest? %>
+        <p class="govuk-hint"><%= t(".capital_hint_text") %></p>
+      <% end %>
       <%= render "shared/property_results" %>
       <%= render "shared/vehicle_results" %>
       <%= render "shared/savings_and_investments" %>
       <%= render "shared/other_assets" %>
       <%= render "shared/total_capital" %>
-      <%= render "shared/restrictions" %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/providers/capital_income_assessment_results/_result_details.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_result_details.html.erb
@@ -8,15 +8,16 @@
       <p class="govuk-hint"><%= t(".hint_text") %></p>
 
       <% if @legal_aid_application.uploading_bank_statements? %>
-        <%= render("bank_statements", bank_statements: @legal_aid_application.attachments.bank_statement_evidence, read_only: true) %>
+        <%= render("bank_statements", bank_statements: @legal_aid_application.attachments.bank_statement_evidence, individual: "Client", read_only: true) %>
       <% end %>
 
       <% if @cfe_result.jobs? %>
-        <%= render "employment_income" %>
+        <%= render("employment_income", individual: "Client") %>
       <% end %>
 
-      <%= render "other_income" %>
-      <%= render "outgoings" %>
+      <%= render("other_income", individual: "Client") %>
+      <%= render("outgoings", individual: "Client") %>
+
       <%= render "deductions" %>
       <%= render "disposable_income" %>
     <% end %>

--- a/app/views/providers/capital_income_assessment_results/_result_details.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_result_details.html.erb
@@ -7,7 +7,7 @@
     <% accordion.with_section(heading_text: t(".income_calculation")) do %>
       <p class="govuk-hint"><%= t(".income_hint_text") %></p>
 
-      <% if @legal_aid_application.uploading_bank_statements? %>
+      <% if @legal_aid_application.client_uploading_bank_statements? %>
         <%= render("bank_statements", bank_statements: @legal_aid_application.attachments.bank_statement_evidence, individual: "Client", read_only: true) %>
       <% end %>
 

--- a/app/views/providers/capital_income_assessment_results/_result_details.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_result_details.html.erb
@@ -30,7 +30,7 @@
       <% end %>
 
       <%= render "deductions" %>
-      <%= render "disposable_income" %>
+      <%= render("disposable_income", individual: "Partner") %>
     <% end %>
 
     <%= accordion.with_section(heading_text: t(".capital_calculation")) do %>

--- a/app/views/providers/capital_income_assessment_results/_result_details.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_result_details.html.erb
@@ -25,6 +25,8 @@
         <%= render("employment_income", individual: "Partner") %>
         <% end %>
 
+        <%= render("other_income", individual: "Partner") %>
+        <%= render("outgoings", individual: "Partner") %>
       <% end %>
 
       <%= render "deductions" %>

--- a/app/views/providers/capital_income_assessment_results/_result_details.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_result_details.html.erb
@@ -18,6 +18,15 @@
       <%= render("other_income", individual: "Client") %>
       <%= render("outgoings", individual: "Client") %>
 
+      <% if @legal_aid_application.applicant.has_partner_with_no_contrary_interest? %>
+        <%= render("bank_statements", bank_statements: @legal_aid_application.attachments.partner_bank_statement_evidence, individual: "Partner", read_only: true) %>
+
+        <% if @cfe_result.partner_jobs? %>
+        <%= render("employment_income", individual: "Partner") %>
+        <% end %>
+
+      <% end %>
+
       <%= render "deductions" %>
       <%= render "disposable_income" %>
     <% end %>

--- a/app/views/shared/_property_results.html.erb
+++ b/app/views/shared/_property_results.html.erb
@@ -1,4 +1,5 @@
 <h2 class="govuk-heading-m"><%= t(".property") %></h2>
+<p class="govuk-hint"><%= t(".hint_text") %></p>
 
 <%= govuk_table do |table|
       table.with_caption(html_attributes: { class: "govuk-visually-hidden" }, text: t(".table_caption"))

--- a/app/views/shared/_savings_and_investments.html.erb
+++ b/app/views/shared/_savings_and_investments.html.erb
@@ -14,11 +14,11 @@
 
         table.with_body do |body|
           body.with_row do |row|
-            row.with_cell(header: true, text: t('.current_accounts'))
+            row.with_cell(header: true, text: t(".current_accounts"))
             row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.current_accounts))
           end
           body.with_row do |row|
-            row.with_cell(header: true, text: t('.savings_accounts'))
+            row.with_cell(header: true, text: t(".savings_accounts"))
             row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.savings_accounts))
           end
           # @cfe_result.liquid_capital_items.each do |item|
@@ -34,7 +34,7 @@
         table.with_foot do |foot|
           foot.with_row do |row|
             row.with_cell(header: true, text: t(".assessed_amount"))
-            row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_savings(partner:)))
+            row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_savings))
           end
         end
       end %>

--- a/app/views/shared/_savings_and_investments.html.erb
+++ b/app/views/shared/_savings_and_investments.html.erb
@@ -1,4 +1,5 @@
 <% if @cfe_result.liquid_capital_items.any? %>
+  <% partner = @legal_aid_application.applicant.has_partner_with_no_contrary_interest? %>
   <h2 class="govuk-heading-m"><%= t(".savings_and_investments") %></h2>
 
   <%= govuk_table do |table|
@@ -12,20 +13,28 @@
         end
 
         table.with_body do |body|
-          @cfe_result.liquid_capital_items.each do |item|
-            next unless capital_items_to_display?(@legal_aid_application, item)
-
-            body.with_row do |row|
-              row.with_cell(header: true, text: item_description(@legal_aid_application, item))
-              row.with_cell(numeric: true, text: gds_number_to_currency(item[:value]))
-            end
+          body.with_row do |row|
+            row.with_cell(header: true, text: t('.current_accounts'))
+            row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.current_accounts))
           end
+          body.with_row do |row|
+            row.with_cell(header: true, text: t('.savings_accounts'))
+            row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.savings_accounts))
+          end
+          # @cfe_result.liquid_capital_items.each do |item|
+          #   next unless capital_items_to_display?(@legal_aid_application, item)
+          #
+          #   body.with_row do |row|
+          #     row.with_cell(header: true, text: item_description(@legal_aid_application, item))
+          #     row.with_cell(numeric: true, text: gds_number_to_currency(item[:value]))
+          #   end
+          # end
         end
 
         table.with_foot do |foot|
           foot.with_row do |row|
             row.with_cell(header: true, text: t(".assessed_amount"))
-            row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_savings))
+            row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_savings(partner:)))
           end
         end
       end %>

--- a/app/views/shared/_savings_and_investments.html.erb
+++ b/app/views/shared/_savings_and_investments.html.erb
@@ -1,5 +1,4 @@
 <% if @cfe_result.liquid_capital_items.any? %>
-  <% partner = @legal_aid_application.applicant.has_partner_with_no_contrary_interest? %>
   <h2 class="govuk-heading-m"><%= t(".savings_and_investments") %></h2>
 
   <%= govuk_table do |table|
@@ -12,29 +11,34 @@
           end
         end
 
-        table.with_body do |body|
-          body.with_row do |row|
-            row.with_cell(header: true, text: t(".current_accounts"))
-            row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.current_accounts))
+        if @cfe_result.version_6?
+          table.with_body do |body|
+            body.with_row do |row|
+              row.with_cell(header: true, text: t(".current_accounts"))
+              row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.current_accounts))
+            end
+            body.with_row do |row|
+              row.with_cell(header: true, text: t(".savings_accounts"))
+              row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.savings_accounts))
+            end
           end
-          body.with_row do |row|
-            row.with_cell(header: true, text: t(".savings_accounts"))
-            row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.savings_accounts))
-          end
-          # @cfe_result.liquid_capital_items.each do |item|
-          #   next unless capital_items_to_display?(@legal_aid_application, item)
-          #
-          #   body.with_row do |row|
-          #     row.with_cell(header: true, text: item_description(@legal_aid_application, item))
-          #     row.with_cell(numeric: true, text: gds_number_to_currency(item[:value]))
-          #   end
-          # end
-        end
+        else
+          table.with_body do |body|
+            @cfe_result.liquid_capital_items.each do |item|
+              next unless capital_items_to_display?(@legal_aid_application, item)
 
-        table.with_foot do |foot|
-          foot.with_row do |row|
-            row.with_cell(header: true, text: t(".assessed_amount"))
-            row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_savings))
+              body.with_row do |row|
+                row.with_cell(header: true, text: item_description(@legal_aid_application, item))
+                row.with_cell(numeric: true, text: gds_number_to_currency(item[:value]))
+              end
+            end
+          end
+
+          table.with_foot do |foot|
+            foot.with_row do |row|
+              row.with_cell(header: true, text: t(".assessed_amount"))
+              row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_savings))
+            end
           end
         end
       end %>

--- a/app/views/shared/_total_capital.html.erb
+++ b/app/views/shared/_total_capital.html.erb
@@ -30,7 +30,7 @@
         end
         body.with_row(html_attributes: { class: "govuk-table__foot" }) do |row|
           row.with_cell(header: true, text: t(".total_capital"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_capital_before_pensioner_disregard(partner:)))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_capital_before_pensioner_disregard))
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".pensioner_disregard"))
@@ -41,7 +41,7 @@
       table.with_foot do |foot|
         foot.with_row do |row|
           row.with_cell(header: true, text: t(".disposable_capital"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_disposable_capital(partner:)))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_disposable_capital))
         end
       end
     end %>

--- a/app/views/shared/_total_capital.html.erb
+++ b/app/views/shared/_total_capital.html.erb
@@ -22,7 +22,7 @@
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".savings_and_investments"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_savings(partner:)))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_savings))
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".other_assets"))

--- a/app/views/shared/_total_capital.html.erb
+++ b/app/views/shared/_total_capital.html.erb
@@ -1,3 +1,4 @@
+<% partner = @legal_aid_application.applicant.has_partner_with_no_contrary_interest? %>
 <h2 class="govuk-heading-m"><%= t(".total_assessed_capital") %></h2>
 
 <%= govuk_table do |table|
@@ -21,7 +22,7 @@
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".savings_and_investments"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_savings))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_savings(partner:)))
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".other_assets"))
@@ -29,7 +30,7 @@
         end
         body.with_row(html_attributes: { class: "govuk-table__foot" }) do |row|
           row.with_cell(header: true, text: t(".total_capital"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_capital_before_pensioner_disregard))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_capital_before_pensioner_disregard(partner:)))
         end
         body.with_row do |row|
           row.with_cell(header: true, text: t(".pensioner_disregard"))

--- a/app/views/shared/_total_capital.html.erb
+++ b/app/views/shared/_total_capital.html.erb
@@ -41,7 +41,7 @@
       table.with_foot do |foot|
         foot.with_row do |row|
           row.with_cell(header: true, text: t(".disposable_capital"))
-          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_disposable_capital))
+          row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_disposable_capital(partner:)))
         end
       end
     end %>

--- a/app/views/shared/_vehicle_results.html.erb
+++ b/app/views/shared/_vehicle_results.html.erb
@@ -1,5 +1,6 @@
 <% if @cfe_result.vehicles? %>
   <h2 class="govuk-heading-m"><%= t(".vehicles") %></h2>
+  <p class="govuk-hint"><%= t(".hint_text") %></p>
 
   <%= govuk_table do |table|
         table.with_caption(html_attributes: { class: "govuk-visually-hidden" }, text: t(".table_caption"))

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -107,7 +107,7 @@ en:
         client_eligibility_calculation: How we calculated your client's financial eligibility
         hint_text: We calculated these calendar monthly figures using the information you and your client provided.
       bank_statements:
-        title: Bank statements
+        title: "%{individual} bank statements"
         uploaded: Uploaded bank statements
       disposable_income:
         title: Disposable income
@@ -127,7 +127,7 @@ en:
         type_of_deduction: Type of deductions
         amount: Amount
       employment_income:
-        title: Employment income
+        title: "%{individual} employment income"
         monthly_income_before_tax: Monthly income before tax
         benefits_in_kind: Benefits in kind
         tax: Tax
@@ -138,7 +138,7 @@ en:
         income_type: Types of income
         amount: Amount
       other_income:
-        title: Other income
+        title: "%{individual} other income"
         income: Income
         benefits: Benefits
         friends_or_family: Financial help from friends or family
@@ -151,7 +151,7 @@ en:
         type_of_income: Type of income
         amount: Amount
       outgoings:
-        title: Outgoings
+        title: "%{individual} outgoings"
         housing_costs: Housing costs
         childcare_costs: Childcare payments
         maintenance_out: Maintenance payments to a former partner

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -102,10 +102,11 @@ en:
           contribution_required: Contribution required
           partially_eligible: Partially eligible
       result_details:
-        capital_calculation: Capital calculation
         income_calculation: Income calculation
+        income_hint_text: We calculated these calendar monthly figures using the information you and your client provided.
+        capital_calculation: Capital calculation
+        capital_hint_text: We calculated these figures based on the information you provided about your client and their partner.
         client_eligibility_calculation: How we calculated your client's financial eligibility
-        hint_text: We calculated these calendar monthly figures using the information you and your client provided.
       bank_statements:
         title: "%{individual} bank statements"
         uploaded: Uploaded bank statements
@@ -140,7 +141,7 @@ en:
         amount: Amount
       other_income:
         title: "%{individual} other income"
-        income: Income
+        income: "%{individual} income"
         benefits: Benefits
         friends_or_family: Financial help from friends or family
         maintenance: Maintenance payments from a former partner

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -121,6 +121,7 @@ en:
       deductions:
         title: Deductions
         dependants_allowance: Dependants allowance
+        partner_allowance: Partner allowance
         excluded_benefits: Income from benefits excluded from calculation
         total_deductions: Total deductions
         table_caption: Deductions

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -704,6 +704,8 @@ en:
       amount: Amount
     savings_and_investments:
       savings_and_investments: Savings and investments
+      current_accounts: Current accounts
+      savings_accounts: Savings accounts
       assessed_amount: Total savings and investments
       table_caption: Savings and investments
       savings_and_investments_type: Type of savings and investments

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -685,6 +685,7 @@ en:
       suffix: Apply for legal aid  - GOV.UK
     property_results:
       property: Property
+      hint_text: Property disregards and deductions were calculated using the information you provided.
       value: Value
       outstanding_mortgage: Outstanding mortgage
       disregards: Disregards and deductions
@@ -695,6 +696,7 @@ en:
       amount: Amount
     vehicle_results:
       vehicles: Vehicles
+      hint_text: Vehicle disregards and deductions were calculated using the information you provided.
       value: Value
       oustanding_payments: Outstanding payments
       disregards: Disregards and deductions

--- a/spec/factories/cfe_results/v6/mock_results.rb
+++ b/spec/factories/cfe_results/v6/mock_results.rb
@@ -1074,11 +1074,43 @@ module CFEResults
             net_employment_income: 1777.11,
           },
         }
+        partner_capital_summary = {
+          pensioner_disregard_applied: 0.0,
+          total_liquid: 500.0,
+          total_non_liquid: 0.0,
+          total_vehicle: 0.0,
+          total_property: 0.0,
+          total_mortgage_allowance: 999_999_999_999.0,
+          total_capital: 500.0,
+          subject_matter_of_dispute_disregard: 0.0,
+          assessed_capital: 500_000.0,
+          total_capital_with_smod: 500_000.0,
+          disputed_non_property_disregard: 0,
+          proceeding_types: [
+            { ccms_code: "SE097A",
+              upper_threshold: 8000.0,
+              lower_threshold: 3000.0,
+              result: "ineligible",
+              client_involvement_type: "A" },
+            { ccms_code: "SE101E",
+              upper_threshold: 8000.0,
+              lower_threshold: 3000.0,
+              result: "ineligible",
+              client_involvement_type: "A" },
+          ],
+          combined_disputed_capital: 0,
+          combined_non_disputed_capital: 500_000.0,
+          capital_contribution: 497_000.0,
+          pensioner_capital_disregard: 0.0,
+          combined_assessed_capital: 500_000.0,
+        }
         result[:assessment][:partner_gross_income] = partner_gross_income
         result[:assessment][:partner_disposable_income] = partner_disposable_income
         result[:assessment][:partner_capital] = partner_capital
         result[:result_summary][:partner_gross_income] = { total_gross_income: 150.0 }
+        result[:result_summary][:partner_capital] = partner_capital_summary
         result[:result_summary][:partner_disposable_income] = partner_disposable_income_summary
+        result[:result_summary][:disposable_income][:partner_allowance] = 211.32
         result
       end
     end

--- a/spec/factories/cfe_results/v6/mock_results.rb
+++ b/spec/factories/cfe_results/v6/mock_results.rb
@@ -612,6 +612,319 @@ module CFEResults
           pensioner_capital_disregard: 0.0,
           combined_assessed_capital: 500_000.0,
         }
+      end
+
+      def self.not_eligible
+        not_eligible_result = eligible
+        not_eligible_result[:result_summary][:overall_result][:result] = "ineligible"
+        not_eligible_result[:result_summary][:overall_result][:proceeding_types].each do |pt|
+          pt[:result] = "not_eligible"
+        end
+        not_eligible_result
+      end
+
+      def self.with_capital_contribution_required
+        result = eligible
+        result[:result_summary][:overall_result][:result] = "contribution_required"
+        result[:result_summary][:capital][:capital_contribution] = 465.66
+        result[:result_summary][:overall_result][:capital_contribution] = 465.66
+        result
+      end
+
+      def self.partially_eligible_with_income_contribution_required
+        result = eligible
+        result[:result_summary][:overall_result][:result] = "partially_eligible"
+        result[:result_summary][:disposable_income][:income_contribution] = 238.56
+        result[:result_summary][:overall_result][:income_contribution] = 238.56
+        result
+      end
+
+      def self.partially_eligible_with_capital_contribution_required
+        result = eligible
+        result[:result_summary][:overall_result][:result] = "partially_eligible"
+        result[:result_summary][:capital][:capital_contribution] = 468.56
+        result[:result_summary][:overall_result][:capital_contribution] = 468.56
+        result
+      end
+
+      def self.with_income_contribution_required
+        result = eligible
+        result[:result_summary][:overall_result][:result] = "contribution_required"
+        result[:result_summary][:overall_result][:income_contribution] = 366.82
+        result[:result_summary][:disposable_income][:income_contribution] = 366.82
+        result
+      end
+
+      def self.with_capital_and_income_contributions_required
+        result = eligible
+        result[:result_summary][:overall_result][:result] = "contribution_required"
+
+        result[:result_summary][:overall_result][:income_contribution] = 366.82
+        eligible[:result_summary][:disposable_income][:income_contribution] = 366.82
+
+        result[:result_summary][:overall_result][:result] = "contribution_required"
+        new_capital_section = result[:result_summary][:capital]
+        new_capital_section[:capital_contribution] = 465.66
+        result[:result_summary][:capital] = new_capital_section
+        result[:result_summary][:overall_result][:capital_contribution] = 465.66
+
+        result
+      end
+
+      def self.no_additional_properties
+        result = eligible
+        result[:assessment][:capital][:capital_items][:properties][:additional_properties] = []
+        result
+      end
+
+      def self.with_no_vehicles
+        result = eligible
+        result[:assessment][:capital][:capital_items][:vehicles] = []
+        result
+      end
+
+      def self.with_mortgage_costs
+        result = eligible
+        result[:result_summary][:disposable_income][:gross_housing_costs] = 120.0
+        result
+      end
+
+      def self.with_monthly_income_equivalents
+        result = eligible
+        other_income = result[:assessment][:gross_income][:other_income]
+        monthly_equivalents = other_income[:monthly_equivalents][:all_sources]
+        monthly_equivalents = monthly_equivalents.transform_values { |x| x + 10 }
+        other_income[:monthly_equivalents][:all_sources] = monthly_equivalents
+        result[:assessment][:gross_income][:other_income] = other_income
+
+        result
+      end
+
+      def self.with_monthly_outgoing_equivalents
+        result = eligible
+        other_income = result[:assessment][:disposable_income]
+        monthly_equivalents = other_income[:monthly_equivalents][:all_sources]
+        monthly_equivalents = monthly_equivalents.transform_values { |x| x + 10 }
+        other_income[:monthly_equivalents][:all_sources] = monthly_equivalents
+        result[:assessment][:disposable_income] = other_income
+        result[:result_summary][:disposable_income][:net_housing_costs] += 10.0
+
+        result
+      end
+
+      def self.no_capital
+        result = eligible
+        new_capital_section = result[:assessment][:capital]
+        new_capital_section[:capital_items][:liquid] = []
+        new_capital_section[:capital_items][:non_liquid] = []
+        new_capital_section[:capital_items][:vehicles] = []
+        new_capital_section[:capital_items][:properties][:main_home] = {}
+        new_capital_section[:capital_items][:properties][:additional_properties] = {}
+
+        new_capital_summary = result[:result_summary][:capital]
+        new_capital_summary[:total_liquid] = 0.0
+        new_capital_summary[:total_non_liquid] = 0.0
+        new_capital_summary[:total_vehicle] = 0.0
+        new_capital_summary[:total_property] = 0.0
+        new_capital_summary[:total_capital] = 0.0
+
+        result[:result_summary][:capital] = new_capital_summary
+        result[:assessment][:capital] = new_capital_section
+        result
+      end
+
+      def self.with_additional_properties
+        result = eligible
+        property = {
+          value: 5781.91,
+          outstanding_mortgage: 10_202.39,
+          percentage_owned: 8.33,
+          main_home: false,
+          shared_with_housing_assoc: true,
+          transaction_allowance: 113.46,
+          allowable_outstanding_mortgage: 8202.00,
+          net_value: -4533.94,
+          net_equity: -8000.82,
+          main_home_equity_disregard: "0.0",
+          assessed_equity: 125.33,
+        }
+        result[:assessment][:capital][:capital_items][:properties][:additional_properties] = [property]
+        result
+      end
+
+      def self.with_total_property; end
+
+      def self.with_maintenance_received
+        result = eligible
+        result[:result_summary][:disposable_income][:maintenance_allowance] = 150.0
+        result
+      end
+
+      def self.with_student_finance_received
+        result = eligible
+        result[:assessment][:gross_income][:irregular_income][:monthly_equivalents][:student_loan] = 125.0
+        result
+      end
+
+      def self.with_total_deductions
+        result = eligible
+        deductions = result[:assessment][:disposable_income][:deductions]
+        deductions[:dependants_allowance] = 1200.0
+        deductions[:disregarded_state_benefits] = 100.0
+        result[:assessment][:disposable_income][:deductions] = deductions
+        result
+      end
+
+      def self.with_total_gross_income
+        result = eligible
+        result[:result_summary][:gross_income][:total_gross_income] = 150.0
+
+        result
+      end
+
+      def self.unknown
+        result = eligible
+        result[:assessment][:assessment_result] = "unknown"
+        result[:assessment][:capital][:assessment_result] = "unknown"
+        result[:assessment][:disposable_income][:assessment_result] = "unknown"
+        result
+      end
+
+      def self.mixed_proceeding_type_results
+        result = eligible
+        result[:result_summary][:overall_result][:proceeding_types] = [
+          {
+            ccms_code: "DA006",
+            result: "eligible",
+          },
+          {
+            ccms_code: "SE013",
+            result: "ineligible",
+          },
+          {
+            ccms_code: "SE014",
+            result: "partially_eligible",
+          },
+        ]
+        result
+      end
+
+      def self.partially_eligible
+        result = eligible
+        result[:result_summary][:overall_result][:matter_types] << { matter_type: "section8", result: "ineligible" }
+        result[:result_summary][:overall_result][:proceeding_types] << { ccms_code: "SE003", result: "ineligible" }
+        result[:result_summary][:gross_income][:proceeding_types] << { ccms_code: "SE003", upper_threshold: 2657.0, result: "eligible" }
+        result[:result_summary][:disposable_income][:proceeding_types] << { ccms_code: "SE003", upper_threshold: 733.0, lower_threshold: 315.0, result: "ineligible" }
+        result
+      end
+
+      def self.with_employments
+        result = eligible
+        employment_income = {
+          gross_income: 1041.00,
+          benefits_in_kind: 16.60,
+          tax: -104.10,
+          national_insurance: -18.66,
+          fixed_employment_deduction: -45.00,
+          net_employment_income: 8898.84,
+        }
+        jobs = [
+          {
+            name: "Job 1",
+            payments: [
+              {
+                date: "2021-10-30",
+                gross: 1046.00,
+                benefits_in_kind: 16.60,
+                tax: -104.10,
+                national_insurance: -18.66,
+                net_employment_income: 8898.84,
+              },
+              {
+                date: "2021-10-30",
+                gross: 1046.00,
+                benefits_in_kind: 16.60,
+                tax: -104.10,
+                national_insurance: -18.66,
+                net_employment_income: 8898.84,
+              },
+              {
+                date: "2021-10-30",
+                gross: 1046.00,
+                benefits_in_kind: 16.60,
+                tax: -104.10,
+                national_insurance: -18.66,
+                net_employment_income: 8898.84,
+              },
+            ],
+          },
+          {
+            name: "Job 2",
+            payments: [
+              {
+                date: "2021-10-30",
+                gross: 1046.00,
+                benefits_in_kind: 16.60,
+                tax: -104.10,
+                national_insurance: -18.66,
+                net_employment_income: 8898.84,
+              },
+              {
+                date: "2021-10-30",
+                gross: 1046.00,
+                benefits_in_kind: 16.60,
+                tax: -104.10,
+                national_insurance: -18.66,
+                net_employment_income: 8898.84,
+              },
+              {
+                date: "2021-10-30",
+                gross: 1046.00,
+                benefits_in_kind: 16.60,
+                tax: -104.10,
+                national_insurance: -18.66,
+                net_employment_income: 8898.84,
+              },
+            ],
+          },
+        ]
+        result[:result_summary][:disposable_income][:employment_income] = employment_income
+        result[:assessment][:gross_income][:employment_income] = jobs
+        result
+      end
+
+      def self.with_employment_remarks(record)
+        laa = record.legal_aid_application
+        employments = laa.employments.order(:name)
+        payments = employments.first.employment_payments
+        refunded_nic_ids = payments.select { |p| p.national_insurance > 0 }.map(&:id)
+        refunded_tax_ids = payments.select { |p| p.tax > 0 }.map(&:id)
+        result = with_employments
+        remarks = {
+          employment: {
+            multiple_employments: [employments.map(&:id)],
+          },
+          employment_gross_income: {
+            amount_variation: [payments.map(&:id)],
+            unknown_frequency: [payments.map(&:id)],
+          },
+          employment_nic: {
+            amount_variation: [payments.map(&:id)],
+            refunds: refunded_nic_ids,
+          },
+          employment_tax: {
+            amount_variation: [payments.map(&:id)],
+            refunds: refunded_tax_ids,
+          },
+        }
+        result[:assessment][:remarks] = remarks
+        result
+      end
+
+      def self.with_no_employments
+        result = eligible
+        result[:result_summary][:disposable_income][:employment_income] = {}
+        result[:assessment][:gross_income][:employment_income] = []
         result
       end
     end

--- a/spec/factories/cfe_results/v6/mock_results.rb
+++ b/spec/factories/cfe_results/v6/mock_results.rb
@@ -927,6 +927,134 @@ module CFEResults
         result[:assessment][:gross_income][:employment_income] = []
         result
       end
+
+      def self.with_partner
+        result = eligible
+        partner_gross_income = {
+          employment_income: [],
+          irregular_income: {
+            monthly_equivalents: {
+              student_loan: 0.0,
+              unspecified_source: 0.0,
+            },
+          },
+          state_benefits: {
+            monthly_equivalents: {
+              all_sources: 86.67,
+              cash_transactions: 0.0,
+              bank_transactions: [],
+            },
+          },
+          other_income: {
+            monthly_equivalents: {
+              all_sources: {
+                friends_or_family: 166.67,
+                maintenance_in: 0.0,
+                property_or_lodger: 0.0,
+                pension: 0.0,
+              },
+              bank_transactions: {
+                friends_or_family: 0,
+                maintenance_in: 0,
+                property_or_lodger: 0,
+                pension: 0,
+              },
+              cash_transactions: {
+                friends_or_family: 0.0,
+                maintenance_in: 0.0,
+                property_or_lodger: 0.0,
+                pension: 0.0,
+              },
+            },
+          },
+        }
+        partner_disposable_income = {
+          monthly_equivalents: {
+            all_sources: {
+              child_care: 0.0,
+              rent_or_mortgage: 0.0,
+              maintenance_out: 0.0,
+              legal_aid: 0.0,
+              pension_contribution: 0.0,
+            },
+            bank_transactions: {
+              child_care: 0.0,
+              rent_or_mortgage: 0.0,
+              maintenance_out: 0.0,
+              legal_aid: 0.0,
+              pension_contribution: 0.0,
+            },
+            cash_transactions: {
+              child_care: 0.0,
+              rent_or_mortgage: 0.0,
+              maintenance_out: 0.0,
+              legal_aid: 0.0,
+              pension_contribution: 0.0,
+            },
+          },
+          childcare_allowance: 0.0,
+          deductions: {
+            dependants_allowance: 0.0,
+            disregarded_state_benefits: 0.0,
+          },
+        }
+        partner_capital = {
+          capital_items: {
+            liquid: [
+              { description: "Partner current accounts", value: 400.0 },
+              { description: "Partner savings accounts", value: 300.0 },
+              { description: "Joint current accounts", value: 200.0 },
+            ],
+            non_liquid: [],
+            vehicles: [],
+            properties: {
+              main_home: {
+                value: 0.0,
+                outstanding_mortgage: 0.0,
+                percentage_owned: 0.0,
+                main_home: true,
+                shared_with_housing_assoc: false,
+                transaction_allowance: 0,
+                allowable_outstanding_mortgage: 0.0,
+                net_value: 0,
+                net_equity: 0,
+                smod_allowance: 0,
+                main_home_equity_disregard: 0,
+                assessed_equity: 0,
+                subject_matter_of_dispute: false,
+              },
+              additional_properties: [],
+            },
+          },
+        }
+        partner_disposable_income_summary = {
+          dependant_allowance_under_16: 0,
+          dependant_allowance_over_16: 0,
+          dependant_allowance: 0,
+          gross_housing_costs: 0.0,
+          housing_benefit: 0.0,
+          net_housing_costs: 0.0,
+          maintenance_allowance: 0.0,
+          total_outgoings_and_allowances: 1052.06,
+          total_disposable_income: 2577.11,
+          employment_income: {
+            gross_income: 2229.17,
+            benefits_in_kind: 0.0,
+            tax: -235.2,
+            national_insurance: -171.86,
+            prisoner_levy: 0.0,
+            student_debt_repayment: 0.0,
+            fixed_employment_deduction: -45.0,
+            net_employment_income: 1777.11,
+          },
+        }
+        result[:assessment][:partner_gross_income] = partner_gross_income
+        result[:assessment][:partner_disposable_income] = partner_disposable_income
+        result[:assessment][:partner_capital] = partner_capital
+        result[:result_summary][:partner_gross_income] = { total_gross_income: 150.0 }
+        result[:result_summary][:partner_disposable_income] = partner_disposable_income_summary
+        result
+      end
     end
   end
 end

--- a/spec/factories/cfe_results/v6/mock_results.rb
+++ b/spec/factories/cfe_results/v6/mock_results.rb
@@ -52,7 +52,7 @@ module CFEResults
               income_contribution: 0.0,
               employment_income: {
                 gross_income: 2143.97,
-                benefits_in_kind: 0.0,
+                benefits_in_kind: 16.60,
                 tax: -204.15,
                 national_insurance: -161.64,
                 fixed_employment_deduction: -45.0,
@@ -152,7 +152,7 @@ module CFEResults
                   child_care: 0.0,
                   rent_or_mortgage: 125.0,
                   maintenance_out: 0.0,
-                  legal_aid: 0.0,
+                  legal_aid: 100.0,
                 },
                 bank_transactions: {
                   child_care: 0.0,
@@ -931,10 +931,36 @@ module CFEResults
       def self.with_partner
         result = eligible
         partner_gross_income = {
-          employment_income: [],
+          employment_income: [
+            {
+              name: "Job 1",
+              payments: [
+                {
+                  date: "2023-11-15",
+                  gross: 2083.33,
+                  benefits_in_kind: 0.0,
+                  tax: -206.0,
+                  national_insurance: -154.36,
+                  prisoner_levy: 0.0,
+                  student_debt_repayment: 0.0,
+                  net_employment_income: 1722.97,
+                },
+                {
+                  date: "2023-10-14",
+                  gross: 3083.33,
+                  benefits_in_kind: 0.0,
+                  tax: -406.0,
+                  national_insurance: -274.36,
+                  prisoner_levy: 0.0,
+                  student_debt_repayment: 0.0,
+                  net_employment_income: 2402.97,
+                },
+              ],
+            },
+          ],
           irregular_income: {
             monthly_equivalents: {
-              student_loan: 0.0,
+              student_loan: 100.0,
               unspecified_source: 0.0,
             },
           },
@@ -949,9 +975,9 @@ module CFEResults
             monthly_equivalents: {
               all_sources: {
                 friends_or_family: 166.67,
-                maintenance_in: 0.0,
-                property_or_lodger: 0.0,
-                pension: 0.0,
+                maintenance_in: 21.0,
+                property_or_lodger: 200.0,
+                pension: 30.0,
               },
               bank_transactions: {
                 friends_or_family: 0,
@@ -971,9 +997,9 @@ module CFEResults
         partner_disposable_income = {
           monthly_equivalents: {
             all_sources: {
-              child_care: 0.0,
-              rent_or_mortgage: 0.0,
-              maintenance_out: 0.0,
+              child_care: 30.0,
+              rent_or_mortgage: 400.0,
+              maintenance_out: 50.0,
               legal_aid: 0.0,
               pension_contribution: 0.0,
             },
@@ -1033,7 +1059,7 @@ module CFEResults
           dependant_allowance: 0,
           gross_housing_costs: 0.0,
           housing_benefit: 0.0,
-          net_housing_costs: 0.0,
+          net_housing_costs: 400.0,
           maintenance_allowance: 0.0,
           total_outgoings_and_allowances: 1052.06,
           total_disposable_income: 2577.11,

--- a/spec/factories/cfe_results/v6/mock_results.rb
+++ b/spec/factories/cfe_results/v6/mock_results.rb
@@ -612,6 +612,7 @@ module CFEResults
           pensioner_capital_disregard: 0.0,
           combined_assessed_capital: 500_000.0,
         }
+        result
       end
 
       def self.not_eligible
@@ -1115,7 +1116,7 @@ module CFEResults
       end
 
       def self.without_partner_jobs
-        result = eligible
+        result = with_partner
         result[:assessment][:partner_gross_income][:employment_income] = []
         result
       end

--- a/spec/factories/cfe_results/v6/mock_results.rb
+++ b/spec/factories/cfe_results/v6/mock_results.rb
@@ -1113,6 +1113,12 @@ module CFEResults
         result[:result_summary][:disposable_income][:partner_allowance] = 211.32
         result
       end
+
+      def self.without_partner_jobs
+        result = eligible
+        result[:assessment][:partner_gross_income][:employment_income] = []
+        result
+      end
     end
   end
 end

--- a/spec/factories/cfe_results/v6/results.rb
+++ b/spec/factories/cfe_results/v6/results.rb
@@ -127,6 +127,10 @@ module CFEResults
         trait :with_partner do
           result { CFEResults::V6::MockResults.with_partner.to_json }
         end
+
+        trait :without_partner_jobs do
+          result { CFEResults::V6::MockResults.without_partner_jobs.to_json }
+        end
       end
     end
   end

--- a/spec/factories/cfe_results/v6/results.rb
+++ b/spec/factories/cfe_results/v6/results.rb
@@ -4,8 +4,16 @@ module CFEResults
       factory :cfe_v6_result, class: "CFE::V6::Result" do
         submission factory: :cfe_submission
         legal_aid_application { submission.legal_aid_application }
-        result { CFEResults::V5::MockResults.eligible.to_json }
+        result { CFEResults::V6::MockResults.eligible.to_json }
         type { "CFE::V6::Result" }
+
+        trait :eligible do
+          result { CFEResults::V6::MockResults.eligible.to_json }
+        end
+
+        trait :not_eligible do
+          result { CFEResults::V6::MockResults.not_eligible.to_json }
+        end
 
         trait :ineligible_gross_income do
           result { CFEResults::V6::MockResults.ineligible_gross_income.to_json }
@@ -21,6 +29,99 @@ module CFEResults
 
         trait :fake_ineligible_disposable_income_and_capital do
           result { CFEResults::V6::MockResults.fake_ineligible_disposable_income_and_capital.to_json }
+        end
+
+        trait :partially_eligible do
+          result { CFEResults::V6::MockResults.partially_eligible.to_json }
+        end
+
+        trait :no_capital do
+          result { CFEResults::V6::MockResults.no_capital.to_json }
+        end
+
+        trait :with_capital_contribution_required do
+          result { CFEResults::V6::MockResults.with_capital_contribution_required.to_json }
+        end
+
+        trait :with_income_contribution_required do
+          result { CFEResults::V6::MockResults.with_income_contribution_required.to_json }
+        end
+
+        trait :with_capital_and_income_contributions_required do
+          result { CFEResults::V6::MockResults.with_capital_and_income_contributions_required.to_json }
+        end
+
+        trait :partially_eligible_with_income_contribution_required do
+          result { CFEResults::V6::MockResults.partially_eligible_with_income_contribution_required.to_json }
+        end
+
+        trait :partially_eligible_with_capital_contribution_required do
+          result { CFEResults::V6::MockResults.partially_eligible_with_capital_contribution_required.to_json }
+        end
+
+        trait :no_additional_properties do
+          result { CFEResults::V6::MockResults.no_additional_properties.to_json }
+        end
+
+        trait :with_additional_properties do
+          result { CFEResults::V6::MockResults.with_additional_properties.to_json }
+        end
+
+        trait :with_no_vehicles do
+          result { CFEResults::V6::MockResults.with_no_vehicles.to_json }
+        end
+
+        trait :with_maintenance_received do
+          result { CFEResults::V6::MockResults.with_maintenance_received.to_json }
+        end
+
+        trait :with_student_finance_received do
+          result { CFEResults::V6::MockResults.with_student_finance_received.to_json }
+        end
+
+        trait :with_mortgage_costs do
+          result { CFEResults::V6::MockResults.with_mortgage_costs.to_json }
+        end
+
+        trait :with_monthly_income_equivalents do
+          result { CFEResults::V6::MockResults.with_monthly_income_equivalents.to_json }
+        end
+
+        trait :with_monthly_outgoing_equivalents do
+          result { CFEResults::V6::MockResults.with_monthly_outgoing_equivalents.to_json }
+        end
+
+        trait :with_total_gross_income do
+          result { CFEResults::V6::MockResults.with_total_gross_income.to_json }
+        end
+
+        trait :with_total_deductions do
+          result { CFEResults::V6::MockResults.with_total_deductions.to_json }
+        end
+
+        trait :with_unknown_result do
+          result { CFEResults::V6::MockResults.unknown.to_json }
+        end
+
+        trait :with_mixed_proceeding_type_results do
+          result { CFEResults::V6::MockResults.mixed_proceeding_type_results.to_json }
+        end
+
+        trait :with_employments do
+          result { CFEResults::V6::MockResults.with_employments.to_json }
+        end
+
+        trait :with_no_employments do
+          result { CFEResults::V6::MockResults.with_no_employments.to_json }
+        end
+
+        trait :with_employment_records_and_remarks do
+          after(:create) do |record|
+            record.legal_aid_application.employments << create(:employment, :with_irregularities)
+            record.legal_aid_application.employments << create(:employment)
+
+            record.update!(result: CFEResults::V6::MockResults.with_employment_remarks(record).to_json)
+          end
         end
       end
     end

--- a/spec/factories/cfe_results/v6/results.rb
+++ b/spec/factories/cfe_results/v6/results.rb
@@ -123,6 +123,10 @@ module CFEResults
             record.update!(result: CFEResults::V6::MockResults.with_employment_remarks(record).to_json)
           end
         end
+
+        trait :with_partner do
+          result { CFEResults::V6::MockResults.with_partner.to_json }
+        end
       end
     end
   end

--- a/spec/models/cfe/v6/result_spec.rb
+++ b/spec/models/cfe/v6/result_spec.rb
@@ -7,6 +7,42 @@ module CFE
       let(:ineligible_gross_income_result) { create(:cfe_v6_result, :ineligible_gross_income) }
       let(:ineligible_disposable_income_result) { create(:cfe_v6_result, :ineligible_disposable_income) }
       let(:ineligible_capital_result) { create(:cfe_v6_result, :ineligible_capital) }
+      let(:partially_eligible_result) { create(:cfe_v6_result, :partially_eligible) }
+      let(:not_eligible_result) { create(:cfe_v6_result, :not_eligible) }
+      let(:contribution_required_result) { create(:cfe_v6_result, :with_capital_contribution_required) }
+      let(:no_additional_properties) { create(:cfe_v6_result, :no_additional_properties) }
+      let(:additional_property) { create(:cfe_v6_result, :with_additional_properties) }
+      let(:with_no_vehicles) { create(:cfe_v6_result, :with_no_vehicles) }
+      let(:with_maintenance) { create(:cfe_v6_result, :with_maintenance_received) }
+      let(:with_student_finance) { create(:cfe_v6_result, :with_student_finance_received) }
+      let(:with_total_deductions) { create(:cfe_v6_result, :with_total_deductions) }
+      let(:with_mortgage) { create(:cfe_v6_result, :with_mortgage_costs) }
+      let(:with_monthly_income_equivalents) { create(:cfe_v6_result, :with_monthly_income_equivalents) }
+      let(:with_monthly_outgoing_equivalents) { create(:cfe_v6_result, :with_monthly_outgoing_equivalents) }
+      let(:with_total_gross_income) { create(:cfe_v6_result, :with_total_gross_income) }
+      let(:with_mixed_proceeding_type_results) { create(:cfe_v6_result, :with_mixed_proceeding_type_results) }
+      let(:with_employments) { create(:cfe_v6_result, :with_employments) }
+      let(:with_no_employments) { create(:cfe_v6_result, :with_no_employments) }
+      let(:legal_aid_application) { create(:legal_aid_application, :with_restrictions, :with_cfe_v6_result) }
+      let(:contribution_and_restriction_result) { create(:cfe_v6_result, :with_capital_contribution_required, submission: cfe_submission) }
+      let(:cfe_submission) { create(:cfe_submission, legal_aid_application:) }
+      let(:manual_review_determiner) { CCMS::ManualReviewDeterminer.new(application) }
+
+      describe "#version" do
+        subject(:version) { eligible_result.version }
+
+        it { expect(version).to be 6 }
+      end
+
+      describe "#version_6?" do
+        it "returns boolean response for cfe version check" do
+          expect(eligible_result.version_6?).to be true
+        end
+      end
+
+      ################################################################
+      #  INELIGIBLE RESULTS                                          #
+      ################################################################
 
       describe "#gross_income_results" do
         context "when overall result is eligible" do
@@ -88,6 +124,592 @@ module CFE
         context "when overall result is ineligible because disposable income is above upper threshold" do
           it "returns true" do
             expect(ineligible_capital_result.ineligible_disposable_capital?).to be true
+          end
+        end
+      end
+
+      ################################################################
+      #  CAPITAL CONTRIBUTION                                        #
+      ################################################################
+
+      describe "capital_contribution_required?" do
+        context "when contribution not required" do
+          it "returns false for capital_contribution_required" do
+            expect(eligible_result.capital_contribution_required?).to be false
+          end
+        end
+
+        context "when contribution is required" do
+          it "returns true for capital_contribution_required" do
+            expect(contribution_required_result.capital_contribution_required?).to be true
+          end
+        end
+      end
+
+      ################################################################
+      #  THRESHOLDS                                                  #
+      ################################################################
+
+      describe "thresholds" do
+        describe "#gross_income_upper_threshold" do
+          context "with only domestic abuse" do
+            it "returns N/a" do
+              expect(eligible_result.gross_income_upper_threshold).to eq "N/a"
+            end
+          end
+
+          context "with domestic abuse and section 8 mixed" do
+            it "returns the section 8 threshold" do
+              expect(partially_eligible_result.gross_income_upper_threshold).to eq 2657.0
+            end
+          end
+        end
+
+        describe "#disposable_income_upper_threshold" do
+          context "with only domestic abuse" do
+            it "returns N/a" do
+              expect(eligible_result.disposable_income_upper_threshold).to eq "N/a"
+            end
+          end
+
+          context "with domestic abuse and section 8 mixed" do
+            it "returns the section 8 threshold" do
+              expect(partially_eligible_result.disposable_income_upper_threshold).to eq 733.0
+            end
+          end
+        end
+      end
+
+      ################################################################
+      #  CAPITAL ITEMS                                               #
+      ################################################################
+
+      describe "non_liquid_capital_items" do
+        it "returns the description and value for first item in non liquid items array" do
+          expect(eligible_result.non_liquid_capital_items.first[:description]).to be_a String
+          expect(eligible_result.non_liquid_capital_items.first[:value].to_d).to eq 12.00
+        end
+      end
+
+      describe "liquid_capital_items" do
+        it "returns the description and value for first item in liquid items array" do
+          expect(eligible_result.liquid_capital_items.first[:description]).to be_a String
+          expect(eligible_result.liquid_capital_items.first[:value].to_d).to eq 1.00
+        end
+      end
+
+      describe "total_property" do
+        it "returns the assessed value for total property" do
+          expect(eligible_result.total_property).to eq 0.0
+        end
+      end
+
+      describe "total_capital" do
+        it "returns the assessed value for total capital" do
+          expect(eligible_result.total_capital).to eq 144.0
+        end
+      end
+
+      describe "total_savings" do
+        it "returns the assessed value for liquid assets" do
+          expect(eligible_result.total_savings).to eq 12.00
+        end
+      end
+
+      describe "total_other_assets" do
+        it "returns the assessed value for non liquid assets" do
+          expect(eligible_result.total_other_assets).to eq 12.0
+        end
+      end
+
+      describe "#results_by_proceeding_type" do
+        before do
+          create(:proceeding, :da006)
+          create(:proceeding, :se013)
+          create(:proceeding, :se014)
+        end
+
+        let(:cfe_result) { with_mixed_proceeding_type_results }
+        let(:expected_result_before_transformation) do
+          [
+            {
+              ccms_code: "DA006",
+              result: "eligible",
+            },
+            {
+              ccms_code: "SE013",
+              result: "ineligible",
+            },
+            {
+              ccms_code: "SE014",
+              result: "partially_eligible",
+            },
+          ]
+        end
+        let(:result_after_transformation) do
+          {
+            "Child arrangements order (contact)" => "No",
+            "Child arrangements order (residence)" => "Yes",
+            "Extend, variation or discharge - Part IV" => "Yes",
+          }
+        end
+
+        it "compresses and translates the overall_result[:proceeding_types] struct" do
+          expect(cfe_result.overall_result[:proceeding_types]).to eq expected_result_before_transformation
+          expect(cfe_result.results_by_proceeding_type).to eq result_after_transformation
+        end
+      end
+
+      ################################################################
+      # VEHICLES                                                     #
+      ################################################################
+
+      describe "vehicle" do
+        it "returns a vehicle" do
+          expect(eligible_result.vehicle).to be_a(Hash)
+          expect(eligible_result.vehicle[:value].to_d).to eq 120.0
+        end
+      end
+
+      describe "vehicles?" do
+        context "when vehicle(s) exist" do
+          it "returns a boolean response if vehicles exist" do
+            expect(eligible_result.vehicles?).to be true
+          end
+        end
+
+        context "when vehicles do not exist" do
+          it "returns a boolean response if vehicles do not exist" do
+            expect(with_no_vehicles.vehicles?).to be false
+          end
+        end
+      end
+
+      describe "vehicle_value" do
+        it "returns the assessed value for applicants vehicle" do
+          expect(eligible_result.vehicle_value).to eq 120.0
+        end
+      end
+
+      describe "vehicle_loan_amount_outstanding" do
+        it "returns the loan value outstanding on applicants vehicle" do
+          expect(eligible_result.vehicle_loan_amount_outstanding).to eq 12.0
+        end
+      end
+
+      describe "vehicle_disregard" do
+        it "returns the vehicle disregard for applicants vehicle" do
+          expect(eligible_result.vehicle_disregard).to eq 0.0
+        end
+      end
+
+      describe "vehicle_assessed_amount" do
+        it "returns the assessed value for the applicants vehicle" do
+          expect(eligible_result.vehicle_assessed_amount).to eq 120.0
+        end
+      end
+
+      describe "total_vehicles" do
+        it "returns the assessed value for all applicants vehicle(s)" do
+          expect(eligible_result.total_vehicles).to eq 120.0
+        end
+      end
+
+      ################################################################
+      #  ADDITIONAL PROPERTY                                         #
+      ################################################################
+
+      describe "#additional_property?" do
+        context "when present" do
+          it "returns true" do
+            expect(additional_property.additional_property?).to be true
+          end
+        end
+
+        context "when not present" do
+          it "returns false" do
+            expect(no_additional_properties.additional_property?).to be false
+          end
+        end
+
+        context "when present but zero" do
+          it "returns false" do
+            expect(eligible_result.additional_property?).to be false
+          end
+        end
+      end
+
+      describe "additional_property_value" do
+        it "returns the value of the first additional property" do
+          expect(additional_property.additional_property_value).to eq 5_781.91
+        end
+      end
+
+      describe "additional_property_transaction_allowance" do
+        it "returns the transaction allowance for the first additional property" do
+          expect(additional_property.additional_property_transaction_allowance).to eq(-113.46)
+        end
+      end
+
+      describe "additional_property_mortgage" do
+        it "returns the mortgage for the first additional property" do
+          expect(additional_property.additional_property_mortgage).to eq(-8202.00)
+        end
+      end
+
+      describe "additional_property_assessed_equity" do
+        it "returns the assessed equity for the first additional property" do
+          expect(additional_property.additional_property_assessed_equity).to eq 125.33
+        end
+      end
+
+      ################################################################
+      #  MAIN HOME                                                   #
+      ################################################################
+
+      describe "main_home_value" do
+        it "returns the assessed value for the main home" do
+          expect(eligible_result.main_home_value).to eq 10.0
+        end
+      end
+
+      describe "main_home_outstanding_mortgage" do
+        it "returns the assessed value for the main home" do
+          expect(eligible_result.main_home_outstanding_mortgage).to eq(-20.0)
+        end
+      end
+
+      describe "main_home_transaction_allowance" do
+        it "returns the assessed value for the main home" do
+          expect(eligible_result.main_home_transaction_allowance).to eq(-0.3)
+        end
+      end
+
+      describe "main_home_equity_disregard" do
+        it "returns the assessed value for the main home" do
+          expect(eligible_result.main_home_equity_disregard).to eq(-100_000.0)
+        end
+      end
+
+      describe "main_home_assessed_equity" do
+        it "returns the assessed value for the main home" do
+          expect(eligible_result.main_home_assessed_equity).to eq 0.0
+        end
+      end
+
+      ################################################################
+      #  DISPOSABLE INCOME                                           #
+      ################################################################
+
+      describe "maintenance_per_month" do
+        context "when maintenance is received" do
+          subject(:maintenance_per_month) { with_maintenance.maintenance_per_month }
+
+          it { is_expected.to eq 150.00 }
+        end
+
+        context "when maintenance is not received" do
+          subject(:maintenance_per_month) { eligible_result.maintenance_per_month }
+
+          it { is_expected.to eq 0.00 }
+        end
+      end
+
+      describe "mei_student_loan" do
+        context "when student_loan is received" do
+          subject(:mei_student_loan) { with_student_finance.mei_student_loan }
+
+          it { is_expected.to eq 125.00 }
+        end
+
+        context "when student_loan is not received" do
+          subject(:mei_student_loan) { eligible_result.mei_student_loan }
+
+          it { is_expected.to eq 0.00 }
+        end
+      end
+
+      ################################################################
+      #  THRESHOLDS                                                  #
+      ################################################################
+
+      context "with thresholds within proceeding types" do
+        context "with gross income thresholds" do
+          let(:gross_income_proceeding_types) do
+            [
+              {
+                ccms_code: "DA006",
+                upper_threshold: 999_999_999_999.0,
+                result: "pending",
+              },
+              {
+                ccms_code: "DA002",
+                upper_threshold: 999_999_999_999.0,
+                result: "pending",
+              },
+            ]
+          end
+
+          describe "#gross_income_per_proceeding_types" do
+            it "returns the gross income per proceeding type" do
+              expect(eligible_result.gross_income_proceeding_types).to match gross_income_proceeding_types
+            end
+          end
+        end
+
+        context "with disposable income thresholds" do
+          let(:disposable_income_proceeding_types) do
+            [
+              {
+                ccms_code: "DA006",
+                upper_threshold: 999_999_999_999.0,
+                lower_threshold: 315.0,
+                result: "pending",
+              },
+              {
+                ccms_code: "DA002",
+                upper_threshold: 999_999_999_999.0,
+                lower_threshold: 315.0,
+                result: "pending",
+              },
+            ]
+          end
+
+          describe "#disposable_income_proceeding_types" do
+            it "returns the disposable income upper threshold" do
+              expect(eligible_result.disposable_income_proceeding_types).to match disposable_income_proceeding_types
+            end
+          end
+        end
+      end
+
+      ################################################################
+      #  TOTALS                                                      #
+      ################################################################
+
+      describe "mortgage per month" do
+        context "when mortgage is paid" do
+          it "returns the value of mortgage per month" do
+            expect(with_mortgage.mortgage_per_month).to eq 120.0
+          end
+        end
+
+        context "when no mortgage is paid" do
+          it "returns the value of mortgage per month" do
+            expect(eligible_result.mortgage_per_month).to eq 0.0
+          end
+        end
+      end
+
+      describe "pensioner_capital_disregard" do
+        it "returns the total pension disregard" do
+          expect(eligible_result.pensioner_capital_disregard).to eq 0.0
+        end
+      end
+
+      describe "total_capital_before_pensioner_disregard" do
+        it "returns total capital before pension disregard" do
+          expect(eligible_result.total_capital_before_pensioner_disregard).to eq 144.0
+        end
+      end
+
+      describe "total_disposable_capital" do
+        it "returns total disposable capital" do
+          expect(eligible_result.total_disposable_capital).to eq 144.0
+        end
+      end
+
+      describe "total_monthly_income" do
+        it "returns total monthly income" do
+          expect(with_monthly_income_equivalents.total_monthly_income).to eq 115.0
+        end
+      end
+
+      describe "total_monthly_income_including_employment_income" do
+        it "returns total monthly income including employment income" do
+          expect(with_monthly_income_equivalents.total_monthly_income_including_employment_income).to eq 2258.97
+        end
+      end
+
+      describe "total_monthly_outgoings" do
+        it "returns total monthly outgoings" do
+          expect(with_monthly_outgoing_equivalents.total_monthly_outgoings).to eq 165.0
+        end
+      end
+
+      describe "total_monthly_outgoings_including_tax_and_ni" do
+        it "returns total monthly outgoings including tax and ni" do
+          expect(with_monthly_outgoing_equivalents.total_monthly_outgoings_including_tax_and_ni).to eq 530.79
+        end
+      end
+
+      describe "total_gross_income" do
+        it "returns total gross income" do
+          expect(with_total_gross_income.total_gross_income).to eq 150.0
+        end
+      end
+
+      describe "total_disposable_income_assessed" do
+        it "returns total disposable income assessed" do
+          expect(eligible_result.total_disposable_income_assessed).to eq 0.0
+        end
+      end
+
+      describe "total_gross_income_assessed" do
+        it "returns total gross income assessed" do
+          expect(with_total_gross_income.total_gross_income_assessed).to eq 150.0
+        end
+      end
+
+      describe "total_deductions" do
+        it "returns total deductions" do
+          expect(with_total_deductions.total_deductions).to eq 1300.0
+        end
+      end
+
+      describe "total_deductions_including_fixed_employment_allowance" do
+        it "returns total deductions including_employment restrictions" do
+          expect(with_total_deductions.total_deductions_including_fixed_employment_allowance).to eq 1345.0
+        end
+      end
+
+      ################################################################
+      #  REMARKS                                                     #
+      ################################################################
+
+      describe "remarks" do
+        it "returns a CFE::Remarks object" do
+          expect(eligible_result.remarks).to be_instance_of(CFE::Remarks)
+        end
+
+        it "instantiates the Remarks class with the remarks part of the hash" do
+          expect(CFE::Remarks).to receive(:new).with({})
+          eligible_result.remarks
+        end
+      end
+
+      ################################################################
+      #  EMPLOYMENT_INCOME                                           #
+      ################################################################
+
+      context "with employment income" do
+        context "with employments" do
+          describe "gross_income" do
+            subject(:gross_income) { with_employments.employment_income_gross_income }
+
+            it { is_expected.to eq 1041.00 }
+          end
+
+          describe "benefits_in_kind" do
+            subject(:benefits_in_kind) { with_employments.employment_income_benefits_in_kind }
+
+            it { is_expected.to eq 16.60 }
+          end
+
+          describe "tax" do
+            subject(:tax) { with_employments.employment_income_tax }
+
+            it { is_expected.to eq(-104.10) }
+          end
+
+          describe "national_insurance" do
+            subject(:tax) { with_employments.employment_income_national_insurance }
+
+            it { is_expected.to eq(-18.66) }
+          end
+
+          describe "fixed_employment_deduction" do
+            subject(:tax) { with_employments.employment_income_fixed_employment_deduction }
+
+            it { is_expected.to eq(-45.00) }
+          end
+
+          describe "net_employment_income" do
+            subject(:tax) { with_employments.employment_income_net_employment_income }
+
+            it { is_expected.to eq 8898.84 }
+          end
+
+          describe "jobs" do
+            subject(:jobs) { with_employments.jobs }
+
+            it { is_expected.to be_a(Array) }
+            it { is_expected.not_to be_empty }
+
+            it "has a name" do
+              expect(jobs[0][:name]).to eq "Job 1"
+              expect(jobs[1][:name]).to eq "Job 2"
+            end
+          end
+
+          describe "jobs?" do
+            subject(:jobs?) { with_employments.jobs? }
+
+            it { is_expected.to be(true) }
+
+            context "without employment_income" do
+              before { allow(with_employments).to receive(:jobs).and_return(nil) }
+
+              it { is_expected.to be_falsey }
+            end
+          end
+        end
+
+        context "with no employments" do
+          describe "with employment_income" do
+            subject(:employment_income) { with_no_employments.employment_income }
+
+            it { is_expected.to be_a(Hash) }
+            it { is_expected.to be_empty }
+          end
+
+          describe "jobs" do
+            subject(:jobs) { with_no_employments.jobs }
+
+            it { is_expected.to be_a(Array) }
+            it { is_expected.to be_empty }
+          end
+
+          describe "jobs?" do
+            subject(:jobs?) { with_no_employments.jobs? }
+
+            it { is_expected.to be(false) }
+          end
+
+          describe "gross_income" do
+            subject(:gross_income) { with_no_employments.employment_income_gross_income }
+
+            it { is_expected.to eq 0.0 }
+          end
+
+          describe "benefits_in_kind" do
+            subject(:benefits_in_kind) { with_no_employments.employment_income_benefits_in_kind }
+
+            it { is_expected.to eq 0.0 }
+          end
+
+          describe "tax" do
+            subject(:tax) { with_no_employments.employment_income_tax }
+
+            it { is_expected.to eq 0.0 }
+          end
+
+          describe "national_insurance" do
+            subject(:tax) { with_no_employments.employment_income_national_insurance }
+
+            it { is_expected.to eq 0.0 }
+          end
+
+          describe "fixed_employment_deduction" do
+            subject(:tax) { with_no_employments.employment_income_fixed_employment_deduction }
+
+            it { is_expected.to eq 0.0 }
+          end
+
+          describe "net_employment_income" do
+            subject(:tax) { with_no_employments.employment_income_net_employment_income }
+
+            it { is_expected.to eq 0.0 }
           end
         end
       end

--- a/spec/models/cfe/v6/result_spec.rb
+++ b/spec/models/cfe/v6/result_spec.rb
@@ -29,14 +29,14 @@ module CFE
       let(:manual_review_determiner) { CCMS::ManualReviewDeterminer.new(application) }
 
       describe "#version" do
-        subject(:version) { eligible_result.version }
+        subject(:version) { cfe_result.version }
 
         it { expect(version).to be 6 }
       end
 
       describe "#version_6?" do
         it "returns boolean response for cfe version check" do
-          expect(eligible_result.version_6?).to be true
+          expect(cfe_result.version_6?).to be true
         end
       end
 
@@ -135,7 +135,7 @@ module CFE
       describe "capital_contribution_required?" do
         context "when contribution not required" do
           it "returns false for capital_contribution_required" do
-            expect(eligible_result.capital_contribution_required?).to be false
+            expect(cfe_result.capital_contribution_required?).to be false
           end
         end
 
@@ -154,7 +154,7 @@ module CFE
         describe "#gross_income_upper_threshold" do
           context "with only domestic abuse" do
             it "returns N/a" do
-              expect(eligible_result.gross_income_upper_threshold).to eq "N/a"
+              expect(cfe_result.gross_income_upper_threshold).to eq "N/a"
             end
           end
 
@@ -168,7 +168,7 @@ module CFE
         describe "#disposable_income_upper_threshold" do
           context "with only domestic abuse" do
             it "returns N/a" do
-              expect(eligible_result.disposable_income_upper_threshold).to eq "N/a"
+              expect(cfe_result.disposable_income_upper_threshold).to eq "N/a"
             end
           end
 
@@ -186,39 +186,39 @@ module CFE
 
       describe "non_liquid_capital_items" do
         it "returns the description and value for first item in non liquid items array" do
-          expect(eligible_result.non_liquid_capital_items.first[:description]).to be_a String
-          expect(eligible_result.non_liquid_capital_items.first[:value].to_d).to eq 12.00
+          expect(cfe_result.non_liquid_capital_items.first[:description]).to be_a String
+          expect(cfe_result.non_liquid_capital_items.first[:value].to_d).to eq 12.00
         end
       end
 
       describe "liquid_capital_items" do
         it "returns the description and value for first item in liquid items array" do
-          expect(eligible_result.liquid_capital_items.first[:description]).to be_a String
-          expect(eligible_result.liquid_capital_items.first[:value].to_d).to eq 1.00
+          expect(cfe_result.liquid_capital_items.first[:description]).to be_a String
+          expect(cfe_result.liquid_capital_items.first[:value].to_d).to eq 1.00
         end
       end
 
       describe "total_property" do
         it "returns the assessed value for total property" do
-          expect(eligible_result.total_property).to eq 0.0
+          expect(cfe_result.total_property).to eq 0.0
         end
       end
 
       describe "total_capital" do
         it "returns the assessed value for total capital" do
-          expect(eligible_result.total_capital).to eq 144.0
+          expect(cfe_result.total_capital).to eq 144.0
         end
       end
 
       describe "total_savings" do
         it "returns the assessed value for liquid assets" do
-          expect(eligible_result.total_savings).to eq 12.00
+          expect(cfe_result.total_savings).to eq 12.00
         end
       end
 
       describe "total_other_assets" do
         it "returns the assessed value for non liquid assets" do
-          expect(eligible_result.total_other_assets).to eq 12.0
+          expect(cfe_result.total_other_assets).to eq 12.0
         end
       end
 
@@ -266,15 +266,15 @@ module CFE
 
       describe "vehicle" do
         it "returns a vehicle" do
-          expect(eligible_result.vehicle).to be_a(Hash)
-          expect(eligible_result.vehicle[:value].to_d).to eq 120.0
+          expect(cfe_result.vehicle).to be_a(Hash)
+          expect(cfe_result.vehicle[:value].to_d).to eq 120.0
         end
       end
 
       describe "vehicles?" do
         context "when vehicle(s) exist" do
           it "returns a boolean response if vehicles exist" do
-            expect(eligible_result.vehicles?).to be true
+            expect(cfe_result.vehicles?).to be true
           end
         end
 
@@ -287,31 +287,31 @@ module CFE
 
       describe "vehicle_value" do
         it "returns the assessed value for applicants vehicle" do
-          expect(eligible_result.vehicle_value).to eq 120.0
+          expect(cfe_result.vehicle_value).to eq 120.0
         end
       end
 
       describe "vehicle_loan_amount_outstanding" do
         it "returns the loan value outstanding on applicants vehicle" do
-          expect(eligible_result.vehicle_loan_amount_outstanding).to eq 12.0
+          expect(cfe_result.vehicle_loan_amount_outstanding).to eq 12.0
         end
       end
 
       describe "vehicle_disregard" do
         it "returns the vehicle disregard for applicants vehicle" do
-          expect(eligible_result.vehicle_disregard).to eq 0.0
+          expect(cfe_result.vehicle_disregard).to eq 0.0
         end
       end
 
       describe "vehicle_assessed_amount" do
         it "returns the assessed value for the applicants vehicle" do
-          expect(eligible_result.vehicle_assessed_amount).to eq 120.0
+          expect(cfe_result.vehicle_assessed_amount).to eq 120.0
         end
       end
 
       describe "total_vehicles" do
         it "returns the assessed value for all applicants vehicle(s)" do
-          expect(eligible_result.total_vehicles).to eq 120.0
+          expect(cfe_result.total_vehicles).to eq 120.0
         end
       end
 
@@ -334,7 +334,7 @@ module CFE
 
         context "when present but zero" do
           it "returns false" do
-            expect(eligible_result.additional_property?).to be false
+            expect(cfe_result.additional_property?).to be false
           end
         end
       end
@@ -369,31 +369,31 @@ module CFE
 
       describe "main_home_value" do
         it "returns the assessed value for the main home" do
-          expect(eligible_result.main_home_value).to eq 10.0
+          expect(cfe_result.main_home_value).to eq 10.0
         end
       end
 
       describe "main_home_outstanding_mortgage" do
         it "returns the assessed value for the main home" do
-          expect(eligible_result.main_home_outstanding_mortgage).to eq(-20.0)
+          expect(cfe_result.main_home_outstanding_mortgage).to eq(-20.0)
         end
       end
 
       describe "main_home_transaction_allowance" do
         it "returns the assessed value for the main home" do
-          expect(eligible_result.main_home_transaction_allowance).to eq(-0.3)
+          expect(cfe_result.main_home_transaction_allowance).to eq(-0.3)
         end
       end
 
       describe "main_home_equity_disregard" do
         it "returns the assessed value for the main home" do
-          expect(eligible_result.main_home_equity_disregard).to eq(-100_000.0)
+          expect(cfe_result.main_home_equity_disregard).to eq(-100_000.0)
         end
       end
 
       describe "main_home_assessed_equity" do
         it "returns the assessed value for the main home" do
-          expect(eligible_result.main_home_assessed_equity).to eq 0.0
+          expect(cfe_result.main_home_assessed_equity).to eq 0.0
         end
       end
 
@@ -409,7 +409,7 @@ module CFE
         end
 
         context "when maintenance is not received" do
-          subject(:maintenance_per_month) { eligible_result.maintenance_per_month }
+          subject(:maintenance_per_month) { cfe_result.maintenance_per_month }
 
           it { is_expected.to eq 0.00 }
         end
@@ -423,7 +423,7 @@ module CFE
         end
 
         context "when student_loan is not received" do
-          subject(:mei_student_loan) { eligible_result.mei_student_loan }
+          subject(:mei_student_loan) { cfe_result.mei_student_loan }
 
           it { is_expected.to eq 0.00 }
         end
@@ -452,7 +452,7 @@ module CFE
 
           describe "#gross_income_per_proceeding_types" do
             it "returns the gross income per proceeding type" do
-              expect(eligible_result.gross_income_proceeding_types).to match gross_income_proceeding_types
+              expect(cfe_result.gross_income_proceeding_types).to match gross_income_proceeding_types
             end
           end
         end
@@ -477,7 +477,7 @@ module CFE
 
           describe "#disposable_income_proceeding_types" do
             it "returns the disposable income upper threshold" do
-              expect(eligible_result.disposable_income_proceeding_types).to match disposable_income_proceeding_types
+              expect(cfe_result.disposable_income_proceeding_types).to match disposable_income_proceeding_types
             end
           end
         end
@@ -496,26 +496,26 @@ module CFE
 
         context "when no mortgage is paid" do
           it "returns the value of mortgage per month" do
-            expect(eligible_result.mortgage_per_month).to eq 0.0
+            expect(cfe_result.mortgage_per_month).to eq 0.0
           end
         end
       end
 
       describe "pensioner_capital_disregard" do
         it "returns the total pension disregard" do
-          expect(eligible_result.pensioner_capital_disregard).to eq 0.0
+          expect(cfe_result.pensioner_capital_disregard).to eq 0.0
         end
       end
 
       describe "total_capital_before_pensioner_disregard" do
         it "returns total capital before pension disregard" do
-          expect(eligible_result.total_capital_before_pensioner_disregard).to eq 144.0
+          expect(cfe_result.total_capital_before_pensioner_disregard).to eq 144.0
         end
       end
 
       describe "total_disposable_capital" do
         it "returns total disposable capital" do
-          expect(eligible_result.total_disposable_capital).to eq 144.0
+          expect(cfe_result.total_disposable_capital).to eq 144.0
         end
       end
 
@@ -551,7 +551,7 @@ module CFE
 
       describe "total_disposable_income_assessed" do
         it "returns total disposable income assessed" do
-          expect(eligible_result.total_disposable_income_assessed).to eq 0.0
+          expect(cfe_result.total_disposable_income_assessed).to eq 0.0
         end
       end
 
@@ -579,12 +579,12 @@ module CFE
 
       describe "remarks" do
         it "returns a CFE::Remarks object" do
-          expect(eligible_result.remarks).to be_instance_of(CFE::Remarks)
+          expect(cfe_result.remarks).to be_instance_of(CFE::Remarks)
         end
 
         it "instantiates the Remarks class with the remarks part of the hash" do
           expect(CFE::Remarks).to receive(:new).with({})
-          eligible_result.remarks
+          cfe_result.remarks
         end
       end
 

--- a/spec/models/cfe/v6/result_spec.rb
+++ b/spec/models/cfe/v6/result_spec.rb
@@ -533,13 +533,13 @@ module CFE
 
       describe "total_monthly_outgoings" do
         it "returns total monthly outgoings" do
-          expect(with_monthly_outgoing_equivalents.total_monthly_outgoings).to eq 165.0
+          expect(with_monthly_outgoing_equivalents.total_monthly_outgoings).to eq 265.0
         end
       end
 
       describe "total_monthly_outgoings_including_tax_and_ni" do
         it "returns total monthly outgoings including tax and ni" do
-          expect(with_monthly_outgoing_equivalents.total_monthly_outgoings_including_tax_and_ni).to eq 530.79
+          expect(with_monthly_outgoing_equivalents.total_monthly_outgoings_including_tax_and_ni).to eq 630.79
         end
       end
 

--- a/spec/models/cfe/v6/with_partner_result_spec.rb
+++ b/spec/models/cfe/v6/with_partner_result_spec.rb
@@ -3,24 +3,25 @@ require "rails_helper"
 module CFE
   module V6
     RSpec.describe Result do
-      let(:cfe_result_with_partner) { create(:cfe_v6_result, :with_employments, :with_partner) }
-      let(:with_maintenance) { create(:cfe_v6_result, :with_partner, :with_maintenance_received) }
-      let(:with_student_finance) { create(:cfe_v6_result, :with_partner, :with_student_finance_received) }
-      let(:with_total_deductions) { create(:cfe_v6_result, :with_partner, :with_total_deductions) }
-      let(:with_monthly_income_equivalents) { create(:cfe_v6_result, :with_partner, :with_monthly_income_equivalents) }
-      let(:with_monthly_outgoing_equivalents) { create(:cfe_v6_result, :with_partner, :with_monthly_outgoing_equivalents) }
-      let(:with_total_gross_income) { create(:cfe_v6_result, :with_partner, :with_total_gross_income) }
-      let(:with_employments) { create(:cfe_v6_result, :with_partner, :with_employments) }
-      let(:with_no_employments) { create(:cfe_v6_result, :with_partner, :with_no_employments) }
-      let(:legal_aid_application) { create(:legal_aid_application, :with_applicant_and_partner, :with_restrictions, :with_cfe_v6_result) }
-      let(:cfe_submission) { create(:cfe_submission, legal_aid_application:) }
+      let(:cfe_result) { create(:cfe_v6_result, :with_employments, :with_partner) }
+      # let(:with_maintenance) { create(:cfe_v6_result, :with_partner, :with_maintenance_received) }
+      # let(:with_student_finance) { create(:cfe_v6_result, :with_partner, :with_student_finance_received) }
+      # let(:with_total_deductions) { create(:cfe_v6_result, :with_partner, :with_total_deductions) }
+      # let(:with_monthly_income_equivalents) { create(:cfe_v6_result, :with_partner, :with_monthly_income_equivalents) }
+      # let(:with_monthly_outgoing_equivalents) { create(:cfe_v6_result, :with_partner, :with_monthly_outgoing_equivalents) }
+      # let(:with_total_gross_income) { create(:cfe_v6_result, :with_partner, :with_total_gross_income) }
+      # let(:with_no_employments) { create(:cfe_v6_result, :with_partner, :with_no_employments) }
+      # let(:legal_aid_application) { create(:legal_aid_application, :with_applicant_and_partner, :with_restrictions, :with_cfe_v6_result) }
+      # let(:cfe_submission) { create(:cfe_submission, legal_aid_application:) }
+
+      # INCOME SUMMARIES
 
       describe "gross_income_breakdown" do
         context "with partner set to false" do
           let(:partner) { false }
 
           it "returns the gross income breakdown for the client" do
-            expect(cfe_result_with_partner.gross_income_breakdown(partner:)[:state_benefits][:monthly_equivalents][:all_sources]).to eq(75.0)
+            expect(cfe_result.gross_income_breakdown(partner:)[:state_benefits][:monthly_equivalents][:all_sources]).to eq 75.0
           end
         end
 
@@ -28,7 +29,7 @@ module CFE
           let(:partner) { true }
 
           it "returns the gross income breakdown for the partner" do
-            expect(cfe_result_with_partner.gross_income_breakdown(partner:)[:state_benefits][:monthly_equivalents][:all_sources]).to eq(86.67)
+            expect(cfe_result.gross_income_breakdown(partner:)[:state_benefits][:monthly_equivalents][:all_sources]).to eq 86.67
           end
         end
       end
@@ -38,7 +39,7 @@ module CFE
           let(:partner) { false }
 
           it "returns the gross income summary for the client" do
-            expect(cfe_result_with_partner.gross_income_summary(partner:)[:total_gross_income]).to eq(0.0)
+            expect(cfe_result.gross_income_summary(partner:)[:total_gross_income]).to be_zero
           end
         end
 
@@ -46,7 +47,7 @@ module CFE
           let(:partner) { true }
 
           it "returns the gross income summary for the partner" do
-            expect(cfe_result_with_partner.gross_income_summary(partner:)[:total_gross_income]).to eq(150.0)
+            expect(cfe_result.gross_income_summary(partner:)[:total_gross_income]).to eq 150.0
           end
         end
       end
@@ -56,7 +57,7 @@ module CFE
           let(:partner) { false }
 
           it "returns the total gross income for the client" do
-            expect(cfe_result_with_partner.total_gross_income_assessed(partner:)).to eq(0.0)
+            expect(cfe_result.total_gross_income_assessed(partner:)).to be_zero
           end
         end
 
@@ -64,7 +65,7 @@ module CFE
           let(:partner) { true }
 
           it "returns the total gross income for the partner" do
-            expect(cfe_result_with_partner.total_gross_income_assessed(partner:)).to eq(150.0)
+            expect(cfe_result.total_gross_income_assessed(partner:)).to eq 150.0
           end
         end
       end
@@ -74,7 +75,7 @@ module CFE
           let(:partner) { false }
 
           it "returns the total disposable income for the client only" do
-            expect(cfe_result_with_partner.total_disposable_income_assessed(partner:)).to eq(0.0)
+            expect(cfe_result.total_disposable_income_assessed(partner:)).to be_zero
           end
         end
 
@@ -82,7 +83,7 @@ module CFE
           let(:partner) { true }
 
           it "returns the total disposable income for the client and the partner" do
-            expect(cfe_result_with_partner.total_disposable_income_assessed(partner:)).to eq(2577.11)
+            expect(cfe_result.total_disposable_income_assessed(partner:)).to eq 2577.11
           end
         end
       end
@@ -92,7 +93,7 @@ module CFE
           let(:partner) { false }
 
           it "returns the disposable income summary for the client" do
-            expect(cfe_result_with_partner.disposable_income_summary(partner:)[:total_disposable_income]).to eq(0.0)
+            expect(cfe_result.disposable_income_summary(partner:)[:total_disposable_income]).to be_zero
           end
         end
 
@@ -100,7 +101,7 @@ module CFE
           let(:partner) { true }
 
           it "returns the disposable income summary for the partner" do
-            expect(cfe_result_with_partner.disposable_income_summary(partner:)[:total_disposable_income]).to eq(2577.11)
+            expect(cfe_result.disposable_income_summary(partner:)[:total_disposable_income]).to eq 2577.11
           end
         end
       end
@@ -110,7 +111,7 @@ module CFE
           let(:partner) { false }
 
           it "returns the disposable income breakdown for the client" do
-            expect(cfe_result_with_partner.disposable_income_breakdown(partner:)[:monthly_equivalents][:all_sources][:rent_or_mortgage]).to eq(125.0)
+            expect(cfe_result.disposable_income_breakdown(partner:)[:monthly_equivalents][:all_sources][:rent_or_mortgage]).to eq 125.0
           end
         end
 
@@ -118,17 +119,19 @@ module CFE
           let(:partner) { true }
 
           it "returns the disposable income breakdown for the partner" do
-            expect(cfe_result_with_partner.disposable_income_breakdown(partner:)[:monthly_equivalents][:all_sources][:rent_or_mortgage]).to eq(0.0)
+            expect(cfe_result.disposable_income_breakdown(partner:)[:monthly_equivalents][:all_sources][:rent_or_mortgage]).to be_zero
           end
         end
       end
+
+      # EMPLOYMENT
 
       describe "employment_income" do
         context "with partner set to false" do
           let(:partner) { false }
 
           it "returns the employment income for the client" do
-            expect(cfe_result_with_partner.employment_income(partner:)[:gross_income]).to eq(2143.97)
+            expect(cfe_result.employment_income(partner:)[:gross_income]).to eq 2143.97
           end
         end
 
@@ -136,7 +139,7 @@ module CFE
           let(:partner) { true }
 
           it "returns the employment income for the partner" do
-            expect(cfe_result_with_partner.employment_income(partner:)[:gross_income]).to eq(2229.17)
+            expect(cfe_result.employment_income(partner:)[:gross_income]).to eq 2229.17
           end
         end
       end
@@ -146,7 +149,7 @@ module CFE
           let(:partner) { false }
 
           it "returns the employment income for the client" do
-            expect(cfe_result_with_partner.employment_income_gross_income(partner:)).to eq(2143.97)
+            expect(cfe_result.employment_income_gross_income(partner:)).to eq 2143.97
           end
         end
 
@@ -154,10 +157,276 @@ module CFE
           let(:partner) { true }
 
           it "returns the employment income for the partner" do
-            expect(cfe_result_with_partner.employment_income_gross_income(partner:)).to eq(2229.17)
+            expect(cfe_result.employment_income_gross_income(partner:)).to eq 2229.17
           end
         end
       end
+
+      describe "employment_income_benefits_in_kind" do
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the benefits in kind for the client" do
+            expect(cfe_result.employment_income_benefits_in_kind(partner:)).to eq 16.60
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns the benefits in kind for the partner" do
+            expect(cfe_result.employment_income_benefits_in_kind(partner:)).to be_zero
+          end
+        end
+      end
+
+      describe "employment_income_tax" do
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the employemnt income tax for the client" do
+            expect(cfe_result.employment_income_tax(partner:)).to eq(-204.15)
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns the employment income tax for the partner" do
+            expect(cfe_result.employment_income_tax(partner:)).to eq(-235.2)
+          end
+        end
+      end
+
+      describe "employment_income_national_insurance" do
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the employemnt income national_insurance for the client" do
+            expect(cfe_result.employment_income_national_insurance(partner:)).to eq(-161.64)
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns the employment income national_insurance for the partner" do
+            expect(cfe_result.employment_income_national_insurance(partner:)).to eq(-171.86)
+          end
+        end
+      end
+
+      describe "employment_income_fixed_employment_deduction" do
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the employemnt income fixed_employment_deduction for the client" do
+            expect(cfe_result.employment_income_fixed_employment_deduction(partner:)).to eq(-45.0)
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns the employment income fixed_employment_deduction for the partner" do
+            expect(cfe_result.employment_income_fixed_employment_deduction(partner:)).to eq(-45.0)
+          end
+        end
+      end
+
+      describe "employment_income_net_employment_income" do
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the employemnt income net_employment_income for the client" do
+            expect(cfe_result.employment_income_net_employment_income(partner:)).to eq 1778.18
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns the employment income net_employment_income for the partner" do
+            expect(cfe_result.employment_income_net_employment_income(partner:)).to eq 1777.11
+          end
+        end
+      end
+
+      describe "partner_jobs" do
+        it "returns the jobs for the partner" do
+          expect(cfe_result.partner_jobs[0][:name]).to eq "Job 1"
+          expect(cfe_result.partner_jobs[0][:payments].length).to eq 2
+        end
+      end
+
+      describe "partner_jobs?" do
+        it "returns true" do
+          expect(cfe_result.partner_jobs?).to be true
+        end
+      end
+
+      # MONTHLY INCOME EQUIVALENTS
+
+      describe "monthly_income_equivalents" do
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the expected values" do
+            expect(cfe_result.monthly_state_benefits(partner:)).to eq 75.0
+            expect(cfe_result.mei_friends_or_family(partner:)).to be_zero
+            expect(cfe_result.mei_maintenance_in(partner:)).to be_zero
+            expect(cfe_result.mei_property_or_lodger(partner:)).to be_zero
+            expect(cfe_result.mei_student_loan(partner:)).to be_zero
+            expect(cfe_result.mei_pension(partner:)).to be_zero
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns the expected values" do
+            expect(cfe_result.monthly_state_benefits(partner:)).to eq 86.67
+            expect(cfe_result.mei_friends_or_family(partner:)).to eq 166.67
+            expect(cfe_result.mei_maintenance_in(partner:)).to eq 21.0
+            expect(cfe_result.mei_property_or_lodger(partner:)).to eq 200.0
+            expect(cfe_result.mei_student_loan(partner:)).to eq 100.0
+            expect(cfe_result.mei_pension(partner:)).to eq 30.0
+            expect(cfe_result.total_monthly_income_including_employment_income(partner:)).to eq 5052.48
+          end
+        end
+      end
+
+      describe "total_monthly_income" do
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the total monthly income for the client" do
+            expect(cfe_result.total_monthly_income(partner:)).to eq 75.0
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns the total monthly income for the partner" do
+            expect(cfe_result.total_monthly_income(partner:).round(2)).to eq 604.34
+          end
+        end
+      end
+
+      describe "total_monthly_income_including_employment_income" do
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the total monthly income including employment income for the client only" do
+            expect(cfe_result.total_monthly_income_including_employment_income(partner:)).to eq 2218.97
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns the total monthly income including employment income for both the client and partner combined" do
+            client_monthly_income = cfe_result.total_monthly_income(partner: false)
+            client_employment_income = cfe_result.employment_income_gross_income(partner: false)
+            partner_monthly_income = cfe_result.total_monthly_income(partner: true)
+            partner_employment_income = cfe_result.employment_income_gross_income(partner: true)
+            expected_total = client_monthly_income + client_employment_income + partner_monthly_income + partner_employment_income
+            expect(cfe_result.total_monthly_income_including_employment_income(partner:).round(2)).to eq expected_total
+          end
+        end
+      end
+
+      # MONTHLY OUTGOING EQUIVALENTS
+
+      describe "monthly_outgoing_equivalents" do
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the expected values" do
+            expect(cfe_result.moe_childcare(partner:)).to be_zero
+            expect(cfe_result.moe_housing(partner:)).to eq 125.0
+            expect(cfe_result.moe_maintenance_out(partner:)).to be_zero
+            expect(cfe_result.moe_legal_aid(partner:)).to eq 100.0
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns the expected values" do
+            expect(cfe_result.moe_childcare(partner:)).to eq 30.0
+            expect(cfe_result.moe_housing(partner:)).to eq 400.0
+            expect(cfe_result.moe_maintenance_out(partner:)).to eq 50.0
+            expect(cfe_result.moe_legal_aid(partner:)).to be_zero
+          end
+        end
+      end
+
+      describe "total_monthly_outgoings" do
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the total monthly outgoings for the client" do
+            expect(cfe_result.total_monthly_outgoings(partner:)).to eq 225.0
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns the total monthly outgoings for the partner" do
+            expect(cfe_result.total_monthly_outgoings(partner:)).to eq 480.0
+          end
+        end
+      end
+
+      describe "total_monthly_outgoings_including_employment_outgoings" do
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the total monthly outgoings including employment outgoings for the client only" do
+            expect(cfe_result.total_monthly_outgoings_including_tax_and_ni(partner:)).to eq 590.79
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns the total monthly outgoings including employment outgoings for both the client and partner combined" do
+            client_tax_and_ni = cfe_result.employment_income_tax(partner: false) + cfe_result.employment_income_national_insurance(partner: false)
+            client_total_outgoings = cfe_result.total_monthly_outgoings(partner: false) - client_tax_and_ni
+            partner_tax_and_ni = cfe_result.employment_income_tax(partner: true) + cfe_result.employment_income_national_insurance(partner: true)
+            partner_total_outgoings = cfe_result.total_monthly_outgoings(partner: true) - partner_tax_and_ni
+            expected_total = client_total_outgoings + partner_total_outgoings
+            expect(cfe_result.total_monthly_outgoings_including_tax_and_ni(partner:)).to eq expected_total
+          end
+        end
+      end
+
+      # DEDUCTIONS
+
+      describe "partner_allowance" do
+        it "returns the partner allowance" do
+          expect(cfe_result.partner_allowance).to eq(211.32)
+        end
+      end
+
+      describe "total_deductions" do
+        it "returns the total deductions amount" do
+          expected_amount = cfe_result.dependants_allowance + cfe_result.disregarded_state_benefits + cfe_result.partner_allowance
+          expect(cfe_result.total_deductions).to eq expected_amount
+        end
+      end
+
+      describe "total_deductions_including_fixed_employment_allowance" do
+        it "returns total deductions including fixed employment allowance" do
+          expected_amount = cfe_result.total_deductions + cfe_result.employment_income_fixed_employment_deduction
+          expect(cfe_result.total_deductions_including_fixed_employment_allowance).to eq expected_amount
+        end
+      end
+
+      # CAPITAL
     end
   end
 end

--- a/spec/models/cfe/v6/with_partner_result_spec.rb
+++ b/spec/models/cfe/v6/with_partner_result_spec.rb
@@ -25,6 +25,12 @@ module CFE
         end
       end
 
+      describe "partner_gross_income_breakdown" do
+        it "returns the gross income breakdown for the partner" do
+          expect(cfe_result.gross_income_breakdown(partner:)[:state_benefits][:monthly_equivalents][:all_sources]).to eq 86.67
+        end
+      end
+
       describe "gross_income_summary" do
         context "with partner set to false" do
           let(:partner) { false }
@@ -251,8 +257,18 @@ module CFE
       end
 
       describe "partner_jobs?" do
-        it "returns true" do
-          expect(cfe_result.partner_jobs?).to be true
+        context "when the partner has jobs" do
+          it "returns true" do
+            expect(cfe_result.partner_jobs?).to be true
+          end
+        end
+
+        context "when the partner does not have jobs" do
+          let(:cfe_result) { create(:cfe_v6_result, :with_partner, :without_partner_jobs) }
+
+          it "returns false" do
+            expect(cfe_result.partner_jobs?).to be false
+          end
         end
       end
 

--- a/spec/models/cfe/v6/with_partner_result_spec.rb
+++ b/spec/models/cfe/v6/with_partner_result_spec.rb
@@ -27,7 +27,7 @@ module CFE
 
       describe "partner_gross_income_breakdown" do
         it "returns the gross income breakdown for the partner" do
-          expect(cfe_result.gross_income_breakdown(partner:)[:state_benefits][:monthly_equivalents][:all_sources]).to eq 86.67
+          expect(cfe_result.partner_gross_income_breakdown[:state_benefits][:monthly_equivalents][:all_sources]).to eq 86.67
         end
       end
 
@@ -264,7 +264,7 @@ module CFE
         end
 
         context "when the partner does not have jobs" do
-          let(:cfe_result) { create(:cfe_v6_result, :with_partner, :without_partner_jobs) }
+          let(:cfe_result) { create(:cfe_v6_result, :without_partner_jobs) }
 
           it "returns false" do
             expect(cfe_result.partner_jobs?).to be false

--- a/spec/models/cfe/v6/with_partner_result_spec.rb
+++ b/spec/models/cfe/v6/with_partner_result_spec.rb
@@ -110,7 +110,7 @@ module CFE
           let(:partner) { true }
 
           it "returns the disposable income breakdown for the partner" do
-            expect(cfe_result.disposable_income_breakdown(partner:)[:monthly_equivalents][:all_sources][:rent_or_mortgage]).to be_zero
+            expect(cfe_result.disposable_income_breakdown(partner:)[:monthly_equivalents][:all_sources][:rent_or_mortgage]).to eq 400
           end
         end
       end

--- a/spec/models/cfe/v6/with_partner_result_spec.rb
+++ b/spec/models/cfe/v6/with_partner_result_spec.rb
@@ -420,13 +420,100 @@ module CFE
       end
 
       describe "total_deductions_including_fixed_employment_allowance" do
-        it "returns total deductions including fixed employment allowance" do
-          expected_amount = cfe_result.total_deductions + cfe_result.employment_income_fixed_employment_deduction
-          expect(cfe_result.total_deductions_including_fixed_employment_allowance).to eq expected_amount
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the total monthly outgoings including employment outgoings for the client only" do
+            expect(cfe_result.total_deductions_including_fixed_employment_allowance(partner:)).to eq 301.32
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns total deductions including fixed employment allowance" do
+            expect(cfe_result.total_deductions_including_fixed_employment_allowance(partner:)).to eq 301.32
+          end
         end
       end
 
       # CAPITAL
+
+      describe "capital_summary" do
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the total monthly outgoings including employment outgoings for the client only" do
+            expect(cfe_result.capital_summary(partner:)[:total_liquid]).to eq 12.0
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns total deductions including fixed employment allowance" do
+            expect(cfe_result.capital_summary(partner:)[:total_liquid]).to eq 500.0
+          end
+        end
+      end
+
+      describe "partner_capital" do
+        it "returns the partner capital" do
+          expect(cfe_result.partner_capital).not_to be_nil
+        end
+      end
+
+      describe "partner_capital?" do
+        it "returns true" do
+          expect(cfe_result.partner_capital?).to be true
+        end
+      end
+
+      describe "current_accounts" do
+        it "returns the sum of all current accounts" do
+          expect(cfe_result.current_accounts).to eq 601.0
+        end
+      end
+
+      describe "savings_accounts" do
+        it "returns the sum of all savings accounts" do
+          expect(cfe_result.savings_accounts).to eq 301.0
+        end
+      end
+
+      describe "liquid_capital_items" do
+        client_current_account = { description: "Current accounts", value: 1.0 }
+        partner_current_account = { description: "Partner current accounts", value: 400.0 }
+
+        it "returns the liquid capital items for client and partner" do
+          expect(client_current_account.in?(cfe_result.liquid_capital_items)).to be true
+          expect(partner_current_account.in?(cfe_result.liquid_capital_items)).to be true
+        end
+      end
+
+      describe "total_savings" do
+        it "returns the total savings for the client and partner" do
+          expect(cfe_result.total_savings).to eq 512.0
+        end
+      end
+
+      describe "total_capital" do
+        it "returns the total capital amount for client and partner" do
+          expect(cfe_result.total_capital).to eq 644.0
+        end
+      end
+
+      describe "total_capital_before_pensioner_disregard" do
+        it "returns the total capital amount before pensioner disregard" do
+          expect(cfe_result.total_capital_before_pensioner_disregard).to eq 644.0
+        end
+      end
+
+      describe "total_disposable_capital" do
+        it "returns the total disposable capital amount" do
+          expect(cfe_result.total_disposable_capital).to eq 644.0
+        end
+      end
     end
   end
 end

--- a/spec/models/cfe/v6/with_partner_result_spec.rb
+++ b/spec/models/cfe/v6/with_partner_result_spec.rb
@@ -1,0 +1,163 @@
+require "rails_helper"
+
+module CFE
+  module V6
+    RSpec.describe Result do
+      let(:cfe_result_with_partner) { create(:cfe_v6_result, :with_employments, :with_partner) }
+      let(:with_maintenance) { create(:cfe_v6_result, :with_partner, :with_maintenance_received) }
+      let(:with_student_finance) { create(:cfe_v6_result, :with_partner, :with_student_finance_received) }
+      let(:with_total_deductions) { create(:cfe_v6_result, :with_partner, :with_total_deductions) }
+      let(:with_monthly_income_equivalents) { create(:cfe_v6_result, :with_partner, :with_monthly_income_equivalents) }
+      let(:with_monthly_outgoing_equivalents) { create(:cfe_v6_result, :with_partner, :with_monthly_outgoing_equivalents) }
+      let(:with_total_gross_income) { create(:cfe_v6_result, :with_partner, :with_total_gross_income) }
+      let(:with_employments) { create(:cfe_v6_result, :with_partner, :with_employments) }
+      let(:with_no_employments) { create(:cfe_v6_result, :with_partner, :with_no_employments) }
+      let(:legal_aid_application) { create(:legal_aid_application, :with_applicant_and_partner, :with_restrictions, :with_cfe_v6_result) }
+      let(:cfe_submission) { create(:cfe_submission, legal_aid_application:) }
+
+      describe "gross_income_breakdown" do
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the gross income breakdown for the client" do
+            expect(cfe_result_with_partner.gross_income_breakdown(partner:)[:state_benefits][:monthly_equivalents][:all_sources]).to eq(75.0)
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns the gross income breakdown for the partner" do
+            expect(cfe_result_with_partner.gross_income_breakdown(partner:)[:state_benefits][:monthly_equivalents][:all_sources]).to eq(86.67)
+          end
+        end
+      end
+
+      describe "gross_income_summary" do
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the gross income summary for the client" do
+            expect(cfe_result_with_partner.gross_income_summary(partner:)[:total_gross_income]).to eq(0.0)
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns the gross income summary for the partner" do
+            expect(cfe_result_with_partner.gross_income_summary(partner:)[:total_gross_income]).to eq(150.0)
+          end
+        end
+      end
+
+      describe "total_gross_income_assessed" do
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the total gross income for the client" do
+            expect(cfe_result_with_partner.total_gross_income_assessed(partner:)).to eq(0.0)
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns the total gross income for the partner" do
+            expect(cfe_result_with_partner.total_gross_income_assessed(partner:)).to eq(150.0)
+          end
+        end
+      end
+
+      describe "total_disposable_income_assessed" do
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the total disposable income for the client only" do
+            expect(cfe_result_with_partner.total_disposable_income_assessed(partner:)).to eq(0.0)
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns the total disposable income for the client and the partner" do
+            expect(cfe_result_with_partner.total_disposable_income_assessed(partner:)).to eq(2577.11)
+          end
+        end
+      end
+
+      describe "total_disposable_income_summary" do
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the disposable income summary for the client" do
+            expect(cfe_result_with_partner.disposable_income_summary(partner:)[:total_disposable_income]).to eq(0.0)
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns the disposable income summary for the partner" do
+            expect(cfe_result_with_partner.disposable_income_summary(partner:)[:total_disposable_income]).to eq(2577.11)
+          end
+        end
+      end
+
+      describe "disposable_income_breakdown" do
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the disposable income breakdown for the client" do
+            expect(cfe_result_with_partner.disposable_income_breakdown(partner:)[:monthly_equivalents][:all_sources][:rent_or_mortgage]).to eq(125.0)
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns the disposable income breakdown for the partner" do
+            expect(cfe_result_with_partner.disposable_income_breakdown(partner:)[:monthly_equivalents][:all_sources][:rent_or_mortgage]).to eq(0.0)
+          end
+        end
+      end
+
+      describe "employment_income" do
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the employment income for the client" do
+            expect(cfe_result_with_partner.employment_income(partner:)[:gross_income]).to eq(2143.97)
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns the employment income for the partner" do
+            expect(cfe_result_with_partner.employment_income(partner:)[:gross_income]).to eq(2229.17)
+          end
+        end
+      end
+
+      describe "enployment_income_gross_income" do
+        context "with partner set to false" do
+          let(:partner) { false }
+
+          it "returns the employment income for the client" do
+            expect(cfe_result_with_partner.employment_income_gross_income(partner:)).to eq(2143.97)
+          end
+        end
+
+        context "with partner set to true" do
+          let(:partner) { true }
+
+          it "returns the employment income for the partner" do
+            expect(cfe_result_with_partner.employment_income_gross_income(partner:)).to eq(2229.17)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/cfe/v6/with_partner_result_spec.rb
+++ b/spec/models/cfe/v6/with_partner_result_spec.rb
@@ -4,15 +4,6 @@ module CFE
   module V6
     RSpec.describe Result do
       let(:cfe_result) { create(:cfe_v6_result, :with_employments, :with_partner) }
-      # let(:with_maintenance) { create(:cfe_v6_result, :with_partner, :with_maintenance_received) }
-      # let(:with_student_finance) { create(:cfe_v6_result, :with_partner, :with_student_finance_received) }
-      # let(:with_total_deductions) { create(:cfe_v6_result, :with_partner, :with_total_deductions) }
-      # let(:with_monthly_income_equivalents) { create(:cfe_v6_result, :with_partner, :with_monthly_income_equivalents) }
-      # let(:with_monthly_outgoing_equivalents) { create(:cfe_v6_result, :with_partner, :with_monthly_outgoing_equivalents) }
-      # let(:with_total_gross_income) { create(:cfe_v6_result, :with_partner, :with_total_gross_income) }
-      # let(:with_no_employments) { create(:cfe_v6_result, :with_partner, :with_no_employments) }
-      # let(:legal_aid_application) { create(:legal_aid_application, :with_applicant_and_partner, :with_restrictions, :with_cfe_v6_result) }
-      # let(:cfe_submission) { create(:cfe_submission, legal_aid_application:) }
 
       # INCOME SUMMARIES
 
@@ -420,20 +411,8 @@ module CFE
       end
 
       describe "total_deductions_including_fixed_employment_allowance" do
-        context "with partner set to false" do
-          let(:partner) { false }
-
-          it "returns the total monthly outgoings including employment outgoings for the client only" do
-            expect(cfe_result.total_deductions_including_fixed_employment_allowance(partner:)).to eq 301.32
-          end
-        end
-
-        context "with partner set to true" do
-          let(:partner) { true }
-
-          it "returns total deductions including fixed employment allowance" do
-            expect(cfe_result.total_deductions_including_fixed_employment_allowance(partner:)).to eq 301.32
-          end
+        it "returns the deductions including the fixed employment allowance" do
+          expect(cfe_result.total_deductions_including_fixed_employment_allowance).to eq 301.32
         end
       end
 

--- a/spec/requests/providers/capital_assessment_results_controller_spec.rb
+++ b/spec/requests/providers/capital_assessment_results_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Providers::CapitalAssessmentResultsController do
   describe "GET /providers/applications/:legal_aid_application_id/capital_assessment_result" do
     subject(:get_request) { get providers_legal_aid_application_capital_assessment_result_path(legal_aid_application) }
 
-    let(:cfe_result) { create(:cfe_v3_result) }
+    let(:cfe_result) { create(:cfe_v6_result) }
     let(:legal_aid_application) { cfe_result.legal_aid_application }
     let!(:applicant) { create(:applicant, with_bank_accounts: 2, legal_aid_application:) }
     let(:applicant_name) { legal_aid_application.applicant_full_name }

--- a/spec/requests/providers/capital_income_assessment_results_controller_spec.rb
+++ b/spec/requests/providers/capital_income_assessment_results_controller_spec.rb
@@ -482,8 +482,8 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
       let(:cfe_result) { create(:cfe_v6_result, :with_no_employments) }
 
       it "does not display employment income" do
-        expect(unescaped_response_body).not_to include(I18n.t("providers.capital_income_assessment_results.employment_income.title"))
-        expect(unescaped_response_body).to include(I18n.t("providers.capital_income_assessment_results.other_income.income"))
+        expect(unescaped_response_body).not_to include(I18n.t("providers.capital_income_assessment_results.employment_income.title", individual: "Client"))
+        expect(unescaped_response_body).to include(I18n.t("providers.capital_income_assessment_results.other_income.income", individual: "Client"))
       end
     end
   end

--- a/spec/requests/providers/capital_income_assessment_results_controller_spec.rb
+++ b/spec/requests/providers/capital_income_assessment_results_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
     context "with no restrictions" do
       context "without policy disregards" do
         context "when eligible" do
-          let(:cfe_result) { create(:cfe_v4_result, :eligible) }
+          let(:cfe_result) { create(:cfe_v6_result, :eligible) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -72,7 +72,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
         end
 
         context "when capital contribution required" do
-          let(:cfe_result) { create(:cfe_v4_result, :with_capital_contribution_required) }
+          let(:cfe_result) { create(:cfe_v6_result, :with_capital_contribution_required) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -84,7 +84,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
         end
 
         context "when income contribution required" do
-          let(:cfe_result) { create(:cfe_v4_result, :with_income_contribution_required) }
+          let(:cfe_result) { create(:cfe_v6_result, :with_income_contribution_required) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -96,7 +96,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
         end
 
         context "when both income and capital contribution required" do
-          let(:cfe_result) { create(:cfe_v4_result, :with_capital_and_income_contributions_required) }
+          let(:cfe_result) { create(:cfe_v6_result, :with_capital_and_income_contributions_required) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -118,7 +118,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
         let(:add_policy_disregards?) { true }
 
         context "when eligible" do
-          let(:cfe_result) { create(:cfe_v4_result, :eligible) }
+          let(:cfe_result) { create(:cfe_v6_result, :eligible) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -142,7 +142,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
         end
 
         context "when capital contribution required" do
-          let(:cfe_result) { create(:cfe_v4_result, :with_capital_contribution_required) }
+          let(:cfe_result) { create(:cfe_v6_result, :with_capital_contribution_required) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -156,7 +156,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
         end
 
         context "when income contribution required" do
-          let(:cfe_result) { create(:cfe_v4_result, :with_income_contribution_required) }
+          let(:cfe_result) { create(:cfe_v6_result, :with_income_contribution_required) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -170,7 +170,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
         end
 
         context "when both income and capital contribution required" do
-          let(:cfe_result) { create(:cfe_v4_result, :with_capital_and_income_contributions_required) }
+          let(:cfe_result) { create(:cfe_v6_result, :with_capital_and_income_contributions_required) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -197,7 +197,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
 
       context "without policy disregards" do
         context "when eligible" do
-          let(:cfe_result) { create(:cfe_v4_result, :eligible) }
+          let(:cfe_result) { create(:cfe_v6_result, :eligible) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -209,7 +209,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
         end
 
         context "when capital contribution required" do
-          let(:cfe_result) { create(:cfe_v4_result, :with_capital_contribution_required) }
+          let(:cfe_result) { create(:cfe_v6_result, :with_capital_contribution_required) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -223,7 +223,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
         end
 
         context "when income contribution required" do
-          let(:cfe_result) { create(:cfe_v4_result, :with_income_contribution_required) }
+          let(:cfe_result) { create(:cfe_v6_result, :with_income_contribution_required) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -237,7 +237,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
         end
 
         context "when both income and capital contribution required" do
-          let(:cfe_result) { create(:cfe_v4_result, :with_capital_and_income_contributions_required) }
+          let(:cfe_result) { create(:cfe_v6_result, :with_capital_and_income_contributions_required) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -255,7 +255,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
         let(:add_policy_disregards?) { true }
 
         context "when eligible" do
-          let(:cfe_result) { create(:cfe_v4_result, :eligible) }
+          let(:cfe_result) { create(:cfe_v6_result, :eligible) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -267,7 +267,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
         end
 
         context "when capital contribution required" do
-          let(:cfe_result) { create(:cfe_v4_result, :with_capital_contribution_required) }
+          let(:cfe_result) { create(:cfe_v6_result, :with_capital_contribution_required) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -283,7 +283,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
         end
 
         context "when income contribution required" do
-          let(:cfe_result) { create(:cfe_v4_result, :with_income_contribution_required) }
+          let(:cfe_result) { create(:cfe_v6_result, :with_income_contribution_required) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -299,7 +299,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
         end
 
         context "when both income and capital contribution required" do
-          let(:cfe_result) { create(:cfe_v4_result, :with_capital_and_income_contributions_required) }
+          let(:cfe_result) { create(:cfe_v6_result, :with_capital_and_income_contributions_required) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -326,7 +326,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
       end
 
       context "when eligible" do
-        let(:cfe_result) { create(:cfe_v4_result, :eligible) }
+        let(:cfe_result) { create(:cfe_v6_result, :eligible) }
 
         it "returns http success" do
           expect(response).to have_http_status(:ok)
@@ -341,7 +341,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
       end
 
       context "when capital contribution required" do
-        let(:cfe_result) { create(:cfe_v4_result, :with_capital_contribution_required) }
+        let(:cfe_result) { create(:cfe_v6_result, :with_capital_contribution_required) }
 
         it "returns http success" do
           expect(response).to have_http_status(:ok)
@@ -356,7 +356,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
       end
 
       context "when income contribution required" do
-        let(:cfe_result) { create(:cfe_v4_result, :with_income_contribution_required) }
+        let(:cfe_result) { create(:cfe_v6_result, :with_income_contribution_required) }
 
         it "returns http success" do
           expect(response).to have_http_status(:ok)
@@ -371,7 +371,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
       end
 
       context "when both income and capital contribution required" do
-        let(:cfe_result) { create(:cfe_v4_result, :with_capital_and_income_contributions_required) }
+        let(:cfe_result) { create(:cfe_v6_result, :with_capital_and_income_contributions_required) }
 
         it "returns http success" do
           expect(response).to have_http_status(:ok)
@@ -422,13 +422,13 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
 
     context "when unauthenticated" do
       let(:before_tasks) { get_request }
-      let(:cfe_result) { create(:cfe_v4_result, :eligible) }
+      let(:cfe_result) { create(:cfe_v6_result, :eligible) }
 
       it_behaves_like "a provider not authenticated"
     end
 
     context "with unknown result" do
-      let(:cfe_result) { create(:cfe_v4_result, result: {}.to_json) }
+      let(:cfe_result) { create(:cfe_v6_result, result: {}.to_json) }
       let(:before_tasks) do
         login_provider
       end
@@ -439,7 +439,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
     end
 
     context "when applicant has employment(s)" do
-      let(:cfe_result) { create(:cfe_v4_result, :with_employments) }
+      let(:cfe_result) { create(:cfe_v6_result, :with_employments) }
       let(:td) { "</th><td class=\"govuk-table__cell govuk-table__cell--numeric\">" }
       let(:footer_td) { "</th><td class=\"govuk-table__footer govuk-table__footer--numeric\">" }
       let(:monthly_income_before_tax) { I18n.t("providers.capital_income_assessment_results.employment_income.monthly_income_before_tax") }
@@ -457,8 +457,8 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
       let(:total_disposable) { I18n.t("providers.capital_income_assessment_results.disposable_income.total_disposable") }
 
       it "displays the employment income" do
-        expect(unescaped_response_body).to include(I18n.t("providers.capital_income_assessment_results.other_income.title"))
-        expect(unescaped_response_body).to include(I18n.t("providers.capital_income_assessment_results.employment_income.title"))
+        expect(unescaped_response_body).to include(I18n.t("providers.capital_income_assessment_results.other_income.title", individual: "Client"))
+        expect(unescaped_response_body).to include(I18n.t("providers.capital_income_assessment_results.employment_income.title", individual: "Client"))
         expect(unescaped_response_body).to include(monthly_income_before_tax + td + gds_number_to_currency(cfe_result.employment_income_gross_income))
         expect(unescaped_response_body).to include(benefits_in_kind + td + gds_number_to_currency(cfe_result.employment_income_benefits_in_kind))
         expect(unescaped_response_body).to include(tax + td + gds_number_to_currency(cfe_result.employment_income_tax))
@@ -469,7 +469,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
 
       it "displays the correct totals" do
         expect(unescaped_response_body).to include(total_outgoings + footer_td + gds_number_to_currency(cfe_result.total_monthly_outgoings))
-        expect(unescaped_response_body).to include(total_other_income + footer_td + gds_number_to_currency(cfe_result.total_gross_income))
+        expect(unescaped_response_body).to include(total_other_income + footer_td + gds_number_to_currency(cfe_result.total_monthly_income))
         expect(unescaped_response_body).to include(total_deductions + footer_td + gds_number_to_currency(cfe_result.total_deductions))
         expect(unescaped_response_body).to include(total_disposable_income + td + gds_number_to_currency(cfe_result.total_monthly_income_including_employment_income))
         expect(unescaped_response_body).to include(total_disposable_outgoings + td + gds_number_to_currency(cfe_result.total_monthly_outgoings_including_tax_and_ni))
@@ -479,7 +479,7 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
     end
 
     context "when applicant has no employment(s)" do
-      let(:cfe_result) { create(:cfe_v4_result, :with_no_employments) }
+      let(:cfe_result) { create(:cfe_v6_result, :with_no_employments) }
 
       it "does not display employment income" do
         expect(unescaped_response_body).not_to include(I18n.t("providers.capital_income_assessment_results.employment_income.title"))


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3811)

Updated the means assessment result page to show the partner assessment details.
This required creating the CFE V6 result model which implements many method to retrieve/calculate the partner financial results, overriding these methods from CFE V4 while ensuring these updated methods also still work for client-only applications. 
CFE V4 also had to be updated to take option args (**) to avoid throwing a NoMethod error when the updated V6 methods are called with `partner: true` on an old CFE V4 result
A new separate rspec file was created to test all these methods for an application with a partner `spec/models/cfe/v6/with_partner.rb`. A new mock result `with_partner` has been added. 
Existing rspecs were udpated

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
