### PR TITLE
AP-4617: fix bank holiday test reliance

### DIFF
--- a/features/cassettes/Applicant_details/Allows_return_to_and_proceed_from_Delegated_Function_date_view.yml
+++ b/features/cassettes/Applicant_details/Allows_return_to_and_proceed_from_Delegated_Function_date_view.yml
@@ -8,43 +8,39 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:25:19 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:47 GMT
+      content-type:
       - application/json;charset=UTF-8
-      Transfer-Encoding:
+      transfer-encoding:
       - chunked
-      Connection:
+      connection:
       - keep-alive
-      Request-Context:
+      request-context:
       - appId=cid-v1:cd7023ed-37c2-4bb3-b1f3-cd441a39a9ae
-      Vary:
+      vary:
       - Origin,Accept-Encoding,key
-      Omse-Category:
+      omse-category:
       - premium
-      Omse-Transaction-Count:
+      omse-transaction-count:
       - '60'
-      Omse-Premium-Count:
+      omse-premium-count:
       - '0'
-      Strict-Transport-Security:
+      strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: "{\r\n  \"header\" : {\r\n    \"uri\" : \"https://api.os.uk/search/places/v1/postcode?lr=EN&postcode=SW1H9EA\",\r\n
         \   \"query\" : \"postcode=SW1H9EA\",\r\n    \"offset\" : 0,\r\n    \"totalresults\"
         : 5,\r\n    \"format\" : \"JSON\",\r\n    \"dataset\" : \"DPA\",\r\n    \"lr\"
-        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"98\",\r\n    \"lastupdate\"
-        : \"2023-02-02\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
+        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"106\",\r\n    \"lastupdate\"
+        : \"2023-12-12\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
         : [ {\r\n    \"DPA\" : {\r\n      \"UPRN\" : \"100023337883\",\r\n      \"UDPRN\"
         : \"23749699\",\r\n      \"ADDRESS\" : \"SUPER FIRM LTD, 84, PETTY FRANCE,
         LONDON, SW1H 9EA\",\r\n      \"ORGANISATION_NAME\" : \"SUPER FIRM LTD\",\r\n
@@ -136,7 +132,7 @@ http_interactions:
         \     \"ENTRY_DATE\" : \"15/06/2020\",\r\n      \"BLPU_STATE_DATE\" : \"15/06/2020\",\r\n
         \     \"LANGUAGE\" : \"EN\",\r\n      \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\"
         : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\" : \"1N\"\r\n    }\r\n  } ]\r\n}"
-  recorded_at: Fri, 03 Feb 2023 10:25:19 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:47 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -147,47 +143,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:25:19 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:47 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 517d95270f4de022136b3b6983b8ee6e
-      X-Runtime:
-      - '0.023063'
-      Strict-Transport-Security:
+      x-request-id:
+      - d569054645f60624672bbd7145fde2f5
+      x-runtime:
+      - '0.013253'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -312,7 +302,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:25:19 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:47 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -323,47 +313,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:25:21 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:49 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - '078ab1127e529e00e462cb9996ccd6b0'
-      X-Runtime:
-      - '0.023781'
-      Strict-Transport-Security:
+      x-request-id:
+      - c57ae0b5c95e0f181a4a48636f657861
+      x-runtime:
+      - '0.014388'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -488,7 +472,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:25:20 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:48 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/DA004
@@ -499,47 +483,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:25:21 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:49 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '1310'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"fbabf0efd65b63f03290a3f99682b0d4"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 3416df48568e5e5b7eaf274eb50808b9
-      X-Runtime:
-      - '0.011072'
-      Strict-Transport-Security:
+      x-request-id:
+      - 85c986877cb82839d78f3357234de549
+      x-runtime:
+      - '0.011976'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -556,7 +534,7 @@ http_interactions:
         for an interim order; where application is made without notice to include
         representation on the return date."}},"service_levels":[{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":true}]}'
-  recorded_at: Fri, 03 Feb 2023 10:25:21 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:49 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
@@ -567,54 +545,48 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:25:21 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:49 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '277'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"8bf337339345d42d16a9e6062fb65ccf"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - bb294d47fd702ad3d50dd22d70aafdef
-      X-Runtime:
-      - '0.004486'
-      Strict-Transport-Security:
+      x-request-id:
+      - 2d6bbbb235aac74add2aefcb9f0d1734
+      x-runtime:
+      - '0.003278'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]'
-  recorded_at: Fri, 03 Feb 2023 10:25:21 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:49 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
@@ -625,140 +597,48 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:25:22 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:50 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '277'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"8bf337339345d42d16a9e6062fb65ccf"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 39bcb7f98f4647c3cd91609c4df323a3
-      X-Runtime:
-      - '0.005363'
-      Strict-Transport-Security:
+      x-request-id:
+      - '001789d919cbea6d3709f0a906432aa0'
+      x-runtime:
+      - '0.004113'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]'
-  recorded_at: Fri, 03 Feb 2023 10:25:22 GMT
-- request:
-    method: get
-    uri: https://www.gov.uk/bank-holidays.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Host:
-      - www.gov.uk
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '17854'
-      Content-Type:
-      - application/json; charset=utf-8
-      Server:
-      - nginx
-      Access-Control-Allow-Origin:
-      - "*"
-      Cache-Control:
-      - max-age=3600, public
-      Content-Security-Policy-Report-Only:
-      - default-src 'self'; base-uri 'none'; img-src 'self' *.publishing.service.gov.uk
-        www.gov.uk *.dev.gov.uk www.google-analytics.com ssl.google-analytics.com
-        stats.g.doubleclick.net www.googletagmanager.com www.region1.google-analytics.com
-        region1.google-analytics.com lux.speedcurve.com assets.digital.cabinet-office.gov.uk
-        https://img.youtube.com; script-src 'self' www.google-analytics.com ssl.google-analytics.com
-        stats.g.doubleclick.net www.googletagmanager.com www.region1.google-analytics.com
-        region1.google-analytics.com www.gstatic.com *.ytimg.com www.youtube.com www.youtube-nocookie.com
-        'nonce-uDQaiUdSAp841gqFD/kiqg=='; style-src 'self' www.gstatic.com 'unsafe-inline';
-        font-src 'self'; connect-src 'self' *.publishing.service.gov.uk www.gov.uk
-        *.dev.gov.uk www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net
-        www.googletagmanager.com www.region1.google-analytics.com region1.google-analytics.com
-        lux.speedcurve.com; object-src 'none'; frame-src 'self' *.publishing.service.gov.uk
-        www.gov.uk *.dev.gov.uk www.youtube.com www.youtube-nocookie.com; report-uri
-        https://csp-reporter.publishing.service.gov.uk/report
-      Etag:
-      - W/"21c0301e75119f0665930ca20ca075aa"
-      Permissions-Policy:
-      - interest-cohort=()
-      Referrer-Policy:
-      - strict-origin-when-cross-origin
-      Strict-Transport-Security:
-      - max-age=31536000; preload
-      Via:
-      - 1.1 router, 1.1 varnish, 1.1 varnish
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - ALLOWALL
-      X-Request-Id:
-      - e19ef668-41c4-4b68-866d-90b9fead5a0e
-      Fastly-Backend-Name:
-      - origin
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Fri, 03 Feb 2023 10:25:22 GMT
-      Age:
-      - '3518'
-      X-Served-By:
-      - cache-lon4247-LON
-      X-Cache:
-      - HIT, HIT
-      X-Cache-Hits:
-      - '7'
-      X-Timer:
-      - S1675419923.807441,VS0,VE0
-      Vary:
-      - Accept-Encoding
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        eyJlbmdsYW5kLWFuZC13YWxlcyI6eyJkaXZpc2lvbiI6ImVuZ2xhbmQtYW5kLXdhbGVzIiwiZXZlbnRzIjpbeyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAxOC0wMS0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ikdvb2QgRnJpZGF5IiwiZGF0ZSI6IjIwMTgtMDMtMzAiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiRWFzdGVyIE1vbmRheSIsImRhdGUiOiIyMDE4LTA0LTAyIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiRWFybHkgTWF5IGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE4LTA1LTA3Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE4LTA1LTI4Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE4LTA4LTI3Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQ2hyaXN0bWFzIERheSIsImRhdGUiOiIyMDE4LTEyLTI1Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQm94aW5nIERheSIsImRhdGUiOiIyMDE4LTEyLTI2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiTmV3IFllYXLigJlzIERheSIsImRhdGUiOiIyMDE5LTAxLTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiR29vZCBGcmlkYXkiLCJkYXRlIjoiMjAxOS0wNC0xOSIsIm5vdGVzIjoiIiwiYnVudGluZyI6ZmFsc2V9LHsidGl0bGUiOiJFYXN0ZXIgTW9uZGF5IiwiZGF0ZSI6IjIwMTktMDQtMjIiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJFYXJseSBNYXkgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMTktMDUtMDYiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJTcHJpbmcgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMTktMDUtMjciLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJTdW1tZXIgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMTktMDgtMjYiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJDaHJpc3RtYXMgRGF5IiwiZGF0ZSI6IjIwMTktMTItMjUiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJCb3hpbmcgRGF5IiwiZGF0ZSI6IjIwMTktMTItMjYiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJOZXcgWWVhcuKAmXMgRGF5IiwiZGF0ZSI6IjIwMjAtMDEtMDEiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJHb29kIEZyaWRheSIsImRhdGUiOiIyMDIwLTA0LTEwIiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IkVhc3RlciBNb25kYXkiLCJkYXRlIjoiMjAyMC0wNC0xMyIsIm5vdGVzIjoiIiwiYnVudGluZyI6ZmFsc2V9LHsidGl0bGUiOiJFYXJseSBNYXkgYmFuayBob2xpZGF5IChWRSBkYXkpIiwiZGF0ZSI6IjIwMjAtMDUtMDgiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJTcHJpbmcgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjAtMDUtMjUiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJTdW1tZXIgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjAtMDgtMzEiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJDaHJpc3RtYXMgRGF5IiwiZGF0ZSI6IjIwMjAtMTItMjUiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJCb3hpbmcgRGF5IiwiZGF0ZSI6IjIwMjAtMTItMjgiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAyMS0wMS0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ikdvb2QgRnJpZGF5IiwiZGF0ZSI6IjIwMjEtMDQtMDIiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiRWFzdGVyIE1vbmRheSIsImRhdGUiOiIyMDIxLTA0LTA1Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiRWFybHkgTWF5IGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIxLTA1LTAzIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIxLTA1LTMxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIxLTA4LTMwIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQ2hyaXN0bWFzIERheSIsImRhdGUiOiIyMDIxLTEyLTI3Iiwibm90ZXMiOiJTdWJzdGl0dXRlIGRheSIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJCb3hpbmcgRGF5IiwiZGF0ZSI6IjIwMjEtMTItMjgiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAyMi0wMS0wMyIsIm5vdGVzIjoiU3Vic3RpdHV0ZSBkYXkiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiR29vZCBGcmlkYXkiLCJkYXRlIjoiMjAyMi0wNC0xNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6ZmFsc2V9LHsidGl0bGUiOiJFYXN0ZXIgTW9uZGF5IiwiZGF0ZSI6IjIwMjItMDQtMTgiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJFYXJseSBNYXkgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjItMDUtMDIiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJTcHJpbmcgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjItMDYtMDIiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJQbGF0aW51bSBKdWJpbGVlIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIyLTA2LTAzIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIyLTA4LTI5Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQmFuayBIb2xpZGF5IGZvciB0aGUgU3RhdGUgRnVuZXJhbCBvZiBRdWVlbiBFbGl6YWJldGggSUkiLCJkYXRlIjoiMjAyMi0wOS0xOSIsIm5vdGVzIjoiIiwiYnVudGluZyI6ZmFsc2V9LHsidGl0bGUiOiJCb3hpbmcgRGF5IiwiZGF0ZSI6IjIwMjItMTItMjYiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJDaHJpc3RtYXMgRGF5IiwiZGF0ZSI6IjIwMjItMTItMjciLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAyMy0wMS0wMiIsIm5vdGVzIjoiU3Vic3RpdHV0ZSBkYXkiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiR29vZCBGcmlkYXkiLCJkYXRlIjoiMjAyMy0wNC0wNyIsIm5vdGVzIjoiIiwiYnVudGluZyI6ZmFsc2V9LHsidGl0bGUiOiJFYXN0ZXIgTW9uZGF5IiwiZGF0ZSI6IjIwMjMtMDQtMTAiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJFYXJseSBNYXkgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjMtMDUtMDEiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJCYW5rIGhvbGlkYXkgZm9yIHRoZSBjb3JvbmF0aW9uIG9mIEtpbmcgQ2hhcmxlcyBJSUkiLCJkYXRlIjoiMjAyMy0wNS0wOCIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlNwcmluZyBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMy0wNS0yOSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN1bW1lciBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMy0wOC0yOCIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkNocmlzdG1hcyBEYXkiLCJkYXRlIjoiMjAyMy0xMi0yNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJveGluZyBEYXkiLCJkYXRlIjoiMjAyMy0xMi0yNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAyNC0wMS0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ikdvb2QgRnJpZGF5IiwiZGF0ZSI6IjIwMjQtMDMtMjkiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiRWFzdGVyIE1vbmRheSIsImRhdGUiOiIyMDI0LTA0LTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiRWFybHkgTWF5IGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDI0LTA1LTA2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDI0LTA1LTI3Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDI0LTA4LTI2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQ2hyaXN0bWFzIERheSIsImRhdGUiOiIyMDI0LTEyLTI1Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQm94aW5nIERheSIsImRhdGUiOiIyMDI0LTEyLTI2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiTmV3IFllYXLigJlzIERheSIsImRhdGUiOiIyMDI1LTAxLTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiR29vZCBGcmlkYXkiLCJkYXRlIjoiMjAyNS0wNC0xOCIsIm5vdGVzIjoiIiwiYnVudGluZyI6ZmFsc2V9LHsidGl0bGUiOiJFYXN0ZXIgTW9uZGF5IiwiZGF0ZSI6IjIwMjUtMDQtMjEiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJFYXJseSBNYXkgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjUtMDUtMDUiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJTcHJpbmcgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjUtMDUtMjYiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJTdW1tZXIgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjUtMDgtMjUiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJDaHJpc3RtYXMgRGF5IiwiZGF0ZSI6IjIwMjUtMTItMjUiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJCb3hpbmcgRGF5IiwiZGF0ZSI6IjIwMjUtMTItMjYiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9XX0sInNjb3RsYW5kIjp7ImRpdmlzaW9uIjoic2NvdGxhbmQiLCJldmVudHMiOlt7InRpdGxlIjoiTmV3IFllYXLigJlzIERheSIsImRhdGUiOiIyMDE4LTAxLTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiMm5kIEphbnVhcnkiLCJkYXRlIjoiMjAxOC0wMS0wMiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ikdvb2QgRnJpZGF5IiwiZGF0ZSI6IjIwMTgtMDMtMzAiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiRWFybHkgTWF5IGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE4LTA1LTA3Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE4LTA1LTI4Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE4LTA4LTA2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3QgQW5kcmV34oCZcyBEYXkiLCJkYXRlIjoiMjAxOC0xMS0zMCIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkNocmlzdG1hcyBEYXkiLCJkYXRlIjoiMjAxOC0xMi0yNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJveGluZyBEYXkiLCJkYXRlIjoiMjAxOC0xMi0yNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAxOS0wMS0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IjJuZCBKYW51YXJ5IiwiZGF0ZSI6IjIwMTktMDEtMDIiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJHb29kIEZyaWRheSIsImRhdGUiOiIyMDE5LTA0LTE5Iiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IkVhcmx5IE1heSBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAxOS0wNS0wNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlNwcmluZyBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAxOS0wNS0yNyIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN1bW1lciBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAxOS0wOC0wNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN0IEFuZHJld+KAmXMgRGF5IiwiZGF0ZSI6IjIwMTktMTItMDIiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkNocmlzdG1hcyBEYXkiLCJkYXRlIjoiMjAxOS0xMi0yNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJveGluZyBEYXkiLCJkYXRlIjoiMjAxOS0xMi0yNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAyMC0wMS0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IjJuZCBKYW51YXJ5IiwiZGF0ZSI6IjIwMjAtMDEtMDIiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJHb29kIEZyaWRheSIsImRhdGUiOiIyMDIwLTA0LTEwIiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IkVhcmx5IE1heSBiYW5rIGhvbGlkYXkgKFZFIGRheSkiLCJkYXRlIjoiMjAyMC0wNS0wOCIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlNwcmluZyBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMC0wNS0yNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN1bW1lciBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMC0wOC0wMyIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN0IEFuZHJld+KAmXMgRGF5IiwiZGF0ZSI6IjIwMjAtMTEtMzAiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJDaHJpc3RtYXMgRGF5IiwiZGF0ZSI6IjIwMjAtMTItMjUiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJCb3hpbmcgRGF5IiwiZGF0ZSI6IjIwMjAtMTItMjgiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAyMS0wMS0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IjJuZCBKYW51YXJ5IiwiZGF0ZSI6IjIwMjEtMDEtMDQiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ikdvb2QgRnJpZGF5IiwiZGF0ZSI6IjIwMjEtMDQtMDIiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiRWFybHkgTWF5IGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIxLTA1LTAzIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIxLTA1LTMxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIxLTA4LTAyIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3QgQW5kcmV34oCZcyBEYXkiLCJkYXRlIjoiMjAyMS0xMS0zMCIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkNocmlzdG1hcyBEYXkiLCJkYXRlIjoiMjAyMS0xMi0yNyIsIm5vdGVzIjoiU3Vic3RpdHV0ZSBkYXkiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQm94aW5nIERheSIsImRhdGUiOiIyMDIxLTEyLTI4Iiwibm90ZXMiOiJTdWJzdGl0dXRlIGRheSIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJOZXcgWWVhcuKAmXMgRGF5IiwiZGF0ZSI6IjIwMjItMDEtMDMiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IjJuZCBKYW51YXJ5IiwiZGF0ZSI6IjIwMjItMDEtMDQiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ikdvb2QgRnJpZGF5IiwiZGF0ZSI6IjIwMjItMDQtMTUiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiRWFybHkgTWF5IGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIyLTA1LTAyIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIyLTA2LTAyIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiUGxhdGludW0gSnViaWxlZSBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMi0wNi0wMyIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN1bW1lciBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMi0wOC0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJhbmsgSG9saWRheSBmb3IgdGhlIFN0YXRlIEZ1bmVyYWwgb2YgUXVlZW4gRWxpemFiZXRoIElJIiwiZGF0ZSI6IjIwMjItMDktMTkiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiU3QgQW5kcmV34oCZcyBEYXkiLCJkYXRlIjoiMjAyMi0xMS0zMCIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJveGluZyBEYXkiLCJkYXRlIjoiMjAyMi0xMi0yNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkNocmlzdG1hcyBEYXkiLCJkYXRlIjoiMjAyMi0xMi0yNyIsIm5vdGVzIjoiU3Vic3RpdHV0ZSBkYXkiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiTmV3IFllYXLigJlzIERheSIsImRhdGUiOiIyMDIzLTAxLTAyIiwibm90ZXMiOiJTdWJzdGl0dXRlIGRheSIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiIybmQgSmFudWFyeSIsImRhdGUiOiIyMDIzLTAxLTAzIiwibm90ZXMiOiJTdWJzdGl0dXRlIGRheSIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJHb29kIEZyaWRheSIsImRhdGUiOiIyMDIzLTA0LTA3Iiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IkVhcmx5IE1heSBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMy0wNS0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJhbmsgaG9saWRheSBmb3IgdGhlIGNvcm9uYXRpb24gb2YgS2luZyBDaGFybGVzIElJSSIsImRhdGUiOiIyMDIzLTA1LTA4Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIzLTA1LTI5Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIzLTA4LTA3Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3QgQW5kcmV34oCZcyBEYXkiLCJkYXRlIjoiMjAyMy0xMS0zMCIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkNocmlzdG1hcyBEYXkiLCJkYXRlIjoiMjAyMy0xMi0yNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJveGluZyBEYXkiLCJkYXRlIjoiMjAyMy0xMi0yNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAyNC0wMS0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IjJuZCBKYW51YXJ5IiwiZGF0ZSI6IjIwMjQtMDEtMDIiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJHb29kIEZyaWRheSIsImRhdGUiOiIyMDI0LTAzLTI5Iiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IkVhcmx5IE1heSBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyNC0wNS0wNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlNwcmluZyBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyNC0wNS0yNyIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN1bW1lciBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyNC0wOC0wNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN0IEFuZHJld+KAmXMgRGF5IiwiZGF0ZSI6IjIwMjQtMTItMDIiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkNocmlzdG1hcyBEYXkiLCJkYXRlIjoiMjAyNC0xMi0yNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJveGluZyBEYXkiLCJkYXRlIjoiMjAyNC0xMi0yNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAyNS0wMS0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IjJuZCBKYW51YXJ5IiwiZGF0ZSI6IjIwMjUtMDEtMDIiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJHb29kIEZyaWRheSIsImRhdGUiOiIyMDI1LTA0LTE4Iiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IkVhcmx5IE1heSBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyNS0wNS0wNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlNwcmluZyBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyNS0wNS0yNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN1bW1lciBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyNS0wOC0wNCIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN0IEFuZHJld+KAmXMgRGF5IiwiZGF0ZSI6IjIwMjUtMTItMDEiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkNocmlzdG1hcyBEYXkiLCJkYXRlIjoiMjAyNS0xMi0yNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJveGluZyBEYXkiLCJkYXRlIjoiMjAyNS0xMi0yNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX1dfSwibm9ydGhlcm4taXJlbGFuZCI6eyJkaXZpc2lvbiI6Im5vcnRoZXJuLWlyZWxhbmQiLCJldmVudHMiOlt7InRpdGxlIjoiTmV3IFllYXLigJlzIERheSIsImRhdGUiOiIyMDE4LTAxLTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3QgUGF0cmlja+KAmXMgRGF5IiwiZGF0ZSI6IjIwMTgtMDMtMTkiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ikdvb2QgRnJpZGF5IiwiZGF0ZSI6IjIwMTgtMDMtMzAiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiRWFzdGVyIE1vbmRheSIsImRhdGUiOiIyMDE4LTA0LTAyIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiRWFybHkgTWF5IGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE4LTA1LTA3Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE4LTA1LTI4Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQmF0dGxlIG9mIHRoZSBCb3luZSAoT3JhbmdlbWVu4oCZcyBEYXkpIiwiZGF0ZSI6IjIwMTgtMDctMTIiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE4LTA4LTI3Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQ2hyaXN0bWFzIERheSIsImRhdGUiOiIyMDE4LTEyLTI1Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQm94aW5nIERheSIsImRhdGUiOiIyMDE4LTEyLTI2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiTmV3IFllYXLigJlzIERheSIsImRhdGUiOiIyMDE5LTAxLTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3QgUGF0cmlja+KAmXMgRGF5IiwiZGF0ZSI6IjIwMTktMDMtMTgiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ikdvb2QgRnJpZGF5IiwiZGF0ZSI6IjIwMTktMDQtMTkiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiRWFzdGVyIE1vbmRheSIsImRhdGUiOiIyMDE5LTA0LTIyIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiRWFybHkgTWF5IGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE5LTA1LTA2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE5LTA1LTI3Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQmF0dGxlIG9mIHRoZSBCb3luZSAoT3JhbmdlbWVu4oCZcyBEYXkpIiwiZGF0ZSI6IjIwMTktMDctMTIiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE5LTA4LTI2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQ2hyaXN0bWFzIERheSIsImRhdGUiOiIyMDE5LTEyLTI1Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQm94aW5nIERheSIsImRhdGUiOiIyMDE5LTEyLTI2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiTmV3IFllYXLigJlzIERheSIsImRhdGUiOiIyMDIwLTAxLTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3QgUGF0cmlja+KAmXMgRGF5IiwiZGF0ZSI6IjIwMjAtMDMtMTciLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJHb29kIEZyaWRheSIsImRhdGUiOiIyMDIwLTA0LTEwIiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IkVhc3RlciBNb25kYXkiLCJkYXRlIjoiMjAyMC0wNC0xMyIsIm5vdGVzIjoiIiwiYnVudGluZyI6ZmFsc2V9LHsidGl0bGUiOiJFYXJseSBNYXkgYmFuayBob2xpZGF5IChWRSBkYXkpIiwiZGF0ZSI6IjIwMjAtMDUtMDgiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJTcHJpbmcgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjAtMDUtMjUiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJCYXR0bGUgb2YgdGhlIEJveW5lIChPcmFuZ2VtZW7igJlzIERheSkiLCJkYXRlIjoiMjAyMC0wNy0xMyIsIm5vdGVzIjoiU3Vic3RpdHV0ZSBkYXkiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IlN1bW1lciBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMC0wOC0zMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkNocmlzdG1hcyBEYXkiLCJkYXRlIjoiMjAyMC0xMi0yNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJveGluZyBEYXkiLCJkYXRlIjoiMjAyMC0xMi0yOCIsIm5vdGVzIjoiU3Vic3RpdHV0ZSBkYXkiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiTmV3IFllYXLigJlzIERheSIsImRhdGUiOiIyMDIxLTAxLTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3QgUGF0cmlja+KAmXMgRGF5IiwiZGF0ZSI6IjIwMjEtMDMtMTciLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJHb29kIEZyaWRheSIsImRhdGUiOiIyMDIxLTA0LTAyIiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IkVhc3RlciBNb25kYXkiLCJkYXRlIjoiMjAyMS0wNC0wNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkVhcmx5IE1heSBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMS0wNS0wMyIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlNwcmluZyBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMS0wNS0zMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJhdHRsZSBvZiB0aGUgQm95bmUgKE9yYW5nZW1lbuKAmXMgRGF5KSIsImRhdGUiOiIyMDIxLTA3LTEyIiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IlN1bW1lciBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMS0wOC0zMCIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkNocmlzdG1hcyBEYXkiLCJkYXRlIjoiMjAyMS0xMi0yNyIsIm5vdGVzIjoiU3Vic3RpdHV0ZSBkYXkiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQm94aW5nIERheSIsImRhdGUiOiIyMDIxLTEyLTI4Iiwibm90ZXMiOiJTdWJzdGl0dXRlIGRheSIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJOZXcgWWVhcuKAmXMgRGF5IiwiZGF0ZSI6IjIwMjItMDEtMDMiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN0IFBhdHJpY2vigJlzIERheSIsImRhdGUiOiIyMDIyLTAzLTE3Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiR29vZCBGcmlkYXkiLCJkYXRlIjoiMjAyMi0wNC0xNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6ZmFsc2V9LHsidGl0bGUiOiJFYXN0ZXIgTW9uZGF5IiwiZGF0ZSI6IjIwMjItMDQtMTgiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJFYXJseSBNYXkgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjItMDUtMDIiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJTcHJpbmcgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjItMDYtMDIiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJQbGF0aW51bSBKdWJpbGVlIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIyLTA2LTAzIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQmF0dGxlIG9mIHRoZSBCb3luZSAoT3JhbmdlbWVu4oCZcyBEYXkpIiwiZGF0ZSI6IjIwMjItMDctMTIiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIyLTA4LTI5Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQmFuayBIb2xpZGF5IGZvciB0aGUgU3RhdGUgRnVuZXJhbCBvZiBRdWVlbiBFbGl6YWJldGggSUkiLCJkYXRlIjoiMjAyMi0wOS0xOSIsIm5vdGVzIjoiIiwiYnVudGluZyI6ZmFsc2V9LHsidGl0bGUiOiJCb3hpbmcgRGF5IiwiZGF0ZSI6IjIwMjItMTItMjYiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJDaHJpc3RtYXMgRGF5IiwiZGF0ZSI6IjIwMjItMTItMjciLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAyMy0wMS0wMiIsIm5vdGVzIjoiU3Vic3RpdHV0ZSBkYXkiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3QgUGF0cmlja+KAmXMgRGF5IiwiZGF0ZSI6IjIwMjMtMDMtMTciLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJHb29kIEZyaWRheSIsImRhdGUiOiIyMDIzLTA0LTA3Iiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IkVhc3RlciBNb25kYXkiLCJkYXRlIjoiMjAyMy0wNC0xMCIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkVhcmx5IE1heSBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMy0wNS0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJhbmsgaG9saWRheSBmb3IgdGhlIGNvcm9uYXRpb24gb2YgS2luZyBDaGFybGVzIElJSSIsImRhdGUiOiIyMDIzLTA1LTA4Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIzLTA1LTI5Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQmF0dGxlIG9mIHRoZSBCb3luZSAoT3JhbmdlbWVu4oCZcyBEYXkpIiwiZGF0ZSI6IjIwMjMtMDctMTIiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIzLTA4LTI4Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQ2hyaXN0bWFzIERheSIsImRhdGUiOiIyMDIzLTEyLTI1Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQm94aW5nIERheSIsImRhdGUiOiIyMDIzLTEyLTI2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiTmV3IFllYXLigJlzIERheSIsImRhdGUiOiIyMDI0LTAxLTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3QgUGF0cmlja+KAmXMgRGF5IiwiZGF0ZSI6IjIwMjQtMDMtMTgiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ikdvb2QgRnJpZGF5IiwiZGF0ZSI6IjIwMjQtMDMtMjkiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiRWFzdGVyIE1vbmRheSIsImRhdGUiOiIyMDI0LTA0LTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiRWFybHkgTWF5IGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDI0LTA1LTA2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDI0LTA1LTI3Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQmF0dGxlIG9mIHRoZSBCb3luZSAoT3JhbmdlbWVu4oCZcyBEYXkpIiwiZGF0ZSI6IjIwMjQtMDctMTIiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDI0LTA4LTI2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQ2hyaXN0bWFzIERheSIsImRhdGUiOiIyMDI0LTEyLTI1Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQm94aW5nIERheSIsImRhdGUiOiIyMDI0LTEyLTI2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiTmV3IFllYXLigJlzIERheSIsImRhdGUiOiIyMDI1LTAxLTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3QgUGF0cmlja+KAmXMgRGF5IiwiZGF0ZSI6IjIwMjUtMDMtMTciLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJHb29kIEZyaWRheSIsImRhdGUiOiIyMDI1LTA0LTE4Iiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IkVhc3RlciBNb25kYXkiLCJkYXRlIjoiMjAyNS0wNC0yMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkVhcmx5IE1heSBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyNS0wNS0wNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlNwcmluZyBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyNS0wNS0yNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJhdHRsZSBvZiB0aGUgQm95bmUgKE9yYW5nZW1lbuKAmXMgRGF5KSIsImRhdGUiOiIyMDI1LTA3LTE0Iiwibm90ZXMiOiJTdWJzdGl0dXRlIGRheSIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDI1LTA4LTI1Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQ2hyaXN0bWFzIERheSIsImRhdGUiOiIyMDI1LTEyLTI1Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQm94aW5nIERheSIsImRhdGUiOiIyMDI1LTEyLTI2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfV19fQ==
-  recorded_at: Fri, 03 Feb 2023 10:25:22 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:49 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -769,47 +649,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:25:22 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:50 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '477'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"f6e255747b495453398cd82197a149da"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 84555c88c0b5b07b93752a1e8a1c7fe3
-      X-Runtime:
-      - '0.010802'
-      Strict-Transport-Security:
+      x-request-id:
+      - afbca9049eb20f73660fe69dbeff7b6b
+      x-runtime:
+      - '0.006222'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -818,7 +692,7 @@ http_interactions:
         order inc. return date","description":"Limited to all steps necessary to apply
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:25:22 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:50 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -829,47 +703,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:25:23 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:51 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '477'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"f6e255747b495453398cd82197a149da"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 2a6086be1ed9e7a3e07d0e7892db5975
-      X-Runtime:
-      - '0.008074'
-      Strict-Transport-Security:
+      x-request-id:
+      - 6a58ab87a592775e39bd228fbc51d954
+      x-runtime:
+      - '0.006148'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -878,7 +746,7 @@ http_interactions:
         order inc. return date","description":"Limited to all steps necessary to apply
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:25:23 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:50 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -889,47 +757,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:25:23 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:51 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '708'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"05375658d64485716c2575dd3e911e59"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - b434b136a9d0b13c236be7e125bb59b0
-      X-Runtime:
-      - '0.009800'
-      Strict-Transport-Security:
+      x-request-id:
+      - e3ca11384e5547cda377d76349eabbe7
+      x-runtime:
+      - '0.009583'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -941,7 +803,7 @@ http_interactions:
         of arrest to representation on the consideration of the breach by the court
         (but excluding applying for a warrant of arrest, if not attached, and representation
         in contempt proceedings).","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:25:23 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:51 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -952,47 +814,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:25:23 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:51 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '708'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"05375658d64485716c2575dd3e911e59"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 0ed47894046d67eb9b74d882636c06e2
-      X-Runtime:
-      - '0.009921'
-      Strict-Transport-Security:
+      x-request-id:
+      - e588c5c667d8286991e5c32a8caaf70a
+      x-runtime:
+      - '0.009016'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -1004,5 +860,5 @@ http_interactions:
         of arrest to representation on the consideration of the breach by the court
         (but excluding applying for a warrant of arrest, if not attached, and representation
         in contempt proceedings).","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:25:23 GMT
-recorded_with: VCR 6.1.0
+  recorded_at: Wed, 13 Dec 2023 16:27:51 GMT
+recorded_with: VCR 6.2.0

--- a/features/cassettes/Applicant_details/Completes_the_application_using_address_lookup.yml
+++ b/features/cassettes/Applicant_details/Completes_the_application_using_address_lookup.yml
@@ -8,43 +8,39 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:00:33 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:08 GMT
+      content-type:
       - application/json;charset=UTF-8
-      Transfer-Encoding:
+      transfer-encoding:
       - chunked
-      Connection:
+      connection:
       - keep-alive
-      Request-Context:
+      request-context:
       - appId=cid-v1:cd7023ed-37c2-4bb3-b1f3-cd441a39a9ae
-      Vary:
+      vary:
       - Origin,Accept-Encoding,key
-      Omse-Category:
+      omse-category:
       - premium
-      Omse-Transaction-Count:
+      omse-transaction-count:
       - '60'
-      Omse-Premium-Count:
+      omse-premium-count:
       - '0'
-      Strict-Transport-Security:
+      strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: "{\r\n  \"header\" : {\r\n    \"uri\" : \"https://api.os.uk/search/places/v1/postcode?lr=EN&postcode=SW1H9EA\",\r\n
         \   \"query\" : \"postcode=SW1H9EA\",\r\n    \"offset\" : 0,\r\n    \"totalresults\"
         : 5,\r\n    \"format\" : \"JSON\",\r\n    \"dataset\" : \"DPA\",\r\n    \"lr\"
-        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"98\",\r\n    \"lastupdate\"
-        : \"2023-02-02\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
+        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"106\",\r\n    \"lastupdate\"
+        : \"2023-12-12\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
         : [ {\r\n    \"DPA\" : {\r\n      \"UPRN\" : \"100023337883\",\r\n      \"UDPRN\"
         : \"23749699\",\r\n      \"ADDRESS\" : \"SUPER FIRM LTD, 84, PETTY FRANCE,
         LONDON, SW1H 9EA\",\r\n      \"ORGANISATION_NAME\" : \"SUPER FIRM LTD\",\r\n
@@ -136,7 +132,7 @@ http_interactions:
         \     \"ENTRY_DATE\" : \"15/06/2020\",\r\n      \"BLPU_STATE_DATE\" : \"15/06/2020\",\r\n
         \     \"LANGUAGE\" : \"EN\",\r\n      \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\"
         : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\" : \"1N\"\r\n    }\r\n  } ]\r\n}"
-  recorded_at: Fri, 03 Feb 2023 10:00:32 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:08 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -147,47 +143,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:00:33 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:08 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 53127a023f199d9a3392a5354570b4a4
-      X-Runtime:
-      - '0.023929'
-      Strict-Transport-Security:
+      x-request-id:
+      - 54723914d485ae607da1690772b1fdf8
+      x-runtime:
+      - '0.014031'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -312,7 +302,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:00:33 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:08 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -323,47 +313,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:00:34 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:09 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 73acee054c616a559136fc8a6046ab18
-      X-Runtime:
-      - '0.081052'
-      Strict-Transport-Security:
+      x-request-id:
+      - e0451abf6f38853f900253cfd819fb08
+      x-runtime:
+      - '0.013635'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -488,7 +472,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:00:34 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:09 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/DA004
@@ -499,47 +483,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:00:34 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:10 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '1310'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"fbabf0efd65b63f03290a3f99682b0d4"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 015a12be2a7357ba3b076f14ba9f297f
-      X-Runtime:
-      - '0.015022'
-      Strict-Transport-Security:
+      x-request-id:
+      - e2cbea80d859085ba736c449ef317488
+      x-runtime:
+      - '0.009883'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -556,7 +534,7 @@ http_interactions:
         for an interim order; where application is made without notice to include
         representation on the return date."}},"service_levels":[{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":true}]}'
-  recorded_at: Fri, 03 Feb 2023 10:00:34 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:10 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
@@ -567,54 +545,48 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:00:35 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:10 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '277'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"8bf337339345d42d16a9e6062fb65ccf"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 2437533a6047b29f9ab760be087c388d
-      X-Runtime:
-      - '0.004690'
-      Strict-Transport-Security:
+      x-request-id:
+      - 97c64e85da0d504eef4740f8bf6d642a
+      x-runtime:
+      - '0.003968'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]'
-  recorded_at: Fri, 03 Feb 2023 10:00:35 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:10 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
@@ -625,54 +597,48 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:00:35 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:10 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '277'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"8bf337339345d42d16a9e6062fb65ccf"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 0ccf61223d59f0571ec010007127e29e
-      X-Runtime:
-      - '0.004135'
-      Strict-Transport-Security:
+      x-request-id:
+      - b31008517523b1a7333c39bc17768f90
+      x-runtime:
+      - '0.003856'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]'
-  recorded_at: Fri, 03 Feb 2023 10:00:35 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:10 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -683,47 +649,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:00:36 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:11 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '708'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"05375658d64485716c2575dd3e911e59"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 2d05f18e0daa17edcd55283194d3c3aa
-      X-Runtime:
-      - '0.011001'
-      Strict-Transport-Security:
+      x-request-id:
+      - 861f483d8a7a7176b57c888ea3c782ab
+      x-runtime:
+      - '0.006321'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -735,7 +695,7 @@ http_interactions:
         of arrest to representation on the consideration of the breach by the court
         (but excluding applying for a warrant of arrest, if not attached, and representation
         in contempt proceedings).","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:00:36 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:11 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -746,47 +706,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:00:37 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:11 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '708'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"05375658d64485716c2575dd3e911e59"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 4f7ac2bcc508abaa34390ba0f1bb7646
-      X-Runtime:
-      - '0.011097'
-      Strict-Transport-Security:
+      x-request-id:
+      - 198cd38a61e2fb59701062a4708a164a
+      x-runtime:
+      - '0.009678'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -798,5 +752,5 @@ http_interactions:
         of arrest to representation on the consideration of the breach by the court
         (but excluding applying for a warrant of arrest, if not attached, and representation
         in contempt proceedings).","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:00:37 GMT
-recorded_with: VCR 6.1.0
+  recorded_at: Wed, 13 Dec 2023 16:27:11 GMT
+recorded_with: VCR 6.2.0

--- a/features/cassettes/Applicant_details/Completes_the_application_using_address_lookup_with_multiple_proceedings.yml
+++ b/features/cassettes/Applicant_details/Completes_the_application_using_address_lookup_with_multiple_proceedings.yml
@@ -8,43 +8,39 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:21 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:47 GMT
+      content-type:
       - application/json;charset=UTF-8
-      Transfer-Encoding:
+      transfer-encoding:
       - chunked
-      Connection:
+      connection:
       - keep-alive
-      Request-Context:
+      request-context:
       - appId=cid-v1:cd7023ed-37c2-4bb3-b1f3-cd441a39a9ae
-      Vary:
+      vary:
       - Origin,Accept-Encoding,key
-      Omse-Category:
+      omse-category:
       - premium
-      Omse-Transaction-Count:
+      omse-transaction-count:
       - '60'
-      Omse-Premium-Count:
+      omse-premium-count:
       - '0'
-      Strict-Transport-Security:
+      strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: "{\r\n  \"header\" : {\r\n    \"uri\" : \"https://api.os.uk/search/places/v1/postcode?lr=EN&postcode=SW1H9EA\",\r\n
         \   \"query\" : \"postcode=SW1H9EA\",\r\n    \"offset\" : 0,\r\n    \"totalresults\"
         : 5,\r\n    \"format\" : \"JSON\",\r\n    \"dataset\" : \"DPA\",\r\n    \"lr\"
-        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"98\",\r\n    \"lastupdate\"
-        : \"2023-02-02\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
+        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"106\",\r\n    \"lastupdate\"
+        : \"2023-12-12\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
         : [ {\r\n    \"DPA\" : {\r\n      \"UPRN\" : \"100023337883\",\r\n      \"UDPRN\"
         : \"23749699\",\r\n      \"ADDRESS\" : \"SUPER FIRM LTD, 84, PETTY FRANCE,
         LONDON, SW1H 9EA\",\r\n      \"ORGANISATION_NAME\" : \"SUPER FIRM LTD\",\r\n
@@ -136,7 +132,7 @@ http_interactions:
         \     \"ENTRY_DATE\" : \"15/06/2020\",\r\n      \"BLPU_STATE_DATE\" : \"15/06/2020\",\r\n
         \     \"LANGUAGE\" : \"EN\",\r\n      \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\"
         : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\" : \"1N\"\r\n    }\r\n  } ]\r\n}"
-  recorded_at: Fri, 03 Feb 2023 10:24:21 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:47 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -147,47 +143,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:21 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:48 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 57da0751041d3c380c56e56d4221fe66
-      X-Runtime:
-      - '0.026185'
-      Strict-Transport-Security:
+      x-request-id:
+      - 2f9faccae02ca37e50a39f132215ddf3
+      x-runtime:
+      - '0.015803'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -312,7 +302,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:24:21 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:48 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -323,47 +313,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:23 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:49 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 35a9506e01f09bfe4dcb654e807d7b7c
-      X-Runtime:
-      - '0.026252'
-      Strict-Transport-Security:
+      x-request-id:
+      - 2db4ba82ad6ea8db8c445f0cc8d9dfdd
+      x-runtime:
+      - '0.016657'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -488,7 +472,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:24:23 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:49 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/DA004
@@ -499,47 +483,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:23 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:49 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '1310'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"fbabf0efd65b63f03290a3f99682b0d4"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 5ba12e3797f2e84bc867c2836993cde8
-      X-Runtime:
-      - '0.013122'
-      Strict-Transport-Security:
+      x-request-id:
+      - 9f9a4cb51d64fee5b963cb7bdf77d474
+      x-runtime:
+      - '0.009941'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -556,7 +534,7 @@ http_interactions:
         for an interim order; where application is made without notice to include
         representation on the return date."}},"service_levels":[{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":true}]}'
-  recorded_at: Fri, 03 Feb 2023 10:24:23 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:49 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -567,47 +545,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:23 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:50 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 4faadb97edd54d3f011f253e36e1fdb7
-      X-Runtime:
-      - '0.034400'
-      Strict-Transport-Security:
+      x-request-id:
+      - 6aac3d6d5af1a100aedfde526e5eac99
+      x-runtime:
+      - '0.013699'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -732,7 +704,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:24:23 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:50 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -743,47 +715,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:25 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:51 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 712daa525d6e2a760b5d9688b3d4e2ba
-      X-Runtime:
-      - '0.029047'
-      Strict-Transport-Security:
+      x-request-id:
+      - 4a58d9c2c28a5db1d9b58e56bbbe136f
+      x-runtime:
+      - '0.015746'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -908,7 +874,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:24:25 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:51 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/DA005
@@ -919,47 +885,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:25 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:52 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '1297'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"91f645e50c379de35235d559d59b904e"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - bdd9cd3a2df6bd158373cd38d1d4cab5
-      X-Runtime:
-      - '0.011271'
-      Strict-Transport-Security:
+      x-request-id:
+      - 5a7a97d47cc3171a0ec35b5d76f72f74
+      x-runtime:
+      - '0.009265'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -976,7 +936,7 @@ http_interactions:
         for an interim order; where application is made without notice to include
         representation on the return date."}},"service_levels":[{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":true}]}'
-  recorded_at: Fri, 03 Feb 2023 10:24:25 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:51 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -987,47 +947,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:26 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:52 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 5b6b0710004693b079ceb1dc63871307
-      X-Runtime:
-      - '0.032728'
-      Strict-Transport-Security:
+      x-request-id:
+      - 2e536b8fa9b41f7acca32cc8977a7efa
+      x-runtime:
+      - '0.013407'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -1152,7 +1106,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:24:26 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:52 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -1163,47 +1117,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:27 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:54 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - d378379bef03594d6074f9fa2c3ef73b
-      X-Runtime:
-      - '0.027299'
-      Strict-Transport-Security:
+      x-request-id:
+      - 15d6b381e9bdf951ceccf9279eb815a6
+      x-runtime:
+      - '0.014069'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -1328,7 +1276,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:24:27 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:53 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/DA020
@@ -1339,47 +1287,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:27 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:54 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '1370'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"be2d4fc9764a92450c8a0ec6e0c94bb6"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 7d730397f00f0478bf83d37026430e0b
-      X-Runtime:
-      - '0.017024'
-      Strict-Transport-Security:
+      x-request-id:
+      - 63f0544d4a5d4d3f9adfdba23bd4e071
+      x-runtime:
+      - '0.014106'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -1397,7 +1339,7 @@ http_interactions:
         for an interim order; where application is made without notice to include
         representation on the return date."}},"service_levels":[{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":true}]}'
-  recorded_at: Fri, 03 Feb 2023 10:24:27 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:54 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -1408,47 +1350,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:28 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:54 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 4c75bff5ba48b41a98746cc59d848683
-      X-Runtime:
-      - '0.023606'
-      Strict-Transport-Security:
+      x-request-id:
+      - e625fc660f3b4d3d5b3dd822acbd06b5
+      x-runtime:
+      - '0.015801'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -1573,7 +1509,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:24:28 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:54 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -1584,47 +1520,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:29 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:55 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 1342d281b67b190d82e84f39edb0ff3f
-      X-Runtime:
-      - '0.033053'
-      Strict-Transport-Security:
+      x-request-id:
+      - 2f77c74fa9d78a5ed4e448d333d07b09
+      x-runtime:
+      - '0.016700'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -1749,7 +1679,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:24:29 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:55 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/DA005
@@ -1760,47 +1690,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:29 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:55 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '1297'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"91f645e50c379de35235d559d59b904e"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 630572e055d01259ae23d165eeb33d0b
-      X-Runtime:
-      - '0.019234'
-      Strict-Transport-Security:
+      x-request-id:
+      - 4dd8ca8fcbec2e7b36c07fd426fd5ef4
+      x-runtime:
+      - '0.013266'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -1817,7 +1741,7 @@ http_interactions:
         for an interim order; where application is made without notice to include
         representation on the return date."}},"service_levels":[{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":true}]}'
-  recorded_at: Fri, 03 Feb 2023 10:24:29 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:55 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -1828,47 +1752,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:30 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:56 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 3bb7cca1b8a51367fb5374bb6f264e9f
-      X-Runtime:
-      - '0.025594'
-      Strict-Transport-Security:
+      x-request-id:
+      - 53ec3b6ed3ae865808ec5cc82b8c7029
+      x-runtime:
+      - '0.016837'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -1993,7 +1911,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:24:29 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:56 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -2004,47 +1922,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:31 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:57 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - e7d414f73dd02c9ec31b1e8a604bde9a
-      X-Runtime:
-      - '0.045319'
-      Strict-Transport-Security:
+      x-request-id:
+      - 2490b32c221ce2aadfe426d36bd4696d
+      x-runtime:
+      - '0.012933'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -2169,7 +2081,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:24:31 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:57 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/DA003
@@ -2180,47 +2092,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:31 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:57 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '1350'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"7cc8172bde052549bc19a07db5d6e41d"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - e94d1af2b7552dccca76a16cd152c0db
-      X-Runtime:
-      - '0.020033'
-      Strict-Transport-Security:
+      x-request-id:
+      - 734943046e16b6f40db226c0cdae3ba6
+      x-runtime:
+      - '0.008408'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -2238,7 +2144,7 @@ http_interactions:
         for an interim order; where application is made without notice to include
         representation on the return date."}},"service_levels":[{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":true}]}'
-  recorded_at: Fri, 03 Feb 2023 10:24:31 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:57 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
@@ -2249,54 +2155,48 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:31 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:58 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '277'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"8bf337339345d42d16a9e6062fb65ccf"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 6e527699de29610a6c260d7a3c22fbad
-      X-Runtime:
-      - '0.003814'
-      Strict-Transport-Security:
+      x-request-id:
+      - e042b3f7f6865c0a66feffd7071b86e3
+      x-runtime:
+      - '0.003047'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]'
-  recorded_at: Fri, 03 Feb 2023 10:24:31 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:58 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
@@ -2307,140 +2207,48 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:32 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:58 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '277'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"8bf337339345d42d16a9e6062fb65ccf"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 856f32c7bbd5c549a25cada021b442c5
-      X-Runtime:
-      - '0.005439'
-      Strict-Transport-Security:
+      x-request-id:
+      - 886dc8c7226705f83f22395f4b8351c0
+      x-runtime:
+      - '0.003977'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]'
-  recorded_at: Fri, 03 Feb 2023 10:24:32 GMT
-- request:
-    method: get
-    uri: https://www.gov.uk/bank-holidays.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Host:
-      - www.gov.uk
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '17854'
-      Content-Type:
-      - application/json; charset=utf-8
-      Server:
-      - nginx
-      Access-Control-Allow-Origin:
-      - "*"
-      Cache-Control:
-      - max-age=3600, public
-      Content-Security-Policy-Report-Only:
-      - default-src 'self'; base-uri 'none'; img-src 'self' *.publishing.service.gov.uk
-        www.gov.uk *.dev.gov.uk www.google-analytics.com ssl.google-analytics.com
-        stats.g.doubleclick.net www.googletagmanager.com www.region1.google-analytics.com
-        region1.google-analytics.com lux.speedcurve.com assets.digital.cabinet-office.gov.uk
-        https://img.youtube.com; script-src 'self' www.google-analytics.com ssl.google-analytics.com
-        stats.g.doubleclick.net www.googletagmanager.com www.region1.google-analytics.com
-        region1.google-analytics.com www.gstatic.com *.ytimg.com www.youtube.com www.youtube-nocookie.com
-        'nonce-uDQaiUdSAp841gqFD/kiqg=='; style-src 'self' www.gstatic.com 'unsafe-inline';
-        font-src 'self'; connect-src 'self' *.publishing.service.gov.uk www.gov.uk
-        *.dev.gov.uk www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net
-        www.googletagmanager.com www.region1.google-analytics.com region1.google-analytics.com
-        lux.speedcurve.com; object-src 'none'; frame-src 'self' *.publishing.service.gov.uk
-        www.gov.uk *.dev.gov.uk www.youtube.com www.youtube-nocookie.com; report-uri
-        https://csp-reporter.publishing.service.gov.uk/report
-      Etag:
-      - W/"21c0301e75119f0665930ca20ca075aa"
-      Permissions-Policy:
-      - interest-cohort=()
-      Referrer-Policy:
-      - strict-origin-when-cross-origin
-      Strict-Transport-Security:
-      - max-age=31536000; preload
-      Via:
-      - 1.1 router, 1.1 varnish, 1.1 varnish
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - ALLOWALL
-      X-Request-Id:
-      - e19ef668-41c4-4b68-866d-90b9fead5a0e
-      Fastly-Backend-Name:
-      - origin
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Fri, 03 Feb 2023 10:24:32 GMT
-      Age:
-      - '3468'
-      X-Served-By:
-      - cache-lon420137-LON
-      X-Cache:
-      - HIT, HIT
-      X-Cache-Hits:
-      - '12'
-      X-Timer:
-      - S1675419873.821612,VS0,VE0
-      Vary:
-      - Accept-Encoding
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        eyJlbmdsYW5kLWFuZC13YWxlcyI6eyJkaXZpc2lvbiI6ImVuZ2xhbmQtYW5kLXdhbGVzIiwiZXZlbnRzIjpbeyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAxOC0wMS0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ikdvb2QgRnJpZGF5IiwiZGF0ZSI6IjIwMTgtMDMtMzAiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiRWFzdGVyIE1vbmRheSIsImRhdGUiOiIyMDE4LTA0LTAyIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiRWFybHkgTWF5IGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE4LTA1LTA3Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE4LTA1LTI4Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE4LTA4LTI3Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQ2hyaXN0bWFzIERheSIsImRhdGUiOiIyMDE4LTEyLTI1Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQm94aW5nIERheSIsImRhdGUiOiIyMDE4LTEyLTI2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiTmV3IFllYXLigJlzIERheSIsImRhdGUiOiIyMDE5LTAxLTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiR29vZCBGcmlkYXkiLCJkYXRlIjoiMjAxOS0wNC0xOSIsIm5vdGVzIjoiIiwiYnVudGluZyI6ZmFsc2V9LHsidGl0bGUiOiJFYXN0ZXIgTW9uZGF5IiwiZGF0ZSI6IjIwMTktMDQtMjIiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJFYXJseSBNYXkgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMTktMDUtMDYiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJTcHJpbmcgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMTktMDUtMjciLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJTdW1tZXIgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMTktMDgtMjYiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJDaHJpc3RtYXMgRGF5IiwiZGF0ZSI6IjIwMTktMTItMjUiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJCb3hpbmcgRGF5IiwiZGF0ZSI6IjIwMTktMTItMjYiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJOZXcgWWVhcuKAmXMgRGF5IiwiZGF0ZSI6IjIwMjAtMDEtMDEiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJHb29kIEZyaWRheSIsImRhdGUiOiIyMDIwLTA0LTEwIiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IkVhc3RlciBNb25kYXkiLCJkYXRlIjoiMjAyMC0wNC0xMyIsIm5vdGVzIjoiIiwiYnVudGluZyI6ZmFsc2V9LHsidGl0bGUiOiJFYXJseSBNYXkgYmFuayBob2xpZGF5IChWRSBkYXkpIiwiZGF0ZSI6IjIwMjAtMDUtMDgiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJTcHJpbmcgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjAtMDUtMjUiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJTdW1tZXIgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjAtMDgtMzEiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJDaHJpc3RtYXMgRGF5IiwiZGF0ZSI6IjIwMjAtMTItMjUiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJCb3hpbmcgRGF5IiwiZGF0ZSI6IjIwMjAtMTItMjgiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAyMS0wMS0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ikdvb2QgRnJpZGF5IiwiZGF0ZSI6IjIwMjEtMDQtMDIiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiRWFzdGVyIE1vbmRheSIsImRhdGUiOiIyMDIxLTA0LTA1Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiRWFybHkgTWF5IGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIxLTA1LTAzIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIxLTA1LTMxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIxLTA4LTMwIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQ2hyaXN0bWFzIERheSIsImRhdGUiOiIyMDIxLTEyLTI3Iiwibm90ZXMiOiJTdWJzdGl0dXRlIGRheSIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJCb3hpbmcgRGF5IiwiZGF0ZSI6IjIwMjEtMTItMjgiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAyMi0wMS0wMyIsIm5vdGVzIjoiU3Vic3RpdHV0ZSBkYXkiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiR29vZCBGcmlkYXkiLCJkYXRlIjoiMjAyMi0wNC0xNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6ZmFsc2V9LHsidGl0bGUiOiJFYXN0ZXIgTW9uZGF5IiwiZGF0ZSI6IjIwMjItMDQtMTgiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJFYXJseSBNYXkgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjItMDUtMDIiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJTcHJpbmcgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjItMDYtMDIiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJQbGF0aW51bSBKdWJpbGVlIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIyLTA2LTAzIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIyLTA4LTI5Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQmFuayBIb2xpZGF5IGZvciB0aGUgU3RhdGUgRnVuZXJhbCBvZiBRdWVlbiBFbGl6YWJldGggSUkiLCJkYXRlIjoiMjAyMi0wOS0xOSIsIm5vdGVzIjoiIiwiYnVudGluZyI6ZmFsc2V9LHsidGl0bGUiOiJCb3hpbmcgRGF5IiwiZGF0ZSI6IjIwMjItMTItMjYiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJDaHJpc3RtYXMgRGF5IiwiZGF0ZSI6IjIwMjItMTItMjciLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAyMy0wMS0wMiIsIm5vdGVzIjoiU3Vic3RpdHV0ZSBkYXkiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiR29vZCBGcmlkYXkiLCJkYXRlIjoiMjAyMy0wNC0wNyIsIm5vdGVzIjoiIiwiYnVudGluZyI6ZmFsc2V9LHsidGl0bGUiOiJFYXN0ZXIgTW9uZGF5IiwiZGF0ZSI6IjIwMjMtMDQtMTAiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJFYXJseSBNYXkgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjMtMDUtMDEiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJCYW5rIGhvbGlkYXkgZm9yIHRoZSBjb3JvbmF0aW9uIG9mIEtpbmcgQ2hhcmxlcyBJSUkiLCJkYXRlIjoiMjAyMy0wNS0wOCIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlNwcmluZyBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMy0wNS0yOSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN1bW1lciBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMy0wOC0yOCIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkNocmlzdG1hcyBEYXkiLCJkYXRlIjoiMjAyMy0xMi0yNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJveGluZyBEYXkiLCJkYXRlIjoiMjAyMy0xMi0yNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAyNC0wMS0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ikdvb2QgRnJpZGF5IiwiZGF0ZSI6IjIwMjQtMDMtMjkiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiRWFzdGVyIE1vbmRheSIsImRhdGUiOiIyMDI0LTA0LTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiRWFybHkgTWF5IGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDI0LTA1LTA2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDI0LTA1LTI3Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDI0LTA4LTI2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQ2hyaXN0bWFzIERheSIsImRhdGUiOiIyMDI0LTEyLTI1Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQm94aW5nIERheSIsImRhdGUiOiIyMDI0LTEyLTI2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiTmV3IFllYXLigJlzIERheSIsImRhdGUiOiIyMDI1LTAxLTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiR29vZCBGcmlkYXkiLCJkYXRlIjoiMjAyNS0wNC0xOCIsIm5vdGVzIjoiIiwiYnVudGluZyI6ZmFsc2V9LHsidGl0bGUiOiJFYXN0ZXIgTW9uZGF5IiwiZGF0ZSI6IjIwMjUtMDQtMjEiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJFYXJseSBNYXkgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjUtMDUtMDUiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJTcHJpbmcgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjUtMDUtMjYiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJTdW1tZXIgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjUtMDgtMjUiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJDaHJpc3RtYXMgRGF5IiwiZGF0ZSI6IjIwMjUtMTItMjUiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJCb3hpbmcgRGF5IiwiZGF0ZSI6IjIwMjUtMTItMjYiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9XX0sInNjb3RsYW5kIjp7ImRpdmlzaW9uIjoic2NvdGxhbmQiLCJldmVudHMiOlt7InRpdGxlIjoiTmV3IFllYXLigJlzIERheSIsImRhdGUiOiIyMDE4LTAxLTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiMm5kIEphbnVhcnkiLCJkYXRlIjoiMjAxOC0wMS0wMiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ikdvb2QgRnJpZGF5IiwiZGF0ZSI6IjIwMTgtMDMtMzAiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiRWFybHkgTWF5IGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE4LTA1LTA3Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE4LTA1LTI4Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE4LTA4LTA2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3QgQW5kcmV34oCZcyBEYXkiLCJkYXRlIjoiMjAxOC0xMS0zMCIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkNocmlzdG1hcyBEYXkiLCJkYXRlIjoiMjAxOC0xMi0yNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJveGluZyBEYXkiLCJkYXRlIjoiMjAxOC0xMi0yNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAxOS0wMS0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IjJuZCBKYW51YXJ5IiwiZGF0ZSI6IjIwMTktMDEtMDIiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJHb29kIEZyaWRheSIsImRhdGUiOiIyMDE5LTA0LTE5Iiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IkVhcmx5IE1heSBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAxOS0wNS0wNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlNwcmluZyBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAxOS0wNS0yNyIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN1bW1lciBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAxOS0wOC0wNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN0IEFuZHJld+KAmXMgRGF5IiwiZGF0ZSI6IjIwMTktMTItMDIiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkNocmlzdG1hcyBEYXkiLCJkYXRlIjoiMjAxOS0xMi0yNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJveGluZyBEYXkiLCJkYXRlIjoiMjAxOS0xMi0yNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAyMC0wMS0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IjJuZCBKYW51YXJ5IiwiZGF0ZSI6IjIwMjAtMDEtMDIiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJHb29kIEZyaWRheSIsImRhdGUiOiIyMDIwLTA0LTEwIiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IkVhcmx5IE1heSBiYW5rIGhvbGlkYXkgKFZFIGRheSkiLCJkYXRlIjoiMjAyMC0wNS0wOCIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlNwcmluZyBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMC0wNS0yNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN1bW1lciBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMC0wOC0wMyIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN0IEFuZHJld+KAmXMgRGF5IiwiZGF0ZSI6IjIwMjAtMTEtMzAiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJDaHJpc3RtYXMgRGF5IiwiZGF0ZSI6IjIwMjAtMTItMjUiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJCb3hpbmcgRGF5IiwiZGF0ZSI6IjIwMjAtMTItMjgiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAyMS0wMS0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IjJuZCBKYW51YXJ5IiwiZGF0ZSI6IjIwMjEtMDEtMDQiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ikdvb2QgRnJpZGF5IiwiZGF0ZSI6IjIwMjEtMDQtMDIiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiRWFybHkgTWF5IGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIxLTA1LTAzIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIxLTA1LTMxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIxLTA4LTAyIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3QgQW5kcmV34oCZcyBEYXkiLCJkYXRlIjoiMjAyMS0xMS0zMCIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkNocmlzdG1hcyBEYXkiLCJkYXRlIjoiMjAyMS0xMi0yNyIsIm5vdGVzIjoiU3Vic3RpdHV0ZSBkYXkiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQm94aW5nIERheSIsImRhdGUiOiIyMDIxLTEyLTI4Iiwibm90ZXMiOiJTdWJzdGl0dXRlIGRheSIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJOZXcgWWVhcuKAmXMgRGF5IiwiZGF0ZSI6IjIwMjItMDEtMDMiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IjJuZCBKYW51YXJ5IiwiZGF0ZSI6IjIwMjItMDEtMDQiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ikdvb2QgRnJpZGF5IiwiZGF0ZSI6IjIwMjItMDQtMTUiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiRWFybHkgTWF5IGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIyLTA1LTAyIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIyLTA2LTAyIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiUGxhdGludW0gSnViaWxlZSBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMi0wNi0wMyIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN1bW1lciBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMi0wOC0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJhbmsgSG9saWRheSBmb3IgdGhlIFN0YXRlIEZ1bmVyYWwgb2YgUXVlZW4gRWxpemFiZXRoIElJIiwiZGF0ZSI6IjIwMjItMDktMTkiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiU3QgQW5kcmV34oCZcyBEYXkiLCJkYXRlIjoiMjAyMi0xMS0zMCIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJveGluZyBEYXkiLCJkYXRlIjoiMjAyMi0xMi0yNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkNocmlzdG1hcyBEYXkiLCJkYXRlIjoiMjAyMi0xMi0yNyIsIm5vdGVzIjoiU3Vic3RpdHV0ZSBkYXkiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiTmV3IFllYXLigJlzIERheSIsImRhdGUiOiIyMDIzLTAxLTAyIiwibm90ZXMiOiJTdWJzdGl0dXRlIGRheSIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiIybmQgSmFudWFyeSIsImRhdGUiOiIyMDIzLTAxLTAzIiwibm90ZXMiOiJTdWJzdGl0dXRlIGRheSIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJHb29kIEZyaWRheSIsImRhdGUiOiIyMDIzLTA0LTA3Iiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IkVhcmx5IE1heSBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMy0wNS0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJhbmsgaG9saWRheSBmb3IgdGhlIGNvcm9uYXRpb24gb2YgS2luZyBDaGFybGVzIElJSSIsImRhdGUiOiIyMDIzLTA1LTA4Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIzLTA1LTI5Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIzLTA4LTA3Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3QgQW5kcmV34oCZcyBEYXkiLCJkYXRlIjoiMjAyMy0xMS0zMCIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkNocmlzdG1hcyBEYXkiLCJkYXRlIjoiMjAyMy0xMi0yNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJveGluZyBEYXkiLCJkYXRlIjoiMjAyMy0xMi0yNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAyNC0wMS0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IjJuZCBKYW51YXJ5IiwiZGF0ZSI6IjIwMjQtMDEtMDIiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJHb29kIEZyaWRheSIsImRhdGUiOiIyMDI0LTAzLTI5Iiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IkVhcmx5IE1heSBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyNC0wNS0wNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlNwcmluZyBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyNC0wNS0yNyIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN1bW1lciBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyNC0wOC0wNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN0IEFuZHJld+KAmXMgRGF5IiwiZGF0ZSI6IjIwMjQtMTItMDIiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkNocmlzdG1hcyBEYXkiLCJkYXRlIjoiMjAyNC0xMi0yNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJveGluZyBEYXkiLCJkYXRlIjoiMjAyNC0xMi0yNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAyNS0wMS0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IjJuZCBKYW51YXJ5IiwiZGF0ZSI6IjIwMjUtMDEtMDIiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJHb29kIEZyaWRheSIsImRhdGUiOiIyMDI1LTA0LTE4Iiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IkVhcmx5IE1heSBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyNS0wNS0wNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlNwcmluZyBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyNS0wNS0yNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN1bW1lciBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyNS0wOC0wNCIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN0IEFuZHJld+KAmXMgRGF5IiwiZGF0ZSI6IjIwMjUtMTItMDEiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkNocmlzdG1hcyBEYXkiLCJkYXRlIjoiMjAyNS0xMi0yNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJveGluZyBEYXkiLCJkYXRlIjoiMjAyNS0xMi0yNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX1dfSwibm9ydGhlcm4taXJlbGFuZCI6eyJkaXZpc2lvbiI6Im5vcnRoZXJuLWlyZWxhbmQiLCJldmVudHMiOlt7InRpdGxlIjoiTmV3IFllYXLigJlzIERheSIsImRhdGUiOiIyMDE4LTAxLTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3QgUGF0cmlja+KAmXMgRGF5IiwiZGF0ZSI6IjIwMTgtMDMtMTkiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ikdvb2QgRnJpZGF5IiwiZGF0ZSI6IjIwMTgtMDMtMzAiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiRWFzdGVyIE1vbmRheSIsImRhdGUiOiIyMDE4LTA0LTAyIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiRWFybHkgTWF5IGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE4LTA1LTA3Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE4LTA1LTI4Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQmF0dGxlIG9mIHRoZSBCb3luZSAoT3JhbmdlbWVu4oCZcyBEYXkpIiwiZGF0ZSI6IjIwMTgtMDctMTIiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE4LTA4LTI3Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQ2hyaXN0bWFzIERheSIsImRhdGUiOiIyMDE4LTEyLTI1Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQm94aW5nIERheSIsImRhdGUiOiIyMDE4LTEyLTI2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiTmV3IFllYXLigJlzIERheSIsImRhdGUiOiIyMDE5LTAxLTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3QgUGF0cmlja+KAmXMgRGF5IiwiZGF0ZSI6IjIwMTktMDMtMTgiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ikdvb2QgRnJpZGF5IiwiZGF0ZSI6IjIwMTktMDQtMTkiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiRWFzdGVyIE1vbmRheSIsImRhdGUiOiIyMDE5LTA0LTIyIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiRWFybHkgTWF5IGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE5LTA1LTA2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE5LTA1LTI3Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQmF0dGxlIG9mIHRoZSBCb3luZSAoT3JhbmdlbWVu4oCZcyBEYXkpIiwiZGF0ZSI6IjIwMTktMDctMTIiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDE5LTA4LTI2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQ2hyaXN0bWFzIERheSIsImRhdGUiOiIyMDE5LTEyLTI1Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQm94aW5nIERheSIsImRhdGUiOiIyMDE5LTEyLTI2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiTmV3IFllYXLigJlzIERheSIsImRhdGUiOiIyMDIwLTAxLTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3QgUGF0cmlja+KAmXMgRGF5IiwiZGF0ZSI6IjIwMjAtMDMtMTciLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJHb29kIEZyaWRheSIsImRhdGUiOiIyMDIwLTA0LTEwIiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IkVhc3RlciBNb25kYXkiLCJkYXRlIjoiMjAyMC0wNC0xMyIsIm5vdGVzIjoiIiwiYnVudGluZyI6ZmFsc2V9LHsidGl0bGUiOiJFYXJseSBNYXkgYmFuayBob2xpZGF5IChWRSBkYXkpIiwiZGF0ZSI6IjIwMjAtMDUtMDgiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJTcHJpbmcgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjAtMDUtMjUiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJCYXR0bGUgb2YgdGhlIEJveW5lIChPcmFuZ2VtZW7igJlzIERheSkiLCJkYXRlIjoiMjAyMC0wNy0xMyIsIm5vdGVzIjoiU3Vic3RpdHV0ZSBkYXkiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IlN1bW1lciBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMC0wOC0zMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkNocmlzdG1hcyBEYXkiLCJkYXRlIjoiMjAyMC0xMi0yNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJveGluZyBEYXkiLCJkYXRlIjoiMjAyMC0xMi0yOCIsIm5vdGVzIjoiU3Vic3RpdHV0ZSBkYXkiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiTmV3IFllYXLigJlzIERheSIsImRhdGUiOiIyMDIxLTAxLTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3QgUGF0cmlja+KAmXMgRGF5IiwiZGF0ZSI6IjIwMjEtMDMtMTciLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJHb29kIEZyaWRheSIsImRhdGUiOiIyMDIxLTA0LTAyIiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IkVhc3RlciBNb25kYXkiLCJkYXRlIjoiMjAyMS0wNC0wNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkVhcmx5IE1heSBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMS0wNS0wMyIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlNwcmluZyBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMS0wNS0zMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJhdHRsZSBvZiB0aGUgQm95bmUgKE9yYW5nZW1lbuKAmXMgRGF5KSIsImRhdGUiOiIyMDIxLTA3LTEyIiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IlN1bW1lciBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMS0wOC0zMCIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkNocmlzdG1hcyBEYXkiLCJkYXRlIjoiMjAyMS0xMi0yNyIsIm5vdGVzIjoiU3Vic3RpdHV0ZSBkYXkiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQm94aW5nIERheSIsImRhdGUiOiIyMDIxLTEyLTI4Iiwibm90ZXMiOiJTdWJzdGl0dXRlIGRheSIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJOZXcgWWVhcuKAmXMgRGF5IiwiZGF0ZSI6IjIwMjItMDEtMDMiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlN0IFBhdHJpY2vigJlzIERheSIsImRhdGUiOiIyMDIyLTAzLTE3Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiR29vZCBGcmlkYXkiLCJkYXRlIjoiMjAyMi0wNC0xNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6ZmFsc2V9LHsidGl0bGUiOiJFYXN0ZXIgTW9uZGF5IiwiZGF0ZSI6IjIwMjItMDQtMTgiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJFYXJseSBNYXkgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjItMDUtMDIiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJTcHJpbmcgYmFuayBob2xpZGF5IiwiZGF0ZSI6IjIwMjItMDYtMDIiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJQbGF0aW51bSBKdWJpbGVlIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIyLTA2LTAzIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQmF0dGxlIG9mIHRoZSBCb3luZSAoT3JhbmdlbWVu4oCZcyBEYXkpIiwiZGF0ZSI6IjIwMjItMDctMTIiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIyLTA4LTI5Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQmFuayBIb2xpZGF5IGZvciB0aGUgU3RhdGUgRnVuZXJhbCBvZiBRdWVlbiBFbGl6YWJldGggSUkiLCJkYXRlIjoiMjAyMi0wOS0xOSIsIm5vdGVzIjoiIiwiYnVudGluZyI6ZmFsc2V9LHsidGl0bGUiOiJCb3hpbmcgRGF5IiwiZGF0ZSI6IjIwMjItMTItMjYiLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJDaHJpc3RtYXMgRGF5IiwiZGF0ZSI6IjIwMjItMTItMjciLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ik5ldyBZZWFy4oCZcyBEYXkiLCJkYXRlIjoiMjAyMy0wMS0wMiIsIm5vdGVzIjoiU3Vic3RpdHV0ZSBkYXkiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3QgUGF0cmlja+KAmXMgRGF5IiwiZGF0ZSI6IjIwMjMtMDMtMTciLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJHb29kIEZyaWRheSIsImRhdGUiOiIyMDIzLTA0LTA3Iiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IkVhc3RlciBNb25kYXkiLCJkYXRlIjoiMjAyMy0wNC0xMCIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkVhcmx5IE1heSBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyMy0wNS0wMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJhbmsgaG9saWRheSBmb3IgdGhlIGNvcm9uYXRpb24gb2YgS2luZyBDaGFybGVzIElJSSIsImRhdGUiOiIyMDIzLTA1LTA4Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIzLTA1LTI5Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQmF0dGxlIG9mIHRoZSBCb3luZSAoT3JhbmdlbWVu4oCZcyBEYXkpIiwiZGF0ZSI6IjIwMjMtMDctMTIiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDIzLTA4LTI4Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQ2hyaXN0bWFzIERheSIsImRhdGUiOiIyMDIzLTEyLTI1Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQm94aW5nIERheSIsImRhdGUiOiIyMDIzLTEyLTI2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiTmV3IFllYXLigJlzIERheSIsImRhdGUiOiIyMDI0LTAxLTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3QgUGF0cmlja+KAmXMgRGF5IiwiZGF0ZSI6IjIwMjQtMDMtMTgiLCJub3RlcyI6IlN1YnN0aXR1dGUgZGF5IiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6Ikdvb2QgRnJpZGF5IiwiZGF0ZSI6IjIwMjQtMDMtMjkiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiRWFzdGVyIE1vbmRheSIsImRhdGUiOiIyMDI0LTA0LTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiRWFybHkgTWF5IGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDI0LTA1LTA2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3ByaW5nIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDI0LTA1LTI3Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQmF0dGxlIG9mIHRoZSBCb3luZSAoT3JhbmdlbWVu4oCZcyBEYXkpIiwiZGF0ZSI6IjIwMjQtMDctMTIiLCJub3RlcyI6IiIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDI0LTA4LTI2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQ2hyaXN0bWFzIERheSIsImRhdGUiOiIyMDI0LTEyLTI1Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQm94aW5nIERheSIsImRhdGUiOiIyMDI0LTEyLTI2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiTmV3IFllYXLigJlzIERheSIsImRhdGUiOiIyMDI1LTAxLTAxIiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiU3QgUGF0cmlja+KAmXMgRGF5IiwiZGF0ZSI6IjIwMjUtMDMtMTciLCJub3RlcyI6IiIsImJ1bnRpbmciOnRydWV9LHsidGl0bGUiOiJHb29kIEZyaWRheSIsImRhdGUiOiIyMDI1LTA0LTE4Iiwibm90ZXMiOiIiLCJidW50aW5nIjpmYWxzZX0seyJ0aXRsZSI6IkVhc3RlciBNb25kYXkiLCJkYXRlIjoiMjAyNS0wNC0yMSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkVhcmx5IE1heSBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyNS0wNS0wNSIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IlNwcmluZyBiYW5rIGhvbGlkYXkiLCJkYXRlIjoiMjAyNS0wNS0yNiIsIm5vdGVzIjoiIiwiYnVudGluZyI6dHJ1ZX0seyJ0aXRsZSI6IkJhdHRsZSBvZiB0aGUgQm95bmUgKE9yYW5nZW1lbuKAmXMgRGF5KSIsImRhdGUiOiIyMDI1LTA3LTE0Iiwibm90ZXMiOiJTdWJzdGl0dXRlIGRheSIsImJ1bnRpbmciOmZhbHNlfSx7InRpdGxlIjoiU3VtbWVyIGJhbmsgaG9saWRheSIsImRhdGUiOiIyMDI1LTA4LTI1Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQ2hyaXN0bWFzIERheSIsImRhdGUiOiIyMDI1LTEyLTI1Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfSx7InRpdGxlIjoiQm94aW5nIERheSIsImRhdGUiOiIyMDI1LTEyLTI2Iiwibm90ZXMiOiIiLCJidW50aW5nIjp0cnVlfV19fQ==
-  recorded_at: Fri, 03 Feb 2023 10:24:32 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:58 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -2451,47 +2259,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:33 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:59 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '477'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"65ca4eca3aa35e25dc82a369f068e056"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 43d83979180b2c5614814d87e5e17d90
-      X-Runtime:
-      - '0.015713'
-      Strict-Transport-Security:
+      x-request-id:
+      - 01e2d07a1e43ce6177069dd23eb76a06
+      x-runtime:
+      - '0.011838'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -2500,7 +2302,7 @@ http_interactions:
         order inc. return date","description":"Limited to all steps necessary to apply
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:24:32 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:59 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -2511,47 +2313,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:33 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:59 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '477'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"65ca4eca3aa35e25dc82a369f068e056"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 47505f01536a3fce5cd7bacc19c036f9
-      X-Runtime:
-      - '0.013935'
-      Strict-Transport-Security:
+      x-request-id:
+      - 662a11cd9535555905fd739a61b0c80a
+      x-runtime:
+      - '0.010647'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -2560,7 +2356,7 @@ http_interactions:
         order inc. return date","description":"Limited to all steps necessary to apply
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:24:33 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:59 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -2571,47 +2367,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:33 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:26:59 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '708'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"3e338b67cfbc5a1d3f0456dabcc6ccd0"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 6d1f326f653171dad22246a6761b84e3
-      X-Runtime:
-      - '0.011617'
-      Strict-Transport-Security:
+      x-request-id:
+      - 9337c839ef71a38880ddd86157c5b930
+      x-runtime:
+      - '0.007459'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -2623,7 +2413,7 @@ http_interactions:
         of arrest to representation on the consideration of the breach by the court
         (but excluding applying for a warrant of arrest, if not attached, and representation
         in contempt proceedings).","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:24:33 GMT
+  recorded_at: Wed, 13 Dec 2023 16:26:59 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -2634,47 +2424,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:34 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:00 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '708'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"3e338b67cfbc5a1d3f0456dabcc6ccd0"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 615991f8f248bc88e91f6a456a8c3609
-      X-Runtime:
-      - '0.009900'
-      Strict-Transport-Security:
+      x-request-id:
+      - 663614fae64b1c7c33f441eee48d9177
+      x-runtime:
+      - '0.006935'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -2686,7 +2470,7 @@ http_interactions:
         of arrest to representation on the consideration of the breach by the court
         (but excluding applying for a warrant of arrest, if not attached, and representation
         in contempt proceedings).","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:24:33 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:00 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
@@ -2697,54 +2481,48 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:34 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:00 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '277'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"8bf337339345d42d16a9e6062fb65ccf"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - d28540cd5c2a13fce8ef34250e9b5dc5
-      X-Runtime:
-      - '0.009279'
-      Strict-Transport-Security:
+      x-request-id:
+      - 9fcda398e86031a0ca50f749f359b324
+      x-runtime:
+      - '0.004143'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]'
-  recorded_at: Fri, 03 Feb 2023 10:24:34 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:00 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
@@ -2755,54 +2533,48 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:34 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:00 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '277'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"8bf337339345d42d16a9e6062fb65ccf"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - a284b325f716490d0df2aa4288c15207
-      X-Runtime:
-      - '0.008792'
-      Strict-Transport-Security:
+      x-request-id:
+      - dc7ea6037eaa7ea49784f9ca4e2eafa7
+      x-runtime:
+      - '0.003036'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]'
-  recorded_at: Fri, 03 Feb 2023 10:24:34 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:00 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -2813,47 +2585,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:35 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:01 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '449'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"2a548122c895182fbfbfe564e797f97e"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 8a594453dd820b49cffb63427f7df2c8
-      X-Runtime:
-      - '0.021496'
-      Strict-Transport-Security:
+      x-request-id:
+      - 97dc8cd736724242b97959767919e5c4
+      x-runtime:
+      - '0.013106'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -2861,7 +2627,7 @@ http_interactions:
         Representation","stage":8},"default_scope":{"code":"CV118","meaning":"Hearing","description":"Limited
         to all steps up to and including the hearing on [see additional limitation
         notes]","additional_params":[{"name":"hearing_date","type":"date","mandatory":true}]}}'
-  recorded_at: Fri, 03 Feb 2023 10:24:35 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:01 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -2872,47 +2638,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:36 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:02 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '449'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"2a548122c895182fbfbfe564e797f97e"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 84c0b9d32f7e4815d4670f34b18c056d
-      X-Runtime:
-      - '0.012460'
-      Strict-Transport-Security:
+      x-request-id:
+      - a5f44db87faca879abf1f14aeae82d0a
+      x-runtime:
+      - '0.008024'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -2920,7 +2680,7 @@ http_interactions:
         Representation","stage":8},"default_scope":{"code":"CV118","meaning":"Hearing","description":"Limited
         to all steps up to and including the hearing on [see additional limitation
         notes]","additional_params":[{"name":"hearing_date","type":"date","mandatory":true}]}}'
-  recorded_at: Fri, 03 Feb 2023 10:24:36 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:02 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -2931,47 +2691,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:36 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:02 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '708'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"a18d205fdfcef2fe7f282a1b87882954"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 9d024712817544a9eeb14ffeb3a24466
-      X-Runtime:
-      - '0.017732'
-      Strict-Transport-Security:
+      x-request-id:
+      - 93314c11943b4bff49e327269cafd3ed
+      x-runtime:
+      - '0.007021'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -2983,7 +2737,7 @@ http_interactions:
         of arrest to representation on the consideration of the breach by the court
         (but excluding applying for a warrant of arrest, if not attached, and representation
         in contempt proceedings).","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:24:36 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:02 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -2994,47 +2748,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:36 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:03 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '708'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"a18d205fdfcef2fe7f282a1b87882954"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 575faf9bc2d1897591d2a65f40ec9b8e
-      X-Runtime:
-      - '0.009320'
-      Strict-Transport-Security:
+      x-request-id:
+      - 7ccc146565ca2ede553af41763daab1c
+      x-runtime:
+      - '0.007995'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -3046,7 +2794,7 @@ http_interactions:
         of arrest to representation on the consideration of the breach by the court
         (but excluding applying for a warrant of arrest, if not attached, and representation
         in contempt proceedings).","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:24:36 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:03 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
@@ -3057,54 +2805,48 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:37 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:03 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '277'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"8bf337339345d42d16a9e6062fb65ccf"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 91555f75010c02282a1fa673df4a8a2b
-      X-Runtime:
-      - '0.008772'
-      Strict-Transport-Security:
+      x-request-id:
+      - 76007b618af1a6b2ab951f59f9651a35
+      x-runtime:
+      - '0.003019'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]'
-  recorded_at: Fri, 03 Feb 2023 10:24:37 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:03 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
@@ -3115,54 +2857,48 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:37 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:03 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '277'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"8bf337339345d42d16a9e6062fb65ccf"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 93e61deee3f6a42bdcd2082013b25cb9
-      X-Runtime:
-      - '0.003626'
-      Strict-Transport-Security:
+      x-request-id:
+      - 23f80acdf3fe54090abba4b501139177
+      x-runtime:
+      - '0.003002'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]'
-  recorded_at: Fri, 03 Feb 2023 10:24:37 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:03 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -3173,47 +2909,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:38 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:04 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '708'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"5991b1d963fc88128f76da3177d56c26"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 693d975f8a1ff82b1c5252f36ddc4753
-      X-Runtime:
-      - '0.008357'
-      Strict-Transport-Security:
+      x-request-id:
+      - b5bcf89e48c74f3f17f8bbbb777b6590
+      x-runtime:
+      - '0.008991'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -3225,7 +2955,7 @@ http_interactions:
         of arrest to representation on the consideration of the breach by the court
         (but excluding applying for a warrant of arrest, if not attached, and representation
         in contempt proceedings).","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:24:38 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:04 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -3236,47 +2966,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:24:38 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:04 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '708'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"5991b1d963fc88128f76da3177d56c26"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 772711f18599b9ad941163d5d603bc70
-      X-Runtime:
-      - '0.009331'
-      Strict-Transport-Security:
+      x-request-id:
+      - 4535e9951208804f434669c8063669ba
+      x-runtime:
+      - '0.006726'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -3288,5 +3012,5 @@ http_interactions:
         of arrest to representation on the consideration of the breach by the court
         (but excluding applying for a warrant of arrest, if not attached, and representation
         in contempt proceedings).","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:24:38 GMT
-recorded_with: VCR 6.1.0
+  recorded_at: Wed, 13 Dec 2023 16:27:04 GMT
+recorded_with: VCR 6.2.0

--- a/features/cassettes/Applicant_details/Completes_the_application_using_manual_address.yml
+++ b/features/cassettes/Applicant_details/Completes_the_application_using_manual_address.yml
@@ -8,44 +8,40 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:08:28 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:17 GMT
+      content-type:
       - application/json;charset=UTF-8
-      Transfer-Encoding:
+      transfer-encoding:
       - chunked
-      Connection:
+      connection:
       - keep-alive
-      Request-Context:
+      request-context:
       - appId=cid-v1:cd7023ed-37c2-4bb3-b1f3-cd441a39a9ae
-      Vary:
+      vary:
       - Origin,Accept-Encoding,key
-      Omse-Category:
+      omse-category:
       - premium
-      Omse-Transaction-Count:
+      omse-transaction-count:
       - '60'
-      Omse-Premium-Count:
+      omse-premium-count:
       - '0'
-      Strict-Transport-Security:
+      strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: "{\r\n  \"header\" : {\r\n    \"uri\" : \"https://api.os.uk/search/places/v1/postcode?lr=EN&postcode=XX11XX\",\r\n
         \   \"query\" : \"postcode=XX11XX\",\r\n    \"offset\" : 0,\r\n    \"totalresults\"
         : 0,\r\n    \"format\" : \"JSON\",\r\n    \"dataset\" : \"DPA\",\r\n    \"lr\"
-        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"98\",\r\n    \"lastupdate\"
-        : \"2023-02-02\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  }\r\n}"
-  recorded_at: Fri, 03 Feb 2023 10:08:28 GMT
+        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"106\",\r\n    \"lastupdate\"
+        : \"2023-12-12\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  }\r\n}"
+  recorded_at: Wed, 13 Dec 2023 16:27:17 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -56,47 +52,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:08:28 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:18 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 9c58a2026c3ee3ba14c89fcec01b02bb
-      X-Runtime:
-      - '0.021648'
-      Strict-Transport-Security:
+      x-request-id:
+      - cadba9dc3ebdbd4419dd20b7bd2e3d3e
+      x-runtime:
+      - '0.013261'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -221,7 +211,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:08:28 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:18 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -232,47 +222,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:08:30 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:19 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - d9c2012f7b0648263d318c2fe9cd1726
-      X-Runtime:
-      - '0.025906'
-      Strict-Transport-Security:
+      x-request-id:
+      - c8831f42b4e2e0d041bad8bc8d9e41d2
+      x-runtime:
+      - '0.013123'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -397,7 +381,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:08:29 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:19 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/DA004
@@ -408,47 +392,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:08:30 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:19 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '1310'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"fbabf0efd65b63f03290a3f99682b0d4"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - afa7ee561a82e3173d821e49e6174d21
-      X-Runtime:
-      - '0.013002'
-      Strict-Transport-Security:
+      x-request-id:
+      - 8af85c44aa59e27935f571da48e5a993
+      x-runtime:
+      - '0.011990'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -465,7 +443,7 @@ http_interactions:
         for an interim order; where application is made without notice to include
         representation on the return date."}},"service_levels":[{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":true}]}'
-  recorded_at: Fri, 03 Feb 2023 10:08:29 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:19 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -476,47 +454,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:08:30 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:20 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - e5283d642bb243f332fc6a254b0e4b08
-      X-Runtime:
-      - '0.025066'
-      Strict-Transport-Security:
+      x-request-id:
+      - ee9aadf4aa65cb0b6ad28c7064ae8869
+      x-runtime:
+      - '0.018286'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -641,7 +613,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:08:30 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:20 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -652,47 +624,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:08:31 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:21 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 1012a7d358a0855ac142e87f624cef31
-      X-Runtime:
-      - '0.024177'
-      Strict-Transport-Security:
+      x-request-id:
+      - fbb67c975c0d2370b3a72e8e4b40f8c8
+      x-runtime:
+      - '0.013117'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -817,7 +783,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:08:31 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:21 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE014
@@ -828,47 +794,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:08:31 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:21 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '1291'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"0628cdb3a0d7f056459a0eb5a468514c"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 82508da0bf0e8191b78c90d54082a9f9
-      X-Runtime:
-      - '0.011132'
-      Strict-Transport-Security:
+      x-request-id:
+      - b4e1e5b23f144c6b717e0564861434b4
+      x-runtime:
+      - '0.008063'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -886,7 +846,7 @@ http_interactions:
         representation on the return date."}},"service_levels":[{"level":1,"name":"Family
         Help (Higher)","stage":1,"proceeding_default":true},{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":false}]}'
-  recorded_at: Fri, 03 Feb 2023 10:08:31 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:21 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
@@ -897,54 +857,48 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:08:32 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:21 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '277'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"8bf337339345d42d16a9e6062fb65ccf"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 5b86b20cf5b30fa0b247a6dd59abcb58
-      X-Runtime:
-      - '0.004922'
-      Strict-Transport-Security:
+      x-request-id:
+      - b77b8f59e3a130baab072cc92a70f879
+      x-runtime:
+      - '0.004478'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]'
-  recorded_at: Fri, 03 Feb 2023 10:08:32 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:21 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
@@ -955,54 +909,48 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:08:32 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:22 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '277'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"8bf337339345d42d16a9e6062fb65ccf"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - '08b4627aacd39fa28c11f4371db2303b'
-      X-Runtime:
-      - '0.004794'
-      Strict-Transport-Security:
+      x-request-id:
+      - 58631f02f076efe21334f836c7afd31a
+      x-runtime:
+      - '0.003016'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]'
-  recorded_at: Fri, 03 Feb 2023 10:08:32 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:22 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -1013,47 +961,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:08:33 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:22 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '708'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"05375658d64485716c2575dd3e911e59"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - fa94d7d7cc78939a18055d66dbed2c5c
-      X-Runtime:
-      - '0.008571'
-      Strict-Transport-Security:
+      x-request-id:
+      - efd52e3973e29c34a3a687baa1e8b58f
+      x-runtime:
+      - '0.009566'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -1065,7 +1007,7 @@ http_interactions:
         of arrest to representation on the consideration of the breach by the court
         (but excluding applying for a warrant of arrest, if not attached, and representation
         in contempt proceedings).","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:08:33 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:22 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -1076,47 +1018,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:08:33 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:23 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '708'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"05375658d64485716c2575dd3e911e59"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - fd4acc8eab07fa38f486477f74046aff
-      X-Runtime:
-      - '0.010873'
-      Strict-Transport-Security:
+      x-request-id:
+      - 3d8cecf59b9c914124ec68656842f42d
+      x-runtime:
+      - '0.010020'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -1128,7 +1064,7 @@ http_interactions:
         of arrest to representation on the consideration of the breach by the court
         (but excluding applying for a warrant of arrest, if not attached, and representation
         in contempt proceedings).","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:08:33 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:22 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
@@ -1139,54 +1075,48 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:08:33 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:23 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '277'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"8bf337339345d42d16a9e6062fb65ccf"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - d2498bdf7ec9070488ca1340e97fbe52
-      X-Runtime:
-      - '0.004795'
-      Strict-Transport-Security:
+      x-request-id:
+      - '093ad8b264c959dade1bcace014f34bc'
+      x-runtime:
+      - '0.002920'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]'
-  recorded_at: Fri, 03 Feb 2023 10:08:33 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:23 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
@@ -1197,54 +1127,48 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:08:34 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:23 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '277'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"8bf337339345d42d16a9e6062fb65ccf"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - af39762e752dca75400bb8c14a792a54
-      X-Runtime:
-      - '0.004264'
-      Strict-Transport-Security:
+      x-request-id:
+      - 46781f1f27979bb02e5aa191740d05a6
+      x-runtime:
+      - '0.003975'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]'
-  recorded_at: Fri, 03 Feb 2023 10:08:34 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:23 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -1255,47 +1179,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:08:34 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:24 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '540'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"1886b353521eb91de6839b95785fe23e"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 4b0c1120bcc80ce65fb4824d65ad59e6
-      X-Runtime:
-      - '0.082043'
-      Strict-Transport-Security:
+      x-request-id:
+      - fb30673788141834028d8b4ad8cf5381
+      x-runtime:
+      - '0.009754'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -1304,7 +1222,7 @@ http_interactions:
         to Family Help (Higher) and to all steps necessary to negotiate and conclude
         a settlement. To include the issue of proceedings and representation in those
         proceedings save in relation to or at a contested final hearing.","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:08:34 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:23 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -1315,47 +1233,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:08:41 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:24 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '540'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"1886b353521eb91de6839b95785fe23e"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 66e2eba221a9d0fbc2aa1b68a39ed468
-      X-Runtime:
-      - '0.008657'
-      Strict-Transport-Security:
+      x-request-id:
+      - 46a38797bf824f7cbe7198daedbc8d29
+      x-runtime:
+      - '0.006258'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -1364,5 +1276,5 @@ http_interactions:
         to Family Help (Higher) and to all steps necessary to negotiate and conclude
         a settlement. To include the issue of proceedings and representation in those
         proceedings save in relation to or at a contested final hearing.","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:08:41 GMT
-recorded_with: VCR 6.1.0
+  recorded_at: Wed, 13 Dec 2023 16:27:24 GMT
+recorded_with: VCR 6.2.0

--- a/features/cassettes/Applicant_details/I_can_see_that_the_applicant_does_not_receive_benefits.yml
+++ b/features/cassettes/Applicant_details/I_can_see_that_the_applicant_does_not_receive_benefits.yml
@@ -8,43 +8,39 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:22:47 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:37 GMT
+      content-type:
       - application/json;charset=UTF-8
-      Transfer-Encoding:
+      transfer-encoding:
       - chunked
-      Connection:
+      connection:
       - keep-alive
-      Request-Context:
+      request-context:
       - appId=cid-v1:cd7023ed-37c2-4bb3-b1f3-cd441a39a9ae
-      Vary:
+      vary:
       - Origin,Accept-Encoding,key
-      Omse-Category:
+      omse-category:
       - premium
-      Omse-Transaction-Count:
+      omse-transaction-count:
       - '60'
-      Omse-Premium-Count:
+      omse-premium-count:
       - '0'
-      Strict-Transport-Security:
+      strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: "{\r\n  \"header\" : {\r\n    \"uri\" : \"https://api.os.uk/search/places/v1/postcode?lr=EN&postcode=SW1H9EA\",\r\n
         \   \"query\" : \"postcode=SW1H9EA\",\r\n    \"offset\" : 0,\r\n    \"totalresults\"
         : 5,\r\n    \"format\" : \"JSON\",\r\n    \"dataset\" : \"DPA\",\r\n    \"lr\"
-        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"98\",\r\n    \"lastupdate\"
-        : \"2023-02-02\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
+        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"106\",\r\n    \"lastupdate\"
+        : \"2023-12-12\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
         : [ {\r\n    \"DPA\" : {\r\n      \"UPRN\" : \"100023337883\",\r\n      \"UDPRN\"
         : \"23749699\",\r\n      \"ADDRESS\" : \"SUPER FIRM LTD, 84, PETTY FRANCE,
         LONDON, SW1H 9EA\",\r\n      \"ORGANISATION_NAME\" : \"SUPER FIRM LTD\",\r\n
@@ -136,7 +132,7 @@ http_interactions:
         \     \"ENTRY_DATE\" : \"15/06/2020\",\r\n      \"BLPU_STATE_DATE\" : \"15/06/2020\",\r\n
         \     \"LANGUAGE\" : \"EN\",\r\n      \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\"
         : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\" : \"1N\"\r\n    }\r\n  } ]\r\n}"
-  recorded_at: Fri, 03 Feb 2023 10:22:47 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:37 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -147,47 +143,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:22:47 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:37 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 38107caef18dc89da42212efe01a2221
-      X-Runtime:
-      - '0.034399'
-      Strict-Transport-Security:
+      x-request-id:
+      - 3d17b17b64573e1e2da1560a162b4354
+      x-runtime:
+      - '0.015652'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -312,7 +302,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:22:47 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:37 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -323,47 +313,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:22:49 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:39 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - c60b9613672c699b145234012709b22a
-      X-Runtime:
-      - '0.026993'
-      Strict-Transport-Security:
+      x-request-id:
+      - 91aabed827b66a71baa2833c355fa029
+      x-runtime:
+      - '0.016012'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -488,7 +472,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:22:48 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:39 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/DA004
@@ -499,47 +483,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:22:49 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:39 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '1310'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"fbabf0efd65b63f03290a3f99682b0d4"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - da0d60faaa1359b4a69fa0e29d053451
-      X-Runtime:
-      - '0.017703'
-      Strict-Transport-Security:
+      x-request-id:
+      - a5c65dee7bb9a1681241fa47f512c64b
+      x-runtime:
+      - '0.008569'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -556,7 +534,7 @@ http_interactions:
         for an interim order; where application is made without notice to include
         representation on the return date."}},"service_levels":[{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":true}]}'
-  recorded_at: Fri, 03 Feb 2023 10:22:49 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:39 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
@@ -567,54 +545,48 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:22:49 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:39 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '277'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"8bf337339345d42d16a9e6062fb65ccf"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 4184d989e368a86eff9966c7ceccecf5
-      X-Runtime:
-      - '0.004094'
-      Strict-Transport-Security:
+      x-request-id:
+      - 569c16190fe1bc8fa073ef6229d22ca4
+      x-runtime:
+      - '0.003942'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]'
-  recorded_at: Fri, 03 Feb 2023 10:22:49 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:39 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
@@ -625,54 +597,48 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:22:50 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:40 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '277'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"8bf337339345d42d16a9e6062fb65ccf"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 7f9d5cdb64d7bc309afd2d163e00f19e
-      X-Runtime:
-      - '0.077799'
-      Strict-Transport-Security:
+      x-request-id:
+      - ab3070cd7b7aa4c4ff7af1293989fd24
+      x-runtime:
+      - '0.004376'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]'
-  recorded_at: Fri, 03 Feb 2023 10:22:50 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:40 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -683,47 +649,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:22:50 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:40 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '708'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"05375658d64485716c2575dd3e911e59"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 48954516493b0a3ec059f852ef28795b
-      X-Runtime:
-      - '0.014819'
-      Strict-Transport-Security:
+      x-request-id:
+      - 18d48051bb949e2537e1319d134705ff
+      x-runtime:
+      - '0.010249'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -735,7 +695,7 @@ http_interactions:
         of arrest to representation on the consideration of the breach by the court
         (but excluding applying for a warrant of arrest, if not attached, and representation
         in contempt proceedings).","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:22:50 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:40 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -746,47 +706,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:22:51 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:41 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '708'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"05375658d64485716c2575dd3e911e59"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 40e4d0e58c4ccf3f8e4139a393181492
-      X-Runtime:
-      - '0.013544'
-      Strict-Transport-Security:
+      x-request-id:
+      - 67f2a5228ea36e926022995104d9017a
+      x-runtime:
+      - '0.007276'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -798,5 +752,5 @@ http_interactions:
         of arrest to representation on the consideration of the breach by the court
         (but excluding applying for a warrant of arrest, if not attached, and representation
         in contempt proceedings).","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:22:50 GMT
-recorded_with: VCR 6.1.0
+  recorded_at: Wed, 13 Dec 2023 16:27:40 GMT
+recorded_with: VCR 6.2.0

--- a/features/cassettes/Applicant_details/I_can_see_that_the_applicant_receives_benefits.yml
+++ b/features/cassettes/Applicant_details/I_can_see_that_the_applicant_receives_benefits.yml
@@ -8,43 +8,39 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:12:22 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:29 GMT
+      content-type:
       - application/json;charset=UTF-8
-      Transfer-Encoding:
+      transfer-encoding:
       - chunked
-      Connection:
+      connection:
       - keep-alive
-      Request-Context:
+      request-context:
       - appId=cid-v1:cd7023ed-37c2-4bb3-b1f3-cd441a39a9ae
-      Vary:
+      vary:
       - Origin,Accept-Encoding,key
-      Omse-Category:
+      omse-category:
       - premium
-      Omse-Transaction-Count:
+      omse-transaction-count:
       - '60'
-      Omse-Premium-Count:
+      omse-premium-count:
       - '0'
-      Strict-Transport-Security:
+      strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: "{\r\n  \"header\" : {\r\n    \"uri\" : \"https://api.os.uk/search/places/v1/postcode?lr=EN&postcode=SW1H9EA\",\r\n
         \   \"query\" : \"postcode=SW1H9EA\",\r\n    \"offset\" : 0,\r\n    \"totalresults\"
         : 5,\r\n    \"format\" : \"JSON\",\r\n    \"dataset\" : \"DPA\",\r\n    \"lr\"
-        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"98\",\r\n    \"lastupdate\"
-        : \"2023-02-02\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
+        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"106\",\r\n    \"lastupdate\"
+        : \"2023-12-12\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
         : [ {\r\n    \"DPA\" : {\r\n      \"UPRN\" : \"100023337883\",\r\n      \"UDPRN\"
         : \"23749699\",\r\n      \"ADDRESS\" : \"SUPER FIRM LTD, 84, PETTY FRANCE,
         LONDON, SW1H 9EA\",\r\n      \"ORGANISATION_NAME\" : \"SUPER FIRM LTD\",\r\n
@@ -136,7 +132,7 @@ http_interactions:
         \     \"ENTRY_DATE\" : \"15/06/2020\",\r\n      \"BLPU_STATE_DATE\" : \"15/06/2020\",\r\n
         \     \"LANGUAGE\" : \"EN\",\r\n      \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\"
         : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\" : \"1N\"\r\n    }\r\n  } ]\r\n}"
-  recorded_at: Fri, 03 Feb 2023 10:12:22 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:29 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -147,47 +143,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:12:22 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:29 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 1b70f32ec76dfc06798b204fbfb577d2
-      X-Runtime:
-      - '0.024459'
-      Strict-Transport-Security:
+      x-request-id:
+      - 0f045e6164aaff75ccefc7630cdc0892
+      x-runtime:
+      - '0.015660'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -312,7 +302,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:12:22 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:29 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
@@ -323,47 +313,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:12:23 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:31 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '12573'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"dd6907b8448bc8458adb599124824756"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 1df9c4bfe9c61bc6038434260f69a9d9
-      X-Runtime:
-      - '0.024984'
-      Strict-Transport-Security:
+      x-request-id:
+      - f3761187c986c0ae3e5d7086dded2152
+      x-runtime:
+      - '0.012807'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -488,7 +472,7 @@ http_interactions:
         - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
         be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
         abuse"}]'
-  recorded_at: Fri, 03 Feb 2023 10:12:23 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:31 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/DA004
@@ -499,47 +483,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:12:24 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:31 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '1310'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"fbabf0efd65b63f03290a3f99682b0d4"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 1cb010bd59948d424c486bfb0dcc4880
-      X-Runtime:
-      - '0.014868'
-      Strict-Transport-Security:
+      x-request-id:
+      - 30301d9cd8f4bd3cf65990e518a1c76e
+      x-runtime:
+      - '0.013937'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -556,7 +534,7 @@ http_interactions:
         for an interim order; where application is made without notice to include
         representation on the return date."}},"service_levels":[{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":true}]}'
-  recorded_at: Fri, 03 Feb 2023 10:12:23 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:31 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
@@ -567,54 +545,48 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:12:24 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:31 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '277'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"8bf337339345d42d16a9e6062fb65ccf"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 7e28871cfb8a25b1e5afd04a27f5bf6d
-      X-Runtime:
-      - '0.006138'
-      Strict-Transport-Security:
+      x-request-id:
+      - 2f5408e261f4292658f147ce3e937d59
+      x-runtime:
+      - '0.003901'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]'
-  recorded_at: Fri, 03 Feb 2023 10:12:24 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:31 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types
@@ -625,54 +597,48 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:12:25 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:32 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '277'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"8bf337339345d42d16a9e6062fb65ccf"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - b7e585b95d24c0faaf3c36dd9a686c4e
-      X-Runtime:
-      - '0.010172'
-      Strict-Transport-Security:
+      x-request-id:
+      - '082640a942880838f9ed0ffd8be93c4e'
+      x-runtime:
+      - '0.002937'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]'
-  recorded_at: Fri, 03 Feb 2023 10:12:24 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:32 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -683,47 +649,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:12:26 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:33 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '477'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"f6e255747b495453398cd82197a149da"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 449ea137fa5c80c0af62383e182cb738
-      X-Runtime:
-      - '0.008205'
-      Strict-Transport-Security:
+      x-request-id:
+      - bb9880fe24577e4bb0761c6983e0ec19
+      x-runtime:
+      - '0.008701'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -732,7 +692,7 @@ http_interactions:
         order inc. return date","description":"Limited to all steps necessary to apply
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:12:25 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:33 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -743,47 +703,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:12:26 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:33 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '477'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"f6e255747b495453398cd82197a149da"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - ce2e956c40cae9b0f55b030685bf846c
-      X-Runtime:
-      - '0.011120'
-      Strict-Transport-Security:
+      x-request-id:
+      - 9e79a0c3268ea2540db6e05d43d55977
+      x-runtime:
+      - '0.005982'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -792,7 +746,7 @@ http_interactions:
         order inc. return date","description":"Limited to all steps necessary to apply
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:12:26 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:33 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -803,47 +757,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:12:26 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:33 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '708'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"05375658d64485716c2575dd3e911e59"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 1abe1755e71d90527d83f593d1731149
-      X-Runtime:
-      - '0.012993'
-      Strict-Transport-Security:
+      x-request-id:
+      - 5bcb1cb36faa72a26ef5ab492ce05eae
+      x-runtime:
+      - '0.008890'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -855,7 +803,7 @@ http_interactions:
         of arrest to representation on the consideration of the breach by the court
         (but excluding applying for a warrant of arrest, if not attached, and representation
         in contempt proceedings).","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:12:26 GMT
+  recorded_at: Wed, 13 Dec 2023 16:27:33 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -866,47 +814,41 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      - Faraday v2.7.12
   response:
     status:
       code: 200
       message: OK
     headers:
-      Date:
-      - Fri, 03 Feb 2023 10:12:27 GMT
-      Content-Type:
+      date:
+      - Wed, 13 Dec 2023 16:27:34 GMT
+      content-type:
       - application/json; charset=utf-8
-      Content-Length:
+      content-length:
       - '708'
-      Connection:
+      connection:
       - keep-alive
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
       - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - none
-      Referrer-Policy:
+      referrer-policy:
       - strict-origin-when-cross-origin
-      Vary:
+      vary:
       - Accept, Origin
-      Etag:
+      etag:
       - W/"05375658d64485716c2575dd3e911e59"
-      Cache-Control:
+      cache-control:
       - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - c3073bd2fec652bfeec22c4feb6b6082
-      X-Runtime:
-      - '0.009940'
-      Strict-Transport-Security:
+      x-request-id:
+      - f2b5cc3f249f3f0f081ed9237a10c676
+      x-runtime:
+      - '0.009551'
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
@@ -918,68 +860,5 @@ http_interactions:
         of arrest to representation on the consideration of the breach by the court
         (but excluding applying for a warrant of arrest, if not attached, and representation
         in contempt proceedings).","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:12:26 GMT
-- request:
-    method: post
-    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
-    body:
-      encoding: UTF-8
-      string: '{"proceeding_type_ccms_code":"DA004","delegated_functions_used":false,"client_involvement_type":"A"}'
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Faraday v1.10.3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 03 Feb 2023 10:12:27 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '708'
-      Connection:
-      - keep-alive
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      Referrer-Policy:
-      - strict-origin-when-cross-origin
-      Vary:
-      - Accept, Origin
-      Etag:
-      - W/"05375658d64485716c2575dd3e911e59"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - f86d991db2fae8ebf26437dc6ff0ed8c
-      X-Runtime:
-      - '0.011560'
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"DA004","delegated_functions_used":false,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
-        Representation","stage":8},"default_scope":{"code":"AA019","meaning":"Injunction
-        FLA-to final hearing","description":"As to proceedings under Part IV Family
-        Law Act 1996 limited to all steps up to and including obtaining and serving
-        a final order and in the event of breach leading to the exercise of a power
-        of arrest to representation on the consideration of the breach by the court
-        (but excluding applying for a warrant of arrest, if not attached, and representation
-        in contempt proceedings).","additional_params":[]}}'
-  recorded_at: Fri, 03 Feb 2023 10:12:27 GMT
-recorded_with: VCR 6.1.0
+  recorded_at: Wed, 13 Dec 2023 16:27:34 GMT
+recorded_with: VCR 6.2.0

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -120,7 +120,11 @@ Cucumber::Rails::Database.javascript_strategy = :transaction
 load Rails.root.join("db/seeds.rb")
 
 Before do |_scenario|
+  # prevent bank holiday API calls
+  allow(BankHoliday).to receive(:dates).and_return(%w[2018-01-01])
+
   Populators::TransactionTypePopulator.call
+
   # Delete previous screenshots from filesystem that were generated during previous feature runs
   FileUtils.rm_rf(Rails.root.join("tmp/capybara/**.*"))
 end


### PR DESCRIPTION
## What
Stub all bank holiday API calls for feature test scenarios.

[Leftover from ticket](https://dsdmoj.atlassian.net/browse/AP-4617)

Bank holidays could introduce flakiness plus, with wifi off, the following tests currently fail with:

```sh
cucumber features/providers/applicant_details.feature:3
cucumber features/providers/applicant_details.feature:300

=> 
 Failed to open TCP connection to www.gov.uk:443 (getaddrinfo: nodename nor servname provided, or not known) (SocketError)
      ./app/services/bank_holiday_retriever.rb:27:in `response'
```

Which i believe relates to async sidekiq jobs attempting to call the API and no vcr stubs existing. recording requests with VCR when they originate from sidekiq bakcground jobs does not appear to work and inlineing the sidekiq jobs causes many other calls (to HMRC interface for example) that would then require stubbing/recording. Simply preventing the bank holiday API calls via a stub is the simplest approach I have found.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
