### PR TITLE
Fix: remove duplicate DocumentIdRequestor call

### DIFF
--- a/app/services/ccms/submitters/obtain_document_id_service.rb
+++ b/app/services/ccms/submitters/obtain_document_id_service.rb
@@ -53,8 +53,8 @@ module CCMS
         raise
       end
 
-      def ccms_document_id(dir)
-        Parsers::DocumentIdResponseParser.new(dir.transaction_request_id, dir.call).document_id
+      def ccms_document_id(transaction_request_id, response)
+        Parsers::DocumentIdResponseParser.new(transaction_request_id, response).document_id
       end
 
       def document_id_requestor(document_type)
@@ -62,9 +62,10 @@ module CCMS
       end
 
       def update_document_and_return_response(document, document_id_requestor)
-        document.ccms_document_id = ccms_document_id(document_id_requestor)
+        response = document_id_requestor.call
+        document.ccms_document_id = ccms_document_id(document_id_requestor.transaction_request_id, response)
         document.status = :id_obtained
-        document_id_requestor.call
+        response
       end
 
       def failed_requesting_ids


### PR DESCRIPTION
## What

This came out of the CCMS dance review.

The DocumentIdRequestor was called on line 57 when it was extracted into a separate method.

It was then called it again and the end of the `update_document_and_return_response` method and, best case, did nothing with the duplicate call.

Worst case, it (correctly) saved number 00001 into the database and then logged 00002 into the submission history

This would have made tracking issues harder, and created empty rows in the CCMS database, but not have been a significant error

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
