### PR TITLE
AP-4694: SAML login sequence change

### DIFF
--- a/app/controllers/saml_sessions_controller.rb
+++ b/app/controllers/saml_sessions_controller.rb
@@ -23,13 +23,21 @@ class SamlSessionsController < Devise::SamlSessionsController
 
   def after_sign_in_path_for(_provider)
     session[:journey_type] = :providers
-    providers_confirm_office_path
+    show_office_select? ? providers_confirm_office_path : root_path
   end
 
 private
 
   def update_provider_details
     ProviderAfterLoginService.call(current_provider)
+  end
+
+  def show_office_select?
+    [
+      page_history.last(10).include?("/"), # recently seen the root path
+      page_history.last(10).grep(/\/\?locale=.*$/).any?, # recently seen the root path with a locale
+      ActiveRecord::Type::Boolean.new.cast(Rails.configuration.x.laa_portal.mock_saml) || false, # mock_saml is true
+    ].any?(true)
   end
 
   # :nocov:

--- a/app/views/providers/start/index.html.erb
+++ b/app/views/providers/start/index.html.erb
@@ -13,6 +13,6 @@
 
     <p class="govuk-body"><%= t(".use_ccms_para_html") %></p>
 
-    <%= govuk_start_button(text: t("generic.start_now"), href: providers_legal_aid_applications_path, html_attributes: { id: "start" }) %>
+    <%= govuk_start_button(text: t("generic.start_now"), href: providers_confirm_office_path, html_attributes: { id: "start" }) %>
   </div>
 </div>

--- a/features/providers/cookies.feature
+++ b/features/providers/cookies.feature
@@ -58,6 +58,9 @@ Feature: Cookies
     Given I am logged in as a provider
     Given I visit the application service
     And I click link "Start"
+    Then I choose 'London'
+    Then I click 'Save and continue'
+
     And I click link "Make a new application"
     And I click link "Accept analytics cookies"
 

--- a/features/providers/mock_saml.feature
+++ b/features/providers/mock_saml.feature
@@ -1,9 +1,9 @@
 Feature: Mock saml test
   @javascript
-  Scenario: A provider can login with mock saml data
+  Scenario: A provider can login with mock saml data from the start page
     Given I visit the root page
     And I click link 'start'
     When I enter the email address 'test1@example.com'
     And I enter the password 'password'
     And I submit to saml
-    Then I should be on the 'select_office' page showing 'Select the account number of the office handling this application'
+    Then I should be on a page with title "Select the account number of the office handling this application"

--- a/features/providers/non_means_tested_journey/under_18_application_journey.feature
+++ b/features/providers/non_means_tested_journey/under_18_application_journey.feature
@@ -6,6 +6,8 @@ Feature: Under 18 applicant journey
 
     When I visit the application service
     And I click link "Start"
+    Then I choose 'London'
+    Then I click 'Save and continue'
     And I click link "Make a new application"
     Then I should be on the 'providers/declaration' page showing 'Declaration'
 

--- a/features/providers/non_means_tested_journey/with_delegated_functions.feature
+++ b/features/providers/non_means_tested_journey/with_delegated_functions.feature
@@ -6,6 +6,8 @@ Feature: Non-means-tested applicant journey with use of delegation functions
 
     When I visit the application service
     And I click link "Start"
+    Then I choose 'London'
+    Then I click 'Save and continue'
     And I click link "Make a new application"
     Then I should be on the 'providers/declaration' page showing 'Declaration'
 

--- a/features/providers/non_means_tested_journey/without_delegated_functions.feature
+++ b/features/providers/non_means_tested_journey/without_delegated_functions.feature
@@ -6,6 +6,8 @@ Feature: Non-means-tested applicant journey without use of delegation functions
 
     When I visit the application service
     And I click link "Start"
+    Then I choose 'London'
+    Then I click 'Save and continue'
     And I click link "Make a new application"
     Then I should be on the 'providers/declaration' page showing 'Declaration'
 

--- a/features/providers/search_applications.feature
+++ b/features/providers/search_applications.feature
@@ -5,5 +5,7 @@ Feature: Search applications
     And An application has been created
     Then I visit the application service
     Then I click link "Start"
+    Then I choose 'London'
+    Then I click 'Save and continue'
     Then I click link "Search applications"
     Then I should be on a page showing "Search applications"

--- a/features/providers/search_proceedings.feature
+++ b/features/providers/search_proceedings.feature
@@ -5,6 +5,8 @@ Feature: Search proceedings
     Given I am logged in as a provider
     Given I visit the application service
     And I click link "Start"
+    Then I choose 'London'
+    Then I click 'Save and continue'
     And I click link "Make a new application"
     Then I should be on the 'providers/declaration' page showing 'Declaration'
     When I click 'Agree and continue'
@@ -26,6 +28,8 @@ Feature: Search proceedings
     Given I am logged in as a provider
     Given I visit the application service
     And I click link "Start"
+    Then I choose 'London'
+    Then I click 'Save and continue'
     And I click link "Make a new application"
     Then I should be on the 'providers/declaration' page showing 'Declaration'
     When I click 'Agree and continue'

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -168,6 +168,8 @@ Given("I start the journey as far as the applicant page") do
     Given I am logged in as a provider
     Given I visit the application service
     And I click link "Start"
+    Then I choose 'London'
+    Then I click 'Save and continue'
     And I click link "Make a new application"
     Then I should be on the 'providers/declaration' page showing 'Declaration'
     When I click 'Agree and continue'

--- a/features/step_definitions/cookie_steps.rb
+++ b/features/step_definitions/cookie_steps.rb
@@ -9,6 +9,8 @@ Given("I start the journey without cookie preferences") do
 
     When I visit the application service
     And I click link "Start"
+    Then I choose 'London'
+    Then I click 'Save and continue'
     Then I am on the legal aid applications page
     And I should see 'Cookies on Apply for legal aid'
   )
@@ -25,6 +27,8 @@ Given("I start the journey with expired cookie preferences") do
 
     When I visit the application service
     And I click link "Start"
+    Then I choose 'London'
+    Then I click 'Save and continue'
     Then I am on the legal aid applications page
     And I should see 'Cookies on Apply for legal aid'
   )

--- a/spec/requests/saml_sessions_spec.rb
+++ b/spec/requests/saml_sessions_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe "SamlSessionsController" do
   let(:username) { "bob the builder" }
   let(:provider_details_api_url) { "#{Rails.configuration.x.provider_details.url}#{username.gsub(' ', '%20')}" }
   let(:provider_details_api_reponse) { api_response.to_json }
+  let(:enable_mock_saml) { false }
+
+  before { allow(Rails.configuration.x.laa_portal).to receive(:mock_saml).and_return(enable_mock_saml) }
 
   describe "DELETE /providers/sign_out" do
     subject(:delete_request) { delete destroy_provider_session_path }
@@ -67,9 +70,18 @@ RSpec.describe "SamlSessionsController" do
             expect(firm.offices.first.ccms_id).to eq raw_details_response[:providerOffices].first[:id].to_s
           end
 
-          it "displays the select office page" do
+          context "when mock_saml is activated" do
+            let(:enable_mock_saml) { true }
+
+            it "displays the select office page" do
+              post_request
+              expect(response).to redirect_to providers_confirm_office_path
+            end
+          end
+
+          it "displays the root page" do
             post_request
-            expect(response).to redirect_to providers_confirm_office_path
+            expect(response).to redirect_to root_path
           end
         end
 
@@ -90,9 +102,9 @@ RSpec.describe "SamlSessionsController" do
             expect(provider.invalid_login_details).to eq "role"
           end
 
-          it "redirects to the confirm office path" do
+          it "redirects to the root path" do
             post_request
-            expect(response).to redirect_to providers_confirm_office_path
+            expect(response).to redirect_to root_path
           end
         end
 
@@ -111,9 +123,9 @@ RSpec.describe "SamlSessionsController" do
             expect(provider.invalid_login_details).to eq "api_details_user_not_found"
           end
 
-          it "redirects to confirm offices page" do
+          it "redirects to the start page" do
             post_request
-            expect(response).to redirect_to providers_confirm_office_path
+            expect(response).to redirect_to root_path
           end
         end
 
@@ -144,9 +156,9 @@ RSpec.describe "SamlSessionsController" do
           ProviderDetailsCreatorWorker.drain
         end
 
-        it "redirects to confirm offices page" do
+        it "redirects to start page" do
           post_request
-          expect(response).to redirect_to providers_confirm_office_path
+          expect(response).to redirect_to root_path
         end
       end
 
@@ -169,9 +181,9 @@ RSpec.describe "SamlSessionsController" do
             expect(firm.offices.first.ccms_id).to eq raw_details_response[:providerOffices].first[:id].to_s
           end
 
-          it "displays the select office page" do
+          it "displays the start page" do
             post_request
-            expect(response).to redirect_to providers_confirm_office_path
+            expect(response).to redirect_to root_path
           end
         end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4694)

This changes the login flow, we know that providers generally start from the portal and then directed into our service from there.

This meant that we routed them to the office select screen and they did not see the Start/Declaration page
![image](https://github.com/ministryofjustice/laa-apply-for-legal-aid/assets/6757677/524b2a1e-92f0-4c62-9157-2f17753f98fa)

This PR changes the login flow to only show the office choice page if the user has seen the root_page within the last 10 page views in the service, or we are using the mock saml provider, otherwise they will be shown the root page

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
