### PR TITLE
AP-4716: Update applicant search response parser

### DIFF
--- a/app/lib/message_logger.rb
+++ b/app/lib/message_logger.rb
@@ -1,0 +1,7 @@
+module MessageLogger
+  def log_message(message)
+    message = "#{self.class}:: #{message}"
+    message = Time.zone.now.strftime("%F %T.%L ") + message if Rails.env.development?
+    Rails.logger.info message
+  end
+end

--- a/app/services/ccms/parsers/applicant_search_response_parser.rb
+++ b/app/services/ccms/parsers/applicant_search_response_parser.rb
@@ -17,9 +17,10 @@ module CCMS
     private
 
       def process_ccms_reference
-        return nil if text_from(MATCH_LEVEL_IND_PATH) == "Number Not Matched"
+        first_match = ni_number_match?(MATCH_LEVEL_IND_PATH)
+        return nil if first_match.nil?
 
-        parse(:extracted_applicant_ccms_reference)
+        parse(:extracted_applicant_ccms_reference, first_match)
       end
 
       def response_type
@@ -34,8 +35,8 @@ module CCMS
         text_from(RECORD_COUNT_PATH)
       end
 
-      def extracted_applicant_ccms_reference
-        doc.xpath(APPLICANT_CCMS_REFERENCE_PATH).first&.text
+      def extracted_applicant_ccms_reference(index = 0)
+        doc.xpath(APPLICANT_CCMS_REFERENCE_PATH)[index]&.text
       end
     end
   end

--- a/app/services/ccms/parsers/applicant_search_response_parser.rb
+++ b/app/services/ccms/parsers/applicant_search_response_parser.rb
@@ -18,6 +18,7 @@ module CCMS
 
       def process_ccms_reference
         first_match = ni_number_match?(MATCH_LEVEL_IND_PATH)
+        log_message("Records Matched: #{extracted_record_count}, MatchLevelInds: #{text_from(MATCH_LEVEL_IND_PATH)}, ChosenMatch: #{first_match}")
         return nil if first_match.nil?
 
         parse(:extracted_applicant_ccms_reference, first_match)

--- a/app/services/ccms/parsers/base_response_parser.rb
+++ b/app/services/ccms/parsers/base_response_parser.rb
@@ -1,6 +1,7 @@
 module CCMS
   module Parsers
     class BaseResponseParser
+      include MessageLogger
       attr_reader :transaction_request_id, :response, :success, :message
 
       def initialize(tx_request_id, response)

--- a/app/services/ccms/parsers/base_response_parser.rb
+++ b/app/services/ccms/parsers/base_response_parser.rb
@@ -14,11 +14,11 @@ module CCMS
         @doc ||= Nokogiri::XML(response.to_s).remove_namespaces!
       end
 
-      def parse(data_method)
+      def parse(data_method, *)
         check_matching_transaction_request_ids if expect_transaction_request_id_in_response?
 
         extract_result_status
-        __send__(data_method)
+        __send__(data_method, *)
       end
 
       def extracted_id_matches_request_id?
@@ -27,6 +27,15 @@ module CCMS
 
       def text_from(xpath)
         doc.xpath(xpath).text
+      end
+
+      def ni_number_match?(xpath)
+        matches = doc.xpath(xpath).map(&:text)
+        if matches.all?("Number Not Matched")
+          nil
+        else
+          matches.each_index.find { |i| matches[i].include? "Number Matched" }
+        end
       end
 
     private

--- a/app/services/ccms/submitters/base_submission_service.rb
+++ b/app/services/ccms/submitters/base_submission_service.rb
@@ -10,6 +10,7 @@ module CCMS
 
   module Submitters
     class BaseSubmissionService
+      include MessageLogger
       attr_accessor :submission
 
       def initialize(submission)

--- a/app/services/ccms/submitters/obtain_applicant_reference_service.rb
+++ b/app/services/ccms/submitters/obtain_applicant_reference_service.rb
@@ -23,12 +23,14 @@ module CCMS
       def process_records(parser)
         applicant_ccms_reference = parser.applicant_ccms_reference
         if applicant_ccms_reference.nil?
-          create_history(:case_ref_obtained, submission.aasm_state, xml_request, response)
+          history = create_history(:case_ref_obtained, submission.aasm_state, xml_request, response)
+          log_message("SubmissionHistory: #{history.id}: Creating new applicant in CCMS")
           CCMS::Submitters::AddApplicantService.new(submission).call
         else
           submission.applicant_ccms_reference = applicant_ccms_reference
           submission.save!
-          create_history(:case_ref_obtained, submission.aasm_state, xml_request, response) if submission.obtain_applicant_ref!
+          history = create_history(:case_ref_obtained, submission.aasm_state, xml_request, response) if submission.obtain_applicant_ref!
+          log_message("SubmissionHistory: #{history.id}: using existing applicant reference #{applicant_ccms_reference}")
         end
       end
 

--- a/spec/data/ccms/applicant_search_response_multiple_number_not_matched.xml
+++ b/spec/data/ccms/applicant_search_response_multiple_number_not_matched.xml
@@ -1,0 +1,91 @@
+<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:wsa="http://www.w3.org/2005/08/addressing">
+  <env:Header>
+    <instra:tracking.ecid wsa:IsReferenceParameter="1" xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0" xmlns:wsa="http://www.w3.org/2005/08/addressing">be91808f-e069-40a9-8858-8f2fe35ded25-001db0f4</instra:tracking.ecid>
+    <instra:tracking.parentComponentInstanceId wsa:IsReferenceParameter="1" xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0" xmlns:wsa="http://www.w3.org/2005/08/addressing">mediator:233108951</instra:tracking.parentComponentInstanceId>
+    <instra:tracking.parentReferenceId wsa:IsReferenceParameter="1" xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0" xmlns:wsa="http://www.w3.org/2005/08/addressing">mediator:233108951:dbc7479a-3dad-11ed-9fed-0a58a9feac03:req</instra:tracking.parentReferenceId>
+    <instra:tracking.FlowEventId wsa:IsReferenceParameter="1" xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0" xmlns:wsa="http://www.w3.org/2005/08/addressing">597852472</instra:tracking.FlowEventId>
+    <instra:tracking.FlowId wsa:IsReferenceParameter="1" xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0" xmlns:wsa="http://www.w3.org/2005/08/addressing">24180278</instra:tracking.FlowId>
+    <instra:tracking.CorrelationFlowId wsa:IsReferenceParameter="1" xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0" xmlns:wsa="http://www.w3.org/2005/08/addressing">0000ODuNCW9EoId5PfS4yd1Z6CJA001^Aa</instra:tracking.CorrelationFlowId>
+    <instra:tracking.quiescing.SCAEntityId wsa:IsReferenceParameter="1" xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0" xmlns:wsa="http://www.w3.org/2005/08/addressing">10064</instra:tracking.quiescing.SCAEntityId>
+    <instra:tracking.ecid xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">be91808f-e069-40a9-8858-8f2fe35ded25-001db0f4</instra:tracking.ecid>
+    <instra:tracking.FlowEventId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">597852532</instra:tracking.FlowEventId>
+    <instra:tracking.FlowId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">24180278</instra:tracking.FlowId>
+    <instra:tracking.CorrelationFlowId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">0000ODuNCW9EoId5PfS4yd1Z6CJA001^Aa</instra:tracking.CorrelationFlowId>
+    <instra:tracking.quiescing.SCAEntityId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">10064</instra:tracking.quiescing.SCAEntityId>
+    <wsa:To>http://www.w3.org/2005/08/addressing/anonymous</wsa:To>
+    <wsa:Action>process</wsa:Action>
+    <wsa:MessageID>urn:e7cafda1-3dad-11ed-9fed-0a58a9feac03</wsa:MessageID>
+    <wsa:RelatesTo>urn:dbc76eae-3dad-11ed-9fed-0a58a9feac03</wsa:RelatesTo>
+    <wsa:ReplyTo>
+      <wsa:Address>http://www.w3.org/2005/08/addressing/anonymous</wsa:Address>
+      <wsa:ReferenceParameters>
+        <instra:tracking.ecid xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">be91808f-e069-40a9-8858-8f2fe35ded25-001db0f4</instra:tracking.ecid>
+        <instra:tracking.conversationId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">urn:dbc76eae-3dad-11ed-9fed-0a58a9feac03</instra:tracking.conversationId>
+        <instra:tracking.FlowEventId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">597852536</instra:tracking.FlowEventId>
+        <instra:tracking.FlowId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">24180278</instra:tracking.FlowId>
+        <instra:tracking.CorrelationFlowId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">0000ODuNCW9EoId5PfS4yd1Z6CJA001^Aa</instra:tracking.CorrelationFlowId>
+        <instra:tracking.quiescing.SCAEntityId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">10064</instra:tracking.quiescing.SCAEntityId>
+      </wsa:ReferenceParameters>
+    </wsa:ReplyTo>
+    <wsa:FaultTo>
+      <wsa:Address>http://www.w3.org/2005/08/addressing/anonymous</wsa:Address>
+    </wsa:FaultTo>
+  </env:Header>
+  <env:Body>
+    <ClientInqRS xmlns="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIM" xmlns:msg="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIM" xmlns:oracle-xsl-mapper="http://www.oracle.com/xsl/mapper/schemas" xmlns:wsa="http://www.w3.org/2005/08/addressing">
+      <header:HeaderRS xmlns:header="http://legalservices.gov.uk/Enterprise/Common/1.0/Header">
+        <header:TransactionID>202209261614043422799016219</header:TransactionID>
+        <header:RequestDetails>
+          <header:TransactionRequestID>202209261614043422799016219</header:TransactionRequestID>
+          <header:Language>ENG</header:Language>
+          <header:UserLoginID>my_login</header:UserLoginID>
+          <header:UserRole>my_role</header:UserRole>
+        </header:RequestDetails>
+        <header:Status>
+          <header:Status>Success</header:Status>
+          <header:StatusFreeText>End of Get Party details process.</header:StatusFreeText>
+        </header:Status>
+      </header:HeaderRS>
+      <msg:RecordCount>
+        <common:MaxRecordsToFetch xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">200</common:MaxRecordsToFetch>
+        <common:RecordsFetched xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">2</common:RecordsFetched>
+        <common:RetriveDataOnMaxCount xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">false</common:RetriveDataOnMaxCount>
+      </msg:RecordCount>
+      <msg:ClientList>
+        <msg:Client>
+          <client:Name xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">
+            <common:Title xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">MS.</common:Title>
+            <common:Surname xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">SHORT</common:Surname>
+            <common:FirstName xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">carla</common:FirstName>
+            <common:MiddleName xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">JENNA</common:MiddleName>
+            <common:SurnameAtBirth xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">short</common:SurnameAtBirth>
+            <common:FullName xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">carla SHORT</common:FullName>
+          </client:Name>
+          <client:DateOfBirth xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">1987-07-26</client:DateOfBirth>
+          <client:Gender xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">Female</client:Gender>
+          <client:PostalCode xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">CV34 8YA</client:PostalCode>
+          <client:ClientReferenceNumber xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">5590639</client:ClientReferenceNumber>
+          <client:HomeOfficeReference xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">NA</client:HomeOfficeReference>
+          <client:NINumber xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">BR123456C</client:NINumber>
+          <client:MatchLevelInd xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">Number Not Matched</client:MatchLevelInd>
+        </msg:Client>
+        <msg:Client>
+          <client:Name xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">
+            <common:Title xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">MS.</common:Title>
+            <common:Surname xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">Short</common:Surname>
+            <common:FirstName xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">CARLA</common:FirstName>
+            <common:SurnameAtBirth xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">SHORT</common:SurnameAtBirth>
+            <common:FullName xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">CARLA Short</common:FullName>
+          </client:Name>
+          <client:DateOfBirth xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">1987-07-26</client:DateOfBirth>
+          <client:Gender xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">Female</client:Gender>
+          <client:PostalCode xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">DE56 9DS</client:PostalCode>
+          <client:ClientReferenceNumber xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">2499559</client:ClientReferenceNumber>
+          <client:HomeOfficeReference xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">07597530156</client:HomeOfficeReference>
+          <client:NINumber xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">BR123456C</client:NINumber>
+          <client:MatchLevelInd xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">Number Not Matched</client:MatchLevelInd>
+        </msg:Client>
+      </msg:ClientList>
+    </ClientInqRS>
+  </env:Body>
+</env:Envelope>

--- a/spec/data/ccms/applicant_search_response_multiple_results.xml
+++ b/spec/data/ccms/applicant_search_response_multiple_results.xml
@@ -21,116 +21,44 @@
         </header:Status>
       </header:HeaderRS>
       <msg:RecordCount>
+        <common:MaxRecordsToFetch xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">200</common:MaxRecordsToFetch>
         <common:RecordsFetched xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">2</common:RecordsFetched>
+        <common:RetriveDataOnMaxCount xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">false</common:RetriveDataOnMaxCount>
       </msg:RecordCount>
       <msg:ClientList>
-      <msg:Client>
-        <client:ClientReferenceNumber xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">4390017</client:ClientReferenceNumber>
-        <client:Details xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">
-          <client:Name>
+        <msg:Client>
+          <client:Name xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">
             <common:Title xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">MR.</common:Title>
             <common:Surname xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">Mercator</common:Surname>
             <common:FirstName xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">Thomas</common:FirstName>
             <common:SurnameAtBirth xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">NA</common:SurnameAtBirth>
             <common:FullName xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">Thomas Mercator</common:FullName>
           </client:Name>
-          <client:PersonalInformation>
-            <client:DateOfBirth>1972-10-31</client:DateOfBirth>
-            <client:Gender>MALE</client:Gender>
-            <client:MaritalStatus>S</client:MaritalStatus>
-            <client:NINumber>RK699791A</client:NINumber>
-            <client:HomeOfficeNumber>XXXX</client:HomeOfficeNumber>
-            <client:VulnerableClient>false</client:VulnerableClient>
-            <client:HighProfileClient>false</client:HighProfileClient>
-            <client:VexatiousLitigant>false</client:VexatiousLitigant>
-            <client:CountryOfOrigin>GBR</client:CountryOfOrigin>
-            <client:MentalCapacityInd>false</client:MentalCapacityInd>
-          </client:PersonalInformation>
-          <client:Contacts>
-            <client:TelephoneHome>01234567890</client:TelephoneHome>
-            <client:PasswordReminder>hello</client:PasswordReminder>
-            <client:CorrespondenceMethod>LETTER</client:CorrespondenceMethod>
-            <client:CorrespondenceLanguage>ENGLISH</client:CorrespondenceLanguage>
-          </client:Contacts>
-          <client:NoFixedAbode>false</client:NoFixedAbode>
-          <client:Address>
-            <common:AddressID xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">363045</common:AddressID>
-            <common:House xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">32</common:House>
-            <common:AddressLine1 xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">111 Park street</common:AddressLine1>
-            <common:City xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">Boxgrove</common:City>
-            <common:Country xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">GBR</common:Country>
-            <common:County xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">West Sussex</common:County>
-            <common:PostalCode xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">PO18 8HQ</common:PostalCode>
-          </client:Address>
-          <client:EthnicMonitoring>WB</client:EthnicMonitoring>
-        </client:Details>
-        <client:RecordHistory xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">
-          <common:CreatedBy xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">
-            <common:UserLoginID>created_login_id</common:UserLoginID>
-            <common:UserName>created_user_name</common:UserName>
-          </common:CreatedBy>
-          <common:DateCreated xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">2016-06-13T11:06:26.0Z</common:DateCreated>
-          <common:LastUpdatedBy xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">
-            <common:UserLoginID>updated_login_id</common:UserLoginID>
-            <common:UserName>updated_user_name</common:UserName>
-          </common:LastUpdatedBy>
-          <common:DateLastUpdated xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">2016-06-14T13:07:52.0Z</common:DateLastUpdated>
-        </client:RecordHistory>
-      </msg:Client>
-      <msg:Client>
-        <client:ClientReferenceNumber xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">4390018</client:ClientReferenceNumber>
-        <client:Details xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">
-          <client:Name>
+          <client:DateOfBirth xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">1972-10-31</client:DateOfBirth>
+          <client:Gender xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">MALE</client:Gender>
+          <common:PostalCode xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">PO18 8HQ</common:PostalCode>
+          <client:ClientReferenceNumber xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">4390017</client:ClientReferenceNumber>
+          <client:HomeOfficeReference xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">XXXX</client:HomeOfficeReference>
+          <client:NINumber xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">RK699791A</client:NINumber>
+          <client:MatchLevelInd xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">Number Matched</client:MatchLevelInd>
+        </msg:Client>
+        <msg:Client>
+          <client:Name xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">
             <common:Title xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">MR.</common:Title>
             <common:Surname xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">Mercator</common:Surname>
             <common:FirstName xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">Thomas</common:FirstName>
             <common:SurnameAtBirth xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">NA</common:SurnameAtBirth>
             <common:FullName xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">Thomas Mercator</common:FullName>
           </client:Name>
-          <client:PersonalInformation>
-            <client:DateOfBirth>1972-10-31</client:DateOfBirth>
-            <client:Gender>MALE</client:Gender>
-            <client:MaritalStatus>S</client:MaritalStatus>
-            <client:NINumber>RK699791A</client:NINumber>
-            <client:HomeOfficeNumber>XXXX</client:HomeOfficeNumber>
-            <client:VulnerableClient>false</client:VulnerableClient>
-            <client:HighProfileClient>false</client:HighProfileClient>
-            <client:VexatiousLitigant>false</client:VexatiousLitigant>
-            <client:CountryOfOrigin>GBR</client:CountryOfOrigin>
-            <client:MentalCapacityInd>false</client:MentalCapacityInd>
-          </client:PersonalInformation>
-          <client:Contacts>
-            <client:TelephoneHome>01234567890</client:TelephoneHome>
-            <client:PasswordReminder>hello</client:PasswordReminder>
-            <client:CorrespondenceMethod>LETTER</client:CorrespondenceMethod>
-            <client:CorrespondenceLanguage>ENGLISH</client:CorrespondenceLanguage>
-          </client:Contacts>
-          <client:NoFixedAbode>false</client:NoFixedAbode>
-          <client:Address>
-            <common:AddressID xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">363045</common:AddressID>
-            <common:House xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">32</common:House>
-            <common:AddressLine1 xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">111 Park street</common:AddressLine1>
-            <common:City xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">Boxgrove</common:City>
-            <common:Country xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">GBR</common:Country>
-            <common:County xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">West Sussex</common:County>
-            <common:PostalCode xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">PO18 8HQ</common:PostalCode>
-          </client:Address>
-          <client:EthnicMonitoring>WB</client:EthnicMonitoring>
-        </client:Details>
-        <client:RecordHistory xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">
-          <common:CreatedBy xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">
-            <common:UserLoginID>created_login_id</common:UserLoginID>
-            <common:UserName>created_user_name</common:UserName>
-          </common:CreatedBy>
-          <common:DateCreated xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">2016-06-13T11:06:26.0Z</common:DateCreated>
-          <common:LastUpdatedBy xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">
-            <common:UserLoginID>updated_login_id</common:UserLoginID>
-            <common:UserName>updated_user_name</common:UserName>
-          </common:LastUpdatedBy>
-          <common:DateLastUpdated xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">2016-06-14T13:07:52.0Z</common:DateLastUpdated>
-        </client:RecordHistory>
-      </msg:Client>
-      <msg:ClientList>
+          <client:DateOfBirth xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">1972-10-31</client:DateOfBirth>
+          <client:Gender xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">MALE</client:Gender>
+          <common:PostalCode xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">PO18 8HQ</common:PostalCode>
+          <client:ClientReferenceNumber xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">4390018</client:ClientReferenceNumber>
+          <client:HomeOfficeNumber xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">XXXX</client:HomeOfficeNumber>
+          <client:NINumber xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">RK699791A</client:NINumber>
+          <client:MatchLevelInd xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">Number Matched</client:MatchLevelInd>
+        </msg:Client>
+      </msg:ClientList>
     </ClientInqRS>
   </env:Body>
 </env:Envelope>

--- a/spec/data/ccms/applicant_search_response_number_not_held.xml
+++ b/spec/data/ccms/applicant_search_response_number_not_held.xml
@@ -1,0 +1,78 @@
+<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:wsa="http://www.w3.org/2005/08/addressing">
+  <env:Header>
+    <wsa:To xmlns:wsa="http://www.w3.org/2005/08/addressing">http://www.w3.org/2005/08/addressing/anonymous</wsa:To>
+    <wsa:MessageID xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:02C2E960C60F11ECBFFFA9028DC8B183</wsa:MessageID>
+    <wsa:RelatesTo xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:FCB3B400C60E11ECBF68BD66E45C90AB</wsa:RelatesTo>
+    <wsa:ReplyTo xmlns:wsa="http://www.w3.org/2005/08/addressing">
+      <wsa:Address>http://www.w3.org/2005/08/addressing/anonymous</wsa:Address>
+      <wsa:ReferenceParameters/>
+    </wsa:ReplyTo>
+    <wsa:FaultTo xmlns:wsa="http://www.w3.org/2005/08/addressing">
+      <wsa:Address>http://www.w3.org/2005/08/addressing/anonymous</wsa:Address>
+      <wsa:ReferenceParameters/>
+    </wsa:FaultTo>
+    <instra:tracking.ecid wsa:IsReferenceParameter="1" xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0" xmlns:wsa="http://www.w3.org/2005/08/addressing">522cb393-cdf5-4262-a99e-5d26a277ca9b-009a8e2a</instra:tracking.ecid>
+    <instra:tracking.parentComponentInstanceId wsa:IsReferenceParameter="1" xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0" xmlns:wsa="http://www.w3.org/2005/08/addressing">reference:1905513748</instra:tracking.parentComponentInstanceId>
+    <instra:tracking.compositeInstanceCreatedTime wsa:IsReferenceParameter="1" xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0" xmlns:wsa="http://www.w3.org/2005/08/addressing">2022-04-27T10:47:01.293+01:00</instra:tracking.compositeInstanceCreatedTime>
+    <instra:tracking.compositeInstanceCreatedTime xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">2022-04-27T10:47:01.293+01:00</instra:tracking.compositeInstanceCreatedTime>
+    <wsa:To>http://www.w3.org/2005/08/addressing/anonymous</wsa:To>
+    <wsa:MessageID>urn:aef8ad25-f3d1-11ec-b228-0a58a9feac17</wsa:MessageID>
+    <wsa:RelatesTo>urn:a8d8136a-f3d1-11ec-99c7-0a58a9feac1a</wsa:RelatesTo>
+    <wsa:ReplyTo>
+      <wsa:Address>http://www.w3.org/2005/08/addressing/anonymous</wsa:Address>
+      <wsa:ReferenceParameters>
+        <instra:tracking.ecid xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">522cb393-cdf5-4262-a99e-5d26a277ca9b-009a8e2a</instra:tracking.ecid>
+        <instra:tracking.conversationId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">urn:FCB3B400C60E11ECBF68BD66E45C90AB</instra:tracking.conversationId>
+        <instra:tracking.compositeInstanceCreatedTime xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">2022-04-27T10:47:01.293+01:00</instra:tracking.compositeInstanceCreatedTime>
+      </wsa:ReferenceParameters>
+    </wsa:ReplyTo>
+    <wsa:FaultTo>
+      <wsa:Address>http://www.w3.org/2005/08/addressing/anonymous</wsa:Address>
+      <wsa:ReferenceParameters>
+        <instra:tracking.ecid xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">522cb393-cdf5-4262-a99e-5d26a277ca9b-009a8e2a</instra:tracking.ecid>
+        <instra:tracking.conversationId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">urn:FCB3B400C60E11ECBF68BD66E45C90AB</instra:tracking.conversationId>
+        <instra:tracking.compositeInstanceCreatedTime xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">2022-04-27T10:47:01.293+01:00</instra:tracking.compositeInstanceCreatedTime>
+      </wsa:ReferenceParameters>
+    </wsa:FaultTo>
+  </env:Header>
+  <env:Body>
+    <ClientInqRS xmlns="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIM" xmlns:msg="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIM" xmlns:wsa="http://www.w3.org/2005/08/addressing">
+      <header:HeaderRS xmlns:header="http://legalservices.gov.uk/Enterprise/Common/1.0/Header">
+        <header:TransactionID>202206241623547511370989944</header:TransactionID>
+        <header:RequestDetails>
+          <header:TransactionRequestID>202206241623547511370989944</header:TransactionRequestID>
+          <header:Language>ENG</header:Language>
+          <header:UserLoginID>my_login</header:UserLoginID>
+          <header:UserRole>mr_role</header:UserRole>
+        </header:RequestDetails>
+        <header:Status>
+          <header:Status>Success</header:Status>
+          <header:StatusFreeText>End of Get Party details process.</header:StatusFreeText>
+        </header:Status>
+      </header:HeaderRS>
+      <msg:RecordCount>
+        <common:MaxRecordsToFetch xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">200</common:MaxRecordsToFetch>
+        <common:RecordsFetched xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">1</common:RecordsFetched>
+        <common:RetriveDataOnMaxCount xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">false</common:RetriveDataOnMaxCount>
+      </msg:RecordCount>
+      <msg:ClientList>
+        <msg:Client>
+          <client:Name xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">
+            <common:Title xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">MS.</common:Title>
+            <common:Surname xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">Smith</common:Surname>
+            <common:FirstName xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">Sarah</common:FirstName>
+            <common:SurnameAtBirth xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">Smith</common:SurnameAtBirth>
+            <common:FullName xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">Sarah Smith</common:FullName>
+          </client:Name>
+          <client:DateOfBirth xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">1988-10-07</client:DateOfBirth>
+          <client:Gender xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">Female</client:Gender>
+          <client:PostalCode xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">SW1A 1AA</client:PostalCode>
+          <client:ClientReferenceNumber xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">60004249</client:ClientReferenceNumber>
+          <client:HomeOfficeReference xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">NA</client:HomeOfficeReference>
+          <client:NINumber xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">NA</client:NINumber>
+          <client:MatchLevelInd xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">Number Not Held</client:MatchLevelInd>
+        </msg:Client>
+      </msg:ClientList>
+    </ClientInqRS>
+  </env:Body>
+</env:Envelope>

--- a/spec/data/ccms/applicant_search_response_number_not_matched.xml
+++ b/spec/data/ccms/applicant_search_response_number_not_matched.xml
@@ -1,41 +1,17 @@
 <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:wsa="http://www.w3.org/2005/08/addressing">
   <env:Header>
-    <instra:tracking.ecid xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0" wsa:IsReferenceParameter="1"
-                          xmlns:wsa="http://www.w3.org/2005/08/addressing">522cb393-cdf5-4262-a99e-5d26a277ca9b-009a8e2a
-    </instra:tracking.ecid>
-    <instra:tracking.parentComponentInstanceId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0"
-                                               wsa:IsReferenceParameter="1"
-                                               xmlns:wsa="http://www.w3.org/2005/08/addressing">mediator:114930162
-    </instra:tracking.parentComponentInstanceId>
-    <instra:tracking.parentReferenceId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0"
-                                       wsa:IsReferenceParameter="1" xmlns:wsa="http://www.w3.org/2005/08/addressing">
-      mediator:114930162:a8d81366-f3d1-11ec-99c7-0a58a9feac1a:req
-    </instra:tracking.parentReferenceId>
-    <instra:tracking.FlowEventId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0" wsa:IsReferenceParameter="1"
-                                 xmlns:wsa="http://www.w3.org/2005/08/addressing">298327062
-    </instra:tracking.FlowEventId>
-    <instra:tracking.FlowId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0" wsa:IsReferenceParameter="1"
-                            xmlns:wsa="http://www.w3.org/2005/08/addressing">11622465
-    </instra:tracking.FlowId>
-    <instra:tracking.CorrelationFlowId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0"
-                                       wsa:IsReferenceParameter="1" xmlns:wsa="http://www.w3.org/2005/08/addressing">
-      0000O6MK08rCSsd5Pf9Did1YC9oS007GUD
-    </instra:tracking.CorrelationFlowId>
-    <instra:tracking.quiescing.SCAEntityId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0"
-                                           wsa:IsReferenceParameter="1"
-                                           xmlns:wsa="http://www.w3.org/2005/08/addressing">10064
-    </instra:tracking.quiescing.SCAEntityId>
-    <instra:tracking.ecid xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">
-      522cb393-cdf5-4262-a99e-5d26a277ca9b-009a8e2a
-    </instra:tracking.ecid>
-    <instra:tracking.FlowEventId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">298319098
-    </instra:tracking.FlowEventId>
+    <instra:tracking.ecid xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0" wsa:IsReferenceParameter="1" xmlns:wsa="http://www.w3.org/2005/08/addressing">522cb393-cdf5-4262-a99e-5d26a277ca9b-009a8e2a</instra:tracking.ecid>
+    <instra:tracking.parentComponentInstanceId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0" wsa:IsReferenceParameter="1" xmlns:wsa="http://www.w3.org/2005/08/addressing">mediator:114930162</instra:tracking.parentComponentInstanceId>
+    <instra:tracking.parentReferenceId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0" wsa:IsReferenceParameter="1" xmlns:wsa="http://www.w3.org/2005/08/addressing">mediator:114930162:a8d81366-f3d1-11ec-99c7-0a58a9feac1a:req</instra:tracking.parentReferenceId>
+    <instra:tracking.FlowEventId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0" wsa:IsReferenceParameter="1" xmlns:wsa="http://www.w3.org/2005/08/addressing">298327062</instra:tracking.FlowEventId>
+    <instra:tracking.FlowId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0" wsa:IsReferenceParameter="1" xmlns:wsa="http://www.w3.org/2005/08/addressing">11622465</instra:tracking.FlowId>
+    <instra:tracking.CorrelationFlowId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0" wsa:IsReferenceParameter="1" xmlns:wsa="http://www.w3.org/2005/08/addressing">0000O6MK08rCSsd5Pf9Did1YC9oS007GUD</instra:tracking.CorrelationFlowId>
+    <instra:tracking.quiescing.SCAEntityId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0" wsa:IsReferenceParameter="1" xmlns:wsa="http://www.w3.org/2005/08/addressing">10064</instra:tracking.quiescing.SCAEntityId>
+    <instra:tracking.ecid xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">522cb393-cdf5-4262-a99e-5d26a277ca9b-009a8e2a</instra:tracking.ecid>
+    <instra:tracking.FlowEventId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">298319098</instra:tracking.FlowEventId>
     <instra:tracking.FlowId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">11622465</instra:tracking.FlowId>
-    <instra:tracking.CorrelationFlowId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">
-      0000O6MK08rCSsd5Pf9Did1YC9oS007GUD
-    </instra:tracking.CorrelationFlowId>
-    <instra:tracking.quiescing.SCAEntityId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">10064
-    </instra:tracking.quiescing.SCAEntityId>
+    <instra:tracking.CorrelationFlowId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">0000O6MK08rCSsd5Pf9Did1YC9oS007GUD</instra:tracking.CorrelationFlowId>
+    <instra:tracking.quiescing.SCAEntityId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">10064</instra:tracking.quiescing.SCAEntityId>
     <wsa:To>http://www.w3.org/2005/08/addressing/anonymous</wsa:To>
     <wsa:Action>process</wsa:Action>
     <wsa:MessageID>urn:aef8ad25-f3d1-11ec-b228-0a58a9feac17</wsa:MessageID>
@@ -43,21 +19,12 @@
     <wsa:ReplyTo>
       <wsa:Address>http://www.w3.org/2005/08/addressing/anonymous</wsa:Address>
       <wsa:ReferenceParameters>
-        <instra:tracking.ecid xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">
-          522cb393-cdf5-4262-a99e-5d26a277ca9b-009a8e2a
-        </instra:tracking.ecid>
-        <instra:tracking.conversationId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">
-          urn:a8d8136a-f3d1-11ec-99c7-0a58a9feac1a
-        </instra:tracking.conversationId>
-        <instra:tracking.FlowEventId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">298327240
-        </instra:tracking.FlowEventId>
-        <instra:tracking.FlowId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">11622465
-        </instra:tracking.FlowId>
-        <instra:tracking.CorrelationFlowId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">
-          0000O6MK08rCSsd5Pf9Did1YC9oS007GUD
-        </instra:tracking.CorrelationFlowId>
-        <instra:tracking.quiescing.SCAEntityId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">10064
-        </instra:tracking.quiescing.SCAEntityId>
+        <instra:tracking.ecid xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">522cb393-cdf5-4262-a99e-5d26a277ca9b-009a8e2a</instra:tracking.ecid>
+        <instra:tracking.conversationId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">urn:a8d8136a-f3d1-11ec-99c7-0a58a9feac1a</instra:tracking.conversationId>
+        <instra:tracking.FlowEventId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">298327240</instra:tracking.FlowEventId>
+        <instra:tracking.FlowId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">11622465</instra:tracking.FlowId>
+        <instra:tracking.CorrelationFlowId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">0000O6MK08rCSsd5Pf9Did1YC9oS007GUD</instra:tracking.CorrelationFlowId>
+        <instra:tracking.quiescing.SCAEntityId xmlns:instra="http://xmlns.oracle.com/sca/tracking/1.0">10064</instra:tracking.quiescing.SCAEntityId>
       </wsa:ReferenceParameters>
     </wsa:ReplyTo>
     <wsa:FaultTo>
@@ -65,17 +32,14 @@
     </wsa:FaultTo>
   </env:Header>
   <env:Body>
-    <ClientInqRS xmlns:msg="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIM"
-                 xmlns:oracle-xsl-mapper="http://www.oracle.com/xsl/mapper/schemas"
-                 xmlns="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIM"
-                 xmlns:wsa="http://www.w3.org/2005/08/addressing">
+    <ClientInqRS xmlns:msg="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIM" xmlns:oracle-xsl-mapper="http://www.oracle.com/xsl/mapper/schemas" xmlns="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIM" xmlns:wsa="http://www.w3.org/2005/08/addressing">
       <header:HeaderRS xmlns:header="http://legalservices.gov.uk/Enterprise/Common/1.0/Header">
         <header:TransactionID>202206241623547511370989944</header:TransactionID>
         <header:RequestDetails>
           <header:TransactionRequestID>202206241623547511370989944</header:TransactionRequestID>
           <header:Language>ENG</header:Language>
-          <header:UserLoginID>ANNA@LEWISRODGERS.CO.UK</header:UserLoginID>
-          <header:UserRole>EXTERNAL</header:UserRole>
+          <header:UserLoginID>my_login</header:UserLoginID>
+          <header:UserRole>my_role</header:UserRole>
         </header:RequestDetails>
         <header:Status>
           <header:Status>Success</header:Status>
@@ -83,12 +47,9 @@
         </header:Status>
       </header:HeaderRS>
       <msg:RecordCount>
-        <common:MaxRecordsToFetch xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">200
-        </common:MaxRecordsToFetch>
-        <common:RecordsFetched xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">1
-        </common:RecordsFetched>
-        <common:RetriveDataOnMaxCount xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">false
-        </common:RetriveDataOnMaxCount>
+        <common:MaxRecordsToFetch xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">200</common:MaxRecordsToFetch>
+        <common:RecordsFetched xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">1</common:RecordsFetched>
+        <common:RetriveDataOnMaxCount xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">false</common:RetriveDataOnMaxCount>
       </msg:RecordCount>
       <msg:ClientList>
         <msg:Client>

--- a/spec/data/ccms/applicant_search_response_one_result.xml
+++ b/spec/data/ccms/applicant_search_response_one_result.xml
@@ -21,61 +21,28 @@
         </header:Status>
       </header:HeaderRS>
       <msg:RecordCount>
+        <common:MaxRecordsToFetch xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">200</common:MaxRecordsToFetch>
         <common:RecordsFetched xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">1</common:RecordsFetched>
+        <common:RetriveDataOnMaxCount xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">false</common:RetriveDataOnMaxCount>
       </msg:RecordCount>
-      <msg:Client>
-        <client:ClientReferenceNumber xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">4390016</client:ClientReferenceNumber>
-        <client:Details xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">
-          <client:Name>
+      <msg:ClientList>
+        <msg:Client>
+          <client:Name  xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">
             <common:Title xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">MR.</common:Title>
             <common:Surname xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">Mercator</common:Surname>
             <common:FirstName xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">Thomas</common:FirstName>
             <common:SurnameAtBirth xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">NA</common:SurnameAtBirth>
             <common:FullName xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">Thomas Mercator</common:FullName>
           </client:Name>
-          <client:PersonalInformation>
-            <client:DateOfBirth>1972-10-31</client:DateOfBirth>
-            <client:Gender>MALE</client:Gender>
-            <client:MaritalStatus>S</client:MaritalStatus>
-            <client:NINumber>RK699791A</client:NINumber>
-            <client:HomeOfficeNumber>XXXX</client:HomeOfficeNumber>
-            <client:VulnerableClient>false</client:VulnerableClient>
-            <client:HighProfileClient>false</client:HighProfileClient>
-            <client:VexatiousLitigant>false</client:VexatiousLitigant>
-            <client:CountryOfOrigin>GBR</client:CountryOfOrigin>
-            <client:MentalCapacityInd>false</client:MentalCapacityInd>
-          </client:PersonalInformation>
-          <client:Contacts>
-            <client:TelephoneHome>01234567890</client:TelephoneHome>
-            <client:PasswordReminder>hello</client:PasswordReminder>
-            <client:CorrespondenceMethod>LETTER</client:CorrespondenceMethod>
-            <client:CorrespondenceLanguage>ENGLISH</client:CorrespondenceLanguage>
-          </client:Contacts>
-          <client:NoFixedAbode>false</client:NoFixedAbode>
-          <client:Address>
-            <common:AddressID xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">363045</common:AddressID>
-            <common:House xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">32</common:House>
-            <common:AddressLine1 xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">111 Park street</common:AddressLine1>
-            <common:City xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">Boxgrove</common:City>
-            <common:Country xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">GBR</common:Country>
-            <common:County xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">West Sussex</common:County>
-            <common:PostalCode xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">PO18 8HQ</common:PostalCode>
-          </client:Address>
-          <client:EthnicMonitoring>WB</client:EthnicMonitoring>
-        </client:Details>
-        <client:RecordHistory xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">
-          <common:CreatedBy xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">
-            <common:UserLoginID>created_login_id</common:UserLoginID>
-            <common:UserName>created_user_name</common:UserName>
-          </common:CreatedBy>
-          <common:DateCreated xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">2016-06-13T11:06:26.0Z</common:DateCreated>
-          <common:LastUpdatedBy xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">
-            <common:UserLoginID>updated_login_id</common:UserLoginID>
-            <common:UserName>updated_user_name</common:UserName>
-          </common:LastUpdatedBy>
-          <common:DateLastUpdated xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">2016-06-14T13:07:52.0Z</common:DateLastUpdated>
-        </client:RecordHistory>
-      </msg:Client>
+          <client:DateOfBirth xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">1972-10-31</client:DateOfBirth>
+          <client:Gender xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">MALE</client:Gender>
+          <common:PostalCode xmlns:common="http://legalservices.gov.uk/Enterprise/Common/1.0/Common">PO18 8HQ</common:PostalCode>
+          <client:ClientReferenceNumber xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">4390016</client:ClientReferenceNumber>
+          <client:HomeOfficeReference xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">XXXX</client:HomeOfficeReference>
+          <client:NINumber xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">RK699791A</client:NINumber>
+          <client:MatchLevelInd xmlns:client="http://legalservices.gov.uk/CCMS/ClientManagement/Client/1.0/ClientBIO">Number Matched</client:MatchLevelInd>
+        </msg:Client>
+      </msg:ClientList>
     </ClientInqRS>
   </env:Body>
 </env:Envelope>

--- a/spec/services/ccms/parsers/applicant_search_response_parser_spec.rb
+++ b/spec/services/ccms/parsers/applicant_search_response_parser_spec.rb
@@ -95,9 +95,31 @@ module CCMS
           end
         end
 
-        context "when the transaction id is not matched" do
+        context "when the Client NI number is returned as Number Not Matched" do
           let(:expected_tx_id) { "202206241623547511370989944" }
           let(:parser) { described_class.new(expected_tx_id, number_not_matched_response_xml) }
+
+          describe "#applicant_ccms_reference" do
+            it "returns nil" do
+              expect(parser.applicant_ccms_reference).to be_nil
+            end
+          end
+        end
+
+        context "when the Client NI number is returned as Number Not Held" do
+          let(:expected_tx_id) { "202206241623547511370989944" }
+          let(:parser) { described_class.new(expected_tx_id, ccms_data_from_file("applicant_search_response_number_not_held.xml")) }
+
+          describe "#applicant_ccms_reference" do
+            it "returns nil" do
+              expect(parser.applicant_ccms_reference).to be_nil
+            end
+          end
+        end
+
+        context "when there are multiple Client NI numbers returned as Number Not Matched" do
+          let(:expected_tx_id) { "202209261614043422799016219" }
+          let(:parser) { described_class.new(expected_tx_id, ccms_data_from_file("applicant_search_response_multiple_number_not_matched.xml")) }
 
           describe "#applicant_ccms_reference" do
             it "returns nil" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4716)

Following the recent discovery of issues at the CCMS end of our submissions, issues with identifying applicants were discovered.  This PR addresses the following, newly identified, issues with the ApplicantSearchResponseParser:
* when an applicant matches surname and DOB but has no NINO, it would return `Number Not held`
* If two records for the same values were returned with `Number Not Matched` the previous equality check would fail because it would resolve to does `Number Not Matched` equal `Number Not MatchedNumber Not Matched`

This adds tests for the new scenarios and updates the validation checks for the new scenarios

While investigating I discovered that the existing XML example files did not match the current returns from CCMS so I amended them to better match the data that is currently returned.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
