### PR TITLE
Fix: Partner means

### DIFF
--- a/app/models/cfe/submission.rb
+++ b/app/models/cfe/submission.rb
@@ -6,7 +6,7 @@ module CFE
     has_many :submission_histories, -> { order(created_at: :asc) }, inverse_of: :submission
     has_one :result, class_name: "BaseResult", dependent: :destroy
 
-    delegate :passported?, :non_passported?, :uploading_bank_statements?, to: :legal_aid_application
+    delegate :passported?, :non_passported?, :uploading_bank_statements?, :client_uploading_bank_statements?, to: :legal_aid_application
 
     def version_6?
       return false if cfe_result.nil?

--- a/app/services/cfe_civil/component_list.rb
+++ b/app/services/cfe_civil/component_list.rb
@@ -64,7 +64,7 @@ module CFECivil
     def service_set
       if object.passported?
         PASSPORTED_SERVICES
-      elsif object.non_passported? && object.uploading_bank_statements?
+      elsif object.non_passported? && object.client_uploading_bank_statements?
         NON_PASSPORTED_WITH_REGULAR_TRANSACTIONS_SERVICES
       elsif object.non_passported?
         NON_PASSPORTED_WITH_BANK_TRANSACTIONS_SERVICES

--- a/app/views/shared/check_answers/_assets.html.erb
+++ b/app/views/shared/check_answers/_assets.html.erb
@@ -10,7 +10,7 @@
   <%= render "shared/check_answers/vehicles", read_only:, individual: %>
 
   <h2 class="govuk-heading-m"><%= t(".assets.bank_accounts") %></h2>
-  <% if @legal_aid_application.non_passported? && !@legal_aid_application.uploading_bank_statements? %>
+  <% if @legal_aid_application.non_passported? && !@legal_aid_application.client_uploading_bank_statements? %>
     <!-- non-passported truelayer only -->
 
     <% if read_only %>

--- a/app/views/shared/check_answers/_income_details.html.erb
+++ b/app/views/shared/check_answers/_income_details.html.erb
@@ -3,7 +3,7 @@
     <% income_detail_items(@legal_aid_application).each do |item| %>
       <%= render "shared/means_report/item", item.to_h %>
     <% end %>
-    <%= render "shared/means_report/total", name: "total_income", value_method: :total_gross_income_assessed %>
+    <%= render "shared/means_report/total", name: "total_income", value_method: :combined_total_gross_income_assessed %>
   </dl>
 
 </section>

--- a/spec/services/cfe_civil/component_list_spec.rb
+++ b/spec/services/cfe_civil/component_list_spec.rb
@@ -23,7 +23,7 @@ module CFECivil
       end
 
       context "when object is non_passported? but not uploading_bank_statements?" do
-        let(:object) { instance_double(CFE::Submission, passported?: false, non_passported?: true, uploading_bank_statements?: false) }
+        let(:object) { instance_double(CFE::Submission, passported?: false, non_passported?: true, client_uploading_bank_statements?: false) }
 
         it "returns set of non passported CFE::Service classes" do
           expect(call).to match([
@@ -47,7 +47,7 @@ module CFECivil
       end
 
       context "when object is non_passported? and uploading_bank_statements?" do
-        let(:object) { instance_double(LegalAidApplication, passported?: false, non_passported?: true, uploading_bank_statements?: true) }
+        let(:object) { instance_double(LegalAidApplication, passported?: false, non_passported?: true, client_uploading_bank_statements?: true) }
 
         it "returns set of non passported CFE::Service classes" do
           expect(call).to match([


### PR DESCRIPTION

## What

After a partner run through we saw some issues and this fixes some of them
* Update the means report income summary to use the combined total instead of the client total
* Update asset partial to show truelayer bank accounts as well as the manually entered values
* Update the CFECivil component list to ensure that truelayer data is sent when the partner uploads bank statements

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
