### PR TITLE
AP-4612: Change summary list to card on check provider answers page

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -23,7 +23,8 @@ module Admin
                                       :allow_welsh_translation,
                                       :enable_ccms_submission,
                                       :partner_means_assessment,
-                                      :linked_applications)
+                                      :linked_applications,
+                                      :cya_summary_cards)
     end
 
     def setting

--- a/app/forms/settings/setting_form.rb
+++ b/app/forms/settings/setting_form.rb
@@ -7,7 +7,8 @@ module Settings
                   :allow_welsh_translation,
                   :enable_ccms_submission,
                   :partner_means_assessment,
-                  :linked_applications
+                  :linked_applications,
+                  :cya_summary_cards
 
     validates :mock_true_layer_data,
               :manually_review_all_cases,
@@ -15,6 +16,7 @@ module Settings
               :enable_ccms_submission,
               :partner_means_assessment,
               :linked_applications,
+              :cya_summary_cards,
               presence: true
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -31,6 +31,10 @@ class Setting < ApplicationRecord
     setting.linked_applications
   end
 
+  def self.cya_summary_cards?
+    setting.cya_summary_cards
+  end
+
   def self.setting
     Setting.first || Setting.create!
   end

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -66,6 +66,16 @@
           legend: { text: t(".labels.linked_applications") },
         ) %>
 
+    <%= form.govuk_collection_radio_buttons(
+          :cya_summary_cards,
+          yes_no_options,
+          :value,
+          :label,
+          inline: true,
+          hint: { text: t(".hints.cya_summary_cards") },
+          legend: { text: t(".labels.cya_summary_cards") },
+        ) %>
+
     <%= form.govuk_submit(t("generic.submit")) %>
   <% end %>
 <% end %>

--- a/app/views/providers/check_provider_answers/index.html.erb
+++ b/app/views/providers/check_provider_answers/index.html.erb
@@ -4,8 +4,22 @@
      address: @address,
      read_only: @read_only,
    } %>
-<% if @read_only %>
-  <%= render "providers/check_provider_answers/read_only", pass_through %>
+
+<% if Setting.cya_summary_cards? %>
+  <h2 class="govuk-heading-m"><%= t(".client.heading") %></h2>
+
+  <%= render(
+        "shared/check_your_answers/client_details",
+        attributes: %i[first_name last_name date_of_birth national_insurance_number employment_status address],
+        applicant: @applicant,
+        partner: @partner,
+        address: @address,
+        read_only: @read_only,
+      ) %>
 <% else %>
-  <%= render "providers/check_provider_answers/standard", pass_through %>
+  <% if @read_only %>
+    <%= render "providers/check_provider_answers/read_only", pass_through %>
+  <% else %>
+    <%= render "providers/check_provider_answers/standard", pass_through %>
+  <% end %>
 <% end %>

--- a/app/views/shared/check_your_answers/_client_details.html.erb
+++ b/app/views/shared/check_your_answers/_client_details.html.erb
@@ -1,0 +1,109 @@
+
+<%= govuk_summary_list(card: { title: t(".title") },
+                       html_attributes: { id: "client-details-questions" },
+                       actions: !read_only) do |summary_list| %>
+  <% if :first_name.in?(attributes) %>
+    <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__first_name" }) do |row| %>
+      <%= row.with_key(text: t(".first_name")) %>
+      <%= row.with_value(text: applicant.first_name) %>
+      <%= row.with_action(
+            text: t("generic.change"),
+            href: providers_legal_aid_application_applicant_details_path(@legal_aid_application, anchor: :first_name),
+            visually_hidden_text: "#{t('.aria_prefix')} #{t('.first_name')}",
+          ) %>
+    <% end %>
+  <% end %>
+
+  <% if :last_name.in?(attributes) %>
+    <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__last_name" }) do |row| %>
+      <%= row.with_key(text: t(".last_name")) %>
+      <%= row.with_value(text: applicant.last_name) %>
+      <%= row.with_action(
+            text: t("generic.change"),
+            href: providers_legal_aid_application_applicant_details_path(@legal_aid_application, anchor: :last_name),
+            visually_hidden_text: "#{t('.aria_prefix')} #{t('.last_name')}",
+          ) %>
+    <% end %>
+  <% end %>
+
+  <% if :date_of_birth.in?(attributes) %>
+    <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__date_of_birth" }) do |row| %>
+      <%= row.with_key(text: t(".dob")) %>
+      <%= row.with_value(text: applicant.date_of_birth) %>
+      <%= row.with_action(
+            text: t("generic.change"),
+            href: providers_legal_aid_application_applicant_details_path(@legal_aid_application, anchor: :date_of_birth),
+            visually_hidden_text: "#{t('.aria_prefix')} #{t('.dob')}",
+          ) %>
+    <% end %>
+  <% end %>
+
+  <% if :age.in?(attributes) %>
+    <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__age" }) do |row| %>
+      <%= row.with_key(text: t(".age_question")) %>
+      <%= row.with_value(text: t(".age", years: applicant.age)) %>
+    <% end %>
+  <% end %>
+
+  <% if :means_test.in?(attributes) %>
+    <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__means_test" }) do |row| %>
+      <%= row.with_key(text: t(".means_tested")) %>
+      <%= row.with_value(text: yes_no(!@legal_aid_application.non_means_tested?)) %>
+    <% end %>
+  <% end %>
+
+  <% if :address.in?(attributes) %>
+    <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__address" }) do |row| %>
+      <%= row.with_key(text: t(".address")) %>
+      <%= row.with_value(text: address_with_line_breaks(address)) %>
+      <%= row.with_action(
+            text: t("generic.change"),
+            href: change_address_link(applicant),
+            visually_hidden_text: "#{t('.aria_prefix')} #{t('.address')}",
+          ) %>
+    <% end %>
+  <% end %>
+
+  <% if :employment_status.in?(attributes) && !applicant.employed.nil? %>
+    <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__employment_status" }) do |row| %>
+      <%= row.with_key(text: t(".employment_status")) %>
+      <%= row.with_value(text: applicant.employment_status) %>
+    <% end %>
+  <% end %>
+
+  <% if :national_insurance_number.in?(attributes) %>
+    <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__national_insurance_number" }) do |row| %>
+      <%= row.with_key(text: t(".nino")) %>
+      <%= row.with_value(text: applicant.national_insurance_number || t("generic.not_provided")) %>
+      <%= row.with_action(
+            text: t("generic.change"),
+            href: providers_legal_aid_application_has_national_insurance_number_path(@legal_aid_application),
+            visually_hidden_text: "#{t('.aria_prefix')} {#{t('.nino')}",
+          ) %>
+    <% end %>
+  <% end %>
+
+  <% if :email.in?(attributes) %>
+    <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__email" }) do |row| %>
+      <%= row.with_key(text: t(".email")) %>
+      <%= row.with_value(text: applicant.email) %>
+      <%= row.with_action(
+            text: t("generic.change"),
+            href: providers_legal_aid_application_applicant_details_path(@legal_aid_application, anchor: :email),
+            visually_hidden_text: "#{t('.aria_prefix')} {#{t('.email')}",
+          ) %>
+    <% end %>
+  <% end %>
+
+  <% if Setting.partner_means_assessment? %>
+    <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__has_partner" }) do |row| %>
+      <%= row.with_key(text: t(".has_partner")) %>
+      <%= row.with_value(text: yes_no(applicant.has_partner?)) %>
+      <%= row.with_action(
+            text: t("generic.change"),
+            href: providers_legal_aid_application_client_has_partner_path(@legal_aid_application),
+            visually_hidden_text: t(".has_partner_aria_label"),
+          ) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -74,6 +74,7 @@ en:
           enable_evidence_upload: Enable the new evidence upload feature
           partner_means_assessment: Enable Partner Means Assessment
           linked_applications: Enable linked applications
+          cya_summary_cards: Enable summary cards on 'check your answers' pages
         hints:
           mock_true_layer_data: Select Yes and TrueLayer data will be replaced by mock data from %{bank_transaction_filename}
           manually_review_all_cases: |
@@ -84,6 +85,7 @@ en:
           enable_evidence_upload: Select Yes to enable the new evidence upload feature for solicitors
           partner_means_assessment: Select Yes to allow Providers to complete the Partner Means Assessment
           linked_applications: Select Yes to enable the linked applications feature for solicitors
+          cya_summary_cards: Select Yes to enable summary cards on 'check your answers' pages
       update:
         notice: Settings have been updated
     submitted_applications_reports:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -372,6 +372,9 @@ en:
           heading: Covered under a substantive certificate
         emergency_cost_limit: Emergency cost limit
         substantive_cost_limit: Substantive cost limit
+      index:
+        client:
+          heading: Client details
     applicant_bank_accounts:
       show:
         heading: Your client's bank accounts

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -510,6 +510,23 @@ en:
       benefits_breakdown:
         heading: Benefits breakdown
 
+    check_your_answers:
+      client_details:
+        title: Client details
+        address: Correspondence address
+        aria_prefix: client's
+        employment_status: Employment status
+        age: "%{years} years old"
+        age_question: Age at computation date
+        means_tested: Was the client means-tested?
+        dob: Date of birth
+        email: Email address
+        first_name: First name
+        last_name: Last name
+        nino: National Insurance number
+        has_partner: Does your client have a partner?
+        has_partner_aria_label: Change whether your client has a partner
+
     forms:
       applicant_form:
         page_title: Enter your client's details

--- a/db/migrate/20231206161248_add_cya_summary_cards_to_settings.rb
+++ b/db/migrate/20231206161248_add_cya_summary_cards_to_settings.rb
@@ -1,0 +1,5 @@
+class AddCyaSummaryCardsToSettings < ActiveRecord::Migration[7.1]
+  def change
+    add_column :settings, :cya_summary_cards, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_08_110820) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_06_161248) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -945,6 +945,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_08_110820) do
     t.boolean "partner_means_assessment", default: false, null: false
     t.datetime "cfe_compare_run_at"
     t.boolean "linked_applications", default: false, null: false
+    t.boolean "cya_summary_cards", default: false, null: false
   end
 
   create_table "specific_issues", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Setting do
         expect(rec.alert_via_sentry?).to be true
         expect(rec.partner_means_assessment?).to be false
         expect(rec.linked_applications?).to be false
+        expect(rec.cya_summary_cards?).to be false
       end
     end
 
@@ -28,6 +29,7 @@ RSpec.describe Setting do
           alert_via_sentry: true,
           partner_means_assessment: true,
           linked_applications: true,
+          cya_summary_cards: true,
         )
       end
 
@@ -41,6 +43,7 @@ RSpec.describe Setting do
         expect(rec.alert_via_sentry?).to be true
         expect(rec.partner_means_assessment?).to be true
         expect(rec.linked_applications?).to be true
+        expect(rec.cya_summary_cards?).to be true
       end
     end
   end
@@ -57,6 +60,7 @@ RSpec.describe Setting do
       expect(described_class.alert_via_sentry?).to be true
       expect(described_class.partner_means_assessment?).to be false
       expect(described_class.linked_applications?).to be false
+      expect(described_class.cya_summary_cards?).to be false
     end
   end
 end

--- a/spec/requests/admin/settings_controller_spec.rb
+++ b/spec/requests/admin/settings_controller_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Admin::SettingsController do
           enable_ccms_submission: "true",
           partner_means_assessment: "true",
           linked_applications: "true",
+          cya_summary_cards: "true",
         },
       }
     end
@@ -57,6 +58,7 @@ RSpec.describe Admin::SettingsController do
       expect(setting.allow_welsh_translation?).to be(true)
       expect(setting.partner_means_assessment?).to be(true)
       expect(setting.linked_applications?).to be(true)
+      expect(setting.cya_summary_cards?).to be(true)
     end
 
     it "create settings if they do not exist" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4612)

Add feature flag so check your answers pages can be updated one by one. First section has been added as an example

![image](https://github.com/ministryofjustice/laa-apply-for-legal-aid/assets/13471320/02528b62-20aa-44e7-b51d-94835fdc5270)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
