### PR TITLE
Fix: npm Dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,9 +34,14 @@ updates:
   - "ministryofjustice/laa-apply-for-legal-aid"
   groups:
     # Specify a name for the group, which will be used in pull request titles and branch names
-    npm-dependencies:
+    npm-babel:
       # Define patterns to include dependencies in the group (based on # dependency name)
       patterns:
         - "*babel*"
-        - "jest*"  # A wildcard string that matches multiple dependency names syt
+    npm-stylelint:
+      patterns:
         - "stylelint*"
+    npm-jest:
+      # Define patterns to include dependencies in the group (based on # dependency name)
+      patterns:
+        - "jest*"


### PR DESCRIPTION
## What

The previous configuration meant that dependabot would try and group all wildcards into a single PR

This meant, that when a problem occurred, it was hard to isolate the cause

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
