### PR TITLE
Fix circle cache resetting and step deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ jobs:
     - setup_remote_docker
     - *authenticate_k8s_live
     - *decrypt_secrets
-    - deploy:
+    - run:
         name: Helm deployment to UAT
         command: |
           ./bin/uat_deploy
@@ -305,7 +305,7 @@ jobs:
     - setup_remote_docker
     - *decrypt_secrets
     - *authenticate_k8s_live
-    - deploy:
+    - run:
         name: Helm deployment to staging
         command: |
           helm upgrade apply-for-legal-aid ./helm_deploy/apply-for-legal-aid/. \
@@ -322,7 +322,7 @@ jobs:
     - setup_remote_docker
     - *authenticate_k8s_live
     - *decrypt_secrets
-    - deploy:
+    - run:
         name: Helm deployment to production
         command: |
           helm upgrade apply-for-legal-aid ./helm_deploy/apply-for-legal-aid/. \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ executors:
         environment:
           RAILS_ENV: test
           TZ: "Europe/London"
-          CACHE_VERSION: v1
   cloud-platform-executor:
     docker:
       - image: ministryofjustice/cloud-platform-tools:2.7.0
@@ -32,7 +31,6 @@ executors:
       - image: ministryofjustice/apply-ci:latest-3.2.2
         environment:
           RAILS_ENV: test
-          CACHE_VERSION: v1
           NODE_OPTIONS: --openssl-legacy-provider
       - image: cimg/postgres:11.16
       - image: cimg/redis:6.2


### PR DESCRIPTION
## What

- Fix: remove unneeded docker env vars - see [clearing project dependency cache](https://support.circleci.com/hc/en-us/articles/115015426888-Clear-Project-Dependency-Cache)
- Fix: replace deprecated circle step name - [migrate from deploy to run](https://circleci.com/docs/migrate-from-deploy-to-run/)

These references are referring to a Circle project env var
not a docker image env var.

```
{{ .Environment.CACHE_VERSION }}
```

Currently cache names are `blah-<no-value>-blah`


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
