### PR TITLE
AP-4735: Update hint text on address lookup page

### DIFF
--- a/app/views/providers/address_lookups/show.html.erb
+++ b/app/views/providers/address_lookups/show.html.erb
@@ -13,6 +13,7 @@
       ) do %>
 
     <%= form.govuk_fieldset legend: { size: "xl", tag: "h1", text: t(".heading") }  do %>
+      <p class="govuk-body"><%= t(".helper_text") %></p>
       <%= form.govuk_text_field :postcode, label: { text: t(".label"), tag: "h2", size: "m" }, width: 10 %>
     <% end %>
 

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -31,6 +31,10 @@ en:
         heading: Enter your client's correspondence address
         label: Postcode
         submit_button: Find address
+        helper_text:
+          The address you provide is only for this application. If your client has
+          other certificated legal aid cases where a different address has been used,
+          you should review and update those records in CCMS.
     address_selections:
       show:
         heading: Enter your client's correspondence address


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4735)

Update hint text on address lookup page to what's shown in the screenshot below.

Screenshot:
![image](https://github.com/ministryofjustice/laa-apply-for-legal-aid/assets/13471320/716d0256-4e5f-48b1-a490-eccd6f7f4d11)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
