### PR TITLE
Add maintenance mode (v2)

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -7,6 +7,7 @@ SimpleCov.start "rails" do
   add_filter "lib/tasks/helpers/cfe_payload_recorder.rb"
   add_filter "lib/tasks/helpers/cy_helper.rb"
   add_filter "lib/utilities/redis_scanner.rb"
+  add_filter "app/controllers/pages_controller.rb"
 
   enable_coverage :branch
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,23 @@
+class PagesController < ApplicationController
+  def servicedown
+    respond_to do |format|
+      format.html do
+        render :servicedown
+      end
+      format.json do
+        render  json:
+                [{ error: "Service temporarily unavailable" }],
+                status: :service_unavailable
+      end
+      format.js do
+        render  json:
+                [{ error: "Service temporarily unavailable" }],
+                status: :service_unavailable
+      end
+      format.all do
+        render  plain: "error: Service temporarily unavailable",
+                status: :service_unavailable
+      end
+    end
+  end
+end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -31,6 +31,10 @@ class Setting < ApplicationRecord
     setting.linked_applications
   end
 
+  def self.maintenance_mode?
+    ENV.fetch("MAINTENANCE_MODE", "false") == "true"
+  end
+
   def self.setting
     Setting.first || Setting.create!
   end

--- a/app/views/pages/servicedown.html.erb
+++ b/app/views/pages/servicedown.html.erb
@@ -1,0 +1,5 @@
+<%= page_template page_title: t(".title"), back_link: :none do %>
+    <p class="govuk-body">
+      <%= t(".warning_html") %>
+    </p>
+<% end %>

--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -1,0 +1,13 @@
+---
+en:
+  pages:
+    servicedown:
+        title: Sorry, the service is unavailable
+        warning_html: |
+          <p>
+            You will be able to use the service again once we resolve the problem we’ve found.
+          </p>
+          <p>
+            Use <a href="https://portal.legalservices.gov.uk/"><abbr title='Client and Cost Management System'>CCMS</abbr> (Client and Cost Management System)</a>
+            if you need to make a new application.
+          </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,11 @@
 Rails.application.routes.draw do
+  get "ping", to: "status#ping", format: :json
+  get "healthcheck", to: "status#status", format: :json
+  get "status", to: "status#ping", format: :json
+  get "data", to: "status#data"
+
+  match "(*any)", to: "pages#servicedown", via: :all if Setting.maintenance_mode?
+
   root to: "providers/start#index"
 
   require "sidekiq/web"
@@ -35,10 +42,6 @@ Rails.application.routes.draw do
   end
 
   get "auth/failure", to: "auth#failure"
-  get "ping", to: "status#ping", format: :json
-  get "healthcheck", to: "status#status", format: :json
-  get "status", to: "status#ping", format: :json
-  get "data", to: "status#data"
 
   resource :contact, only: [:show]
   resources :accessibility_statement, only: [:index]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -110,9 +110,9 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_08_110820) do
     t.integer "failed_attempts", default: 0, null: false
     t.string "unlock_token"
     t.datetime "locked_at", precision: nil
-    t.boolean "employed"
     t.datetime "remember_created_at", precision: nil
     t.string "remember_token"
+    t.boolean "employed"
     t.boolean "self_employed", default: false
     t.boolean "armed_forces", default: false
     t.boolean "has_national_insurance_number"
@@ -593,9 +593,9 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_08_110820) do
     t.boolean "no_cash_income"
     t.boolean "no_cash_outgoings"
     t.date "purgeable_on"
-    t.string "required_document_categories", default: [], null: false, array: true
     t.boolean "extra_employment_information"
     t.string "extra_employment_information_details"
+    t.string "required_document_categories", default: [], null: false, array: true
     t.string "full_employment_details"
     t.datetime "client_declaration_confirmed_at", precision: nil
     t.boolean "substantive_cost_override"
@@ -1074,8 +1074,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_08_110820) do
   add_foreign_key "legal_aid_applications", "providers"
   add_foreign_key "legal_framework_merits_task_lists", "legal_aid_applications", on_delete: :cascade
   add_foreign_key "legal_framework_submissions", "legal_aid_applications"
-  add_foreign_key "linked_applications", "legal_aid_applications", column: "associated_application_id"
-  add_foreign_key "linked_applications", "legal_aid_applications", column: "lead_application_id"
+  add_foreign_key "linked_applications", "legal_aid_applications", column: "associated_application_id", validate: false
+  add_foreign_key "linked_applications", "legal_aid_applications", column: "lead_application_id", validate: false
   add_foreign_key "matter_oppositions", "legal_aid_applications", on_delete: :cascade
   add_foreign_key "offices", "firms"
   add_foreign_key "offices_providers", "offices"

--- a/helm_deploy/apply-for-legal-aid/templates/_envs.tpl
+++ b/helm_deploy/apply-for-legal-aid/templates/_envs.tpl
@@ -381,5 +381,6 @@ env:
       secretKeyRef:
         name: {{ template "apply-for-legal-aid.fullname" . }}
         key: encryptionKeyDerivationSalt
-
+  - name: MAINTENANCE_MODE
+    value: "true"
 {{- end }}


### PR DESCRIPTION
## What
Add maintenance page

Following security incident we need to put application in maintenance mode
with a custom content/servicedown page. The CP version of doing this
is involved and burdensome.

- Add route controller and view for servicedown
- Add maintenance mode env var and use

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
