### PR TITLE
Chore: Remove Rails Secret deprecation warning

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -9,8 +9,11 @@ Devise.setup do |config|
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
-  # by default. You can change it below and use your own secret key.
-  # config.secret_key = '0f8bffbdad1a8d4a8add95fea3197e1e6d9e7566dcdc60af17892e9a258430a8ca29cd82071fd5bfb9ce67a5685de4e608f052ff8c782217b8641024d0409d52'
+  # by default.
+  # This is set explicitly to remove a deprecation warning during the Rails 7.1
+  # to 7.2 transition, if Devise is set above 4.9.3, try removing it to see if
+  # the deprecation warning has been removed
+  config.secret_key = Rails.application.secret_key_base
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.


### PR DESCRIPTION
## What

This is set explicitly to remove a deprecation warning during the Rails 7.1 to 7.2 transition, if Devise is set above 4.9.3, try removing it to see if the deprecation warning has been addressed

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
