### PR TITLE
AP-4604: Validation so "none" and another checkbox cannot both be selected

### DIFF
--- a/app/forms/applicants/employed_form.rb
+++ b/app/forms/applicants/employed_form.rb
@@ -7,5 +7,9 @@ module Applicants
     def error_message_for_none_selected
       I18n.t("activemodel.errors.models.applicant.attributes.base.none_selected")
     end
+
+    def error_message_for_none_and_another_option_selected
+      I18n.t("activemodel.errors.models.applicant.attributes.base.none_and_another_option_selected")
+    end
   end
 end

--- a/app/forms/partners/employed_form.rb
+++ b/app/forms/partners/employed_form.rb
@@ -7,5 +7,9 @@ module Partners
     def error_message_for_none_selected
       I18n.t("activemodel.errors.models.partner.attributes.base.none_selected")
     end
+
+    def error_message_for_none_and_another_option_selected
+      I18n.t("activemodel.errors.models.applicant.attributes.base.none_and_another_option_selected")
+    end
   end
 end

--- a/app/forms/partners/offline_accounts_form.rb
+++ b/app/forms/partners/offline_accounts_form.rb
@@ -22,7 +22,8 @@ module Partners
 
     before_validation :empty_unchecked_values
 
-    validate :any_checkbox_checked_or_draft
+    validate :validate_any_checkbox_checked, unless: :draft?
+    validate :validate_no_account_and_another_checkbox_not_both_checked, unless: :draft?
 
     def exclude_from_model
       CHECK_BOXES_ATTRIBUTES + [:journey] - [:no_partner_account_selected]
@@ -32,11 +33,19 @@ module Partners
       ATTRIBUTES
     end
 
-    def any_checkbox_checked?
-      CHECK_BOXES_ATTRIBUTES.map { |attribute| __send__(attribute) }.any?(&:present?)
+  private
+
+    def none_and_another_checkbox_checked?
+      checkbox_hash[:no_partner_account_selected].present? && checkbox_hash.except(:no_partner_account_selected).values.any?(&:present?)
     end
 
-  private
+    def any_checkbox_checked?
+      checkbox_hash.values.any?(&:present?)
+    end
+
+    def checkbox_hash
+      CHECK_BOXES_ATTRIBUTES.index_with { |attribute| __send__(attribute) }
+    end
 
     def empty_unchecked_values
       ATTRIBUTES.each do |attribute|
@@ -48,8 +57,12 @@ module Partners
       end
     end
 
-    def any_checkbox_checked_or_draft
-      errors.add :check_box_partner_offline_current_accounts, :blank unless any_checkbox_checked? || draft?
+    def validate_any_checkbox_checked
+      errors.add :check_box_partner_offline_current_accounts, :blank unless any_checkbox_checked?
+    end
+
+    def validate_no_account_and_another_checkbox_not_both_checked
+      errors.add :check_box_partner_offline_current_accounts, :none_and_another_option_selected if none_and_another_checkbox_checked?
     end
   end
 end

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -801,6 +801,7 @@ en:
             base:
               none_selected: Select if you have any of these savings or investments
               no_account_selected: Select if you have current or savings accounts
+              none_and_another_option_selected: If you select 'None of these savings or investments', you cannot select any of the other options
               citizens:
                 none_selected: Select if you have any of these savings or investments
               providers:

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -808,6 +808,7 @@ en:
                 none_selected_with_partner: Select the savings or investments your client and their partner have, or select 'None of these savings or investments'
                 no_account_selected: Select the bank accounts your client has, or select 'None of these'
                 no_account_selected_with_partner: Select the bank accounts your client and their partner have, or select 'None of these'
+                no_account_and_another_option_selected: If you select 'None of these', you cannot select any of the other options
                 no_partner_account_selected: Select if the partner has current or savings accounts
             check_box_partner_offline_current_accounts:
               blank: Select if the partner has current or savings accounts

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -600,6 +600,7 @@ en:
               not_a_number_with_partner: Estimated trust value must be an amount of money, like 60,000
               too_many_decimals_with_partner: Estimated trust value must not include more than 2 decimal numbers
             base:
+              none_and_another_option_selected: If you select 'None of these assets', you cannot select any of the other options
               citizens:
                 none_selected: Select if you have any of these types of assets
               providers:

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -815,6 +815,7 @@ en:
                 no_partner_account_selected: Select if the partner has current or savings accounts
             check_box_partner_offline_current_accounts:
               blank: Select if the partner has current or savings accounts
+              none_and_another_option_selected: If you select 'None of these', you cannot select any of the other options
             cash:
               blank: Enter the value of money that's not in a bank account for your client
               greater_than_or_equal_to: The value of money that's not in a bank account must be 0 or more

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -611,6 +611,7 @@ en:
             base:
               none_selected: Select if your client has received any of these payments
               none_selected_with_partner: Select which schemes or trusts have paid either your client or their partner, or select 'None of these payments'
+              none_and_another_option_selected: If you select 'None of these schemes or trusts', you cannot select any of the other options
         proceeding:
           attributes:
             client_involvement_type_ccms_code:

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -121,6 +121,7 @@ en:
               blank: Select yes if your client is employed
             base:
               none_selected: Select one or more employment types or None of the above if not employed
+              none_and_another_option_selected: If you select 'None of the above', you cannot select any of the other options
             has_partner:
               inclusion: Select yes if the client has a partner
             partner_has_contrary_interest:
@@ -335,6 +336,7 @@ en:
               greater_than_or_equal_to: *student_error
             base:
               none_selected: Select one or more employment types or None of the above if not employed
+              none_and_another_option_selected: If you select 'None of the above', you cannot select any of the other options
             confirm_dwp_result: Select yes if the DWP records are correct
             full_employment_details:
               blank: Enter the partner's employment details

--- a/spec/forms/applicants/employed_form_spec.rb
+++ b/spec/forms/applicants/employed_form_spec.rb
@@ -8,11 +8,22 @@ RSpec.describe Applicants::EmployedForm, type: :form do
   let(:form_params) { params.merge(model: applicant) }
 
   describe "validations" do
-    let(:params) { {} }
+    context "when no checkbox is selected" do
+      let(:params) { {} }
 
-    it "errors if employed not specified" do
-      expect(described_form.save).to be false
-      expect(described_form.errors[:employed]).to eq [I18n.t("activemodel.errors.models.applicant.attributes.base.none_selected")]
+      it "errors" do
+        expect(described_form.save).to be false
+        expect(described_form.errors[:employed]).to eq [I18n.t("activemodel.errors.models.applicant.attributes.base.none_selected")]
+      end
+    end
+
+    context "when 'none of the above' and another checkbox are selected" do
+      let(:params) { { employed: "true", none_selected: "true" } }
+
+      it "errors" do
+        expect(described_form.save).to be false
+        expect(described_form.errors[:employed]).to eq [I18n.t("activemodel.errors.models.applicant.attributes.base.none_and_another_option_selected")]
+      end
     end
   end
 

--- a/spec/forms/partners/employed_form_spec.rb
+++ b/spec/forms/partners/employed_form_spec.rb
@@ -10,11 +10,22 @@ RSpec.describe Partners::EmployedForm, type: :form do
   let(:form_params) { params.merge(model: partner) }
 
   describe "validations" do
-    let(:params) { {} }
+    context "when no checkbox is selected" do
+      let(:params) { {} }
 
-    it "errors if employed not specified" do
-      expect(partner_employed_form.save).to be false
-      expect(partner_employed_form.errors[:employed]).to eq [I18n.t("activemodel.errors.models.partner.attributes.base.none_selected")]
+      it "errors" do
+        expect(partner_employed_form.save).to be false
+        expect(partner_employed_form.errors[:employed]).to eq [I18n.t("activemodel.errors.models.partner.attributes.base.none_selected")]
+      end
+    end
+
+    context "when 'none of the above' and another checkbox are selected" do
+      let(:params) { { employed: "true", none_selected: "true" } }
+
+      it "errors" do
+        expect(partner_employed_form.save).to be false
+        expect(partner_employed_form.errors[:employed]).to eq [I18n.t("activemodel.errors.models.partner.attributes.base.none_and_another_option_selected")]
+      end
     end
   end
 

--- a/spec/forms/partners/offline_accounts_form_spec.rb
+++ b/spec/forms/partners/offline_accounts_form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Partners::OfflineAccountsForm, type: :form do
 
   describe "#save" do
     context "when check boxes are checked" do
-      let(:check_box_params) { check_box_attributes.index_with { |_attr| "true" } }
+      let(:check_box_params) { check_box_attributes.index_with { |attr| "true" unless attr == :no_partner_account_selected } }
 
       context "when amounts are valid" do
         let(:amount_params) { attributes.index_with { |_attr| rand(1...1_000_000.0).round(2).to_s } }
@@ -159,6 +159,24 @@ RSpec.describe Partners::OfflineAccountsForm, type: :form do
         it "returns true" do
           expect(described_form.save).to be(true)
           expect(described_form.errors).to be_empty
+        end
+      end
+
+      context "when both the 'none of these' check box and another checkbox is checked" do
+        let(:check_box_params) do
+          {
+            check_box_partner_offline_current_accounts: "true",
+            no_partner_account_selected: "true",
+          }
+        end
+
+        it "returns false" do
+          expect(described_form.save).to be(false)
+        end
+
+        it "displays an error message" do
+          described_form.save!
+          expect(described_form.errors[:check_box_partner_offline_current_accounts]).to include("If you select 'None of these', you cannot select any of the other options")
         end
       end
 

--- a/spec/forms/providers/other_assets_form_spec.rb
+++ b/spec/forms/providers/other_assets_form_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Providers::OtherAssetsForm do
       { check_box_second_home: "yes",
         second_home_value: "859374.00",
         second_home_mortgage: "123000.00",
-        second_home_percentage: "66.66" }
+        second_home_percentage: "66.66",
+        none_selected: "" }
     end
 
     let(:empty_second_home_params) do
@@ -146,6 +147,21 @@ RSpec.describe Providers::OtherAssetsForm do
               it "is invalid" do
                 expect(form).to be_invalid
                 expect(form.errors[:valuable_items_value]).to eq [translation_for(:valuable_items_value, "greater_than_or_equal_to")]
+              end
+            end
+
+            describe "when both 'none of these' and another checkbox is selected" do
+              let(:params) do
+                {
+                  check_box_trust_value: "true",
+                  trust_value: "1000",
+                  none_selected: "true",
+                }
+              end
+
+              it "is invalid" do
+                expect(form).to be_invalid
+                expect(form.errors[:check_box_valuable_items_value]).to eq [translation_for(:base, "none_and_another_option_selected")]
               end
             end
           end

--- a/spec/forms/savings_amounts/offline_accounts_form_spec.rb
+++ b/spec/forms/savings_amounts/offline_accounts_form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SavingsAmounts::OfflineAccountsForm, type: :form do
 
   describe "#save" do
     context "when check boxes are checked" do
-      let(:check_box_params) { check_box_attributes.index_with { |_attr| "true" } }
+      let(:check_box_params) { check_box_attributes.index_with { |attr| "true" unless attr == :no_account_selected } }
 
       context "when amounts are valid" do
         let(:amount_params) { attributes.index_with { |_attr| rand(1...1_000_000.0).round(2).to_s } }
@@ -35,6 +35,14 @@ RSpec.describe SavingsAmounts::OfflineAccountsForm, type: :form do
 
         it "has no errors" do
           expect(described_form.errors).to be_empty
+        end
+      end
+
+      context "when 'none of the above' and another checkbox are selected" do
+        let(:check_box_params) { { check_box_joint_offline_savings_accounts: "true", no_account_selected: "true" } }
+
+        it "errors" do
+          expect(described_form.save).to be false
         end
       end
 

--- a/spec/forms/savings_amounts/savings_amounts_form_spec.rb
+++ b/spec/forms/savings_amounts/savings_amounts_form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
 
   describe "#save" do
     context "when check boxes are checked" do
-      let(:check_box_params) { check_box_attributes.index_with { |_attr| "true" } }
+      let(:check_box_params) { check_box_attributes.index_with { |attr| "true" unless attr == :none_selected } }
 
       context "and the amounts are valid" do
         let(:amount_params) { attributes.index_with { |_attr| rand(1...1_000_000.0).round(2).to_s } }
@@ -35,6 +35,14 @@ RSpec.describe SavingsAmounts::SavingsAmountsForm, type: :form do
 
         it "has no errors" do
           expect(described_form.errors).to be_empty
+        end
+      end
+
+      context "when 'none of the above' and another checkbox are selected" do
+        let(:check_box_params) { { check_box_life_assurance_endowment_policy: "true", life_assurance_endowment_policy: "100", none_selected: "true" } }
+
+        it "errors" do
+          expect(described_form.save).to be false
         end
       end
 

--- a/spec/requests/providers/means/policy_disregards_controller_spec.rb
+++ b/spec/requests/providers/means/policy_disregards_controller_spec.rb
@@ -132,6 +132,25 @@ RSpec.describe Providers::Means::PolicyDisregardsController do
           end
         end
       end
+
+      context "with 'none of these' checkbox and another checkbox selected" do
+        let(:params) do
+          {
+            policy_disregards: {
+              london_emergencies_trust: "true",
+              none_selected: "true",
+            },
+          }
+        end
+
+        before do
+          patch providers_legal_aid_application_means_policy_disregards_path(policy.legal_aid_application), params:
+        end
+
+        it "the response includes the error message" do
+          expect(unescaped_response_body).to include(I18n.t("activemodel.errors.models.policy_disregards.attributes.base.none_and_another_option_selected"))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4606)

Add extra validation so "None of the above" and another checkbox cannot both be selected when JS is disabled

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
