### PR TITLE
AP-4659: Bump delete uat GHA v1.0.2 --> v1.1.0

### DIFF
--- a/.github/workflows/delete-uat-release.yml
+++ b/.github/workflows/delete-uat-release.yml
@@ -12,9 +12,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Delete UAT release action
         id: delete_uat
-        uses: ministryofjustice/laa-civil-apply-delete-uat-release@v1.0.2
+        uses: ministryofjustice/laa-civil-apply-delete-uat-release@v1.1.0
         with:
           release_name_prefix: "apply-"
+          delete_all_pvc: true
           k8s_cluster: ${{ secrets.K8S_GHA_UAT_CLUSTER_NAME }}
           k8s_cluster_cert: ${{ secrets.K8S_GHA_UAT_CLUSTER_CERT }}
           k8s_namespace: ${{ secrets.K8S_GHA_UAT_NAMESPACE }}


### PR DESCRIPTION
## What
Bump delete uat GHA v1.0.2 --> v1.1.0

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4659)

We have not been clearing up our persistenvolumeclaims
when deleting UAT branches. This eats up cloud platform 
cluster resource and cost (particularly backups apparently).

This bumped version will do the PVC cleanup going forward.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
