### PR TITLE
ap-3772: attempt to fix failures on proceeding search

### DIFF
--- a/docs/puffing_billy_recording.md
+++ b/docs/puffing_billy_recording.md
@@ -51,7 +51,7 @@ If you want to record a request and response, either to use in a feature test or
 3. run the feature (with debug to view request being made of billy's proxy)
 
   ```shell
-  DEBUG_BILLY=true cuke features/providers/applicant_details.feature:3
+  DEBUG_BILLY=true cucumber features/providers/applicant_details.feature:3
   ```
 
 4. The requests should appear in the configured folder
@@ -76,5 +76,5 @@ To rerecord a request cache simply delete the file and rerun the feature.
 You can display all calls that puffing-billy proxied using an env var as below.
 
 ```shell
-DEBUG_BILLY=true cuke features/providers/applicant_details.feature:3
+DEBUG_BILLY=true cucumber features/providers/applicant_details.feature:3
 ```

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -887,7 +887,7 @@ Then(/^proceeding suggestions has (results|no results)$/) do |results|
   wait_for_ajax
   case results
   when "results"
-    expect(page).to have_css("#proceeding-list .proceeding-item", wait: 10)
+    expect(page).to have_css("#proceeding-list .proceeding-item")
   when "no results"
     expect(page).to have_no_css("#proceeding-list .proceeding-item")
   end

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -887,7 +887,7 @@ Then(/^proceeding suggestions has (results|no results)$/) do |results|
   wait_for_ajax
   case results
   when "results"
-    expect(page).to have_css("#proceeding-list .proceeding-item")
+    expect(page).to have_css("#proceeding-list .proceeding-item", wait: 10)
   when "no results"
     expect(page).to have_no_css("#proceeding-list .proceeding-item")
   end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -53,13 +53,12 @@ end
 Capybara.default_driver = :headless_chrome
 Capybara.javascript_driver = :headless_chrome
 
-if ENV["BROWSER"] == "chrome"
-  Capybara.register_driver :chrome do |app|
-    Capybara::Selenium::Driver.new(app, browser: :chrome)
-  end
-
-  Capybara.configure do |config|
-    config.default_max_wait_time = 10 # seconds
+Capybara.configure do |config|
+  config.default_max_wait_time = 10 # seconds
+  if ENV["BROWSER"] == "chrome"
+    Capybara.register_driver :chrome do |app|
+      Capybara::Selenium::Driver.new(app, browser: :chrome)
+    end
     config.javascript_driver = :chrome
   end
 end


### PR DESCRIPTION
The purpose of this pr is to try and resolve (some) of the circleci integration test failures we are seeing. Looking [here](https://app.circleci.com/insights/gh/ministryofjustice/laa-apply-for-legal-aid/workflows/merge_pr/tests?branch=main) it appears the most common test failures are still on applicant_details.feature. We [previously](https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/6041) attempted to resolve these by introducing puffing billy to stub calls made in javascript to LFA and I do believe this has worked when the test failed due to network connectivity, as the applicant_details.feature test passes for me when run locally with wifi switched off.

I therefore think the remaining failures are a result of a timing issue/race condition. The failures we are seeing on circle seem to look like this:-

`expected to find visible css "#proceeding-list .proceeding-item" but there were no matches. Also found "", "", "", "Non-molestation order\nFamily (Domestic abuse)", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", which matched the selector but not all filters.  (RSpec::Expectations::ExpectationNotMetError)
`

I noticed running the test locally (bundle exec cucumber features/providers/applicant_details.feature) that although we define a default_max_wait_time of 10 seconds [here](https://github.com/ministryofjustice/laa-apply-for-legal-aid/blob/9d53972897c1f67923fd74e9e25b64e219e29d1e/features/support/env.rb#L62), if I force the test to fail, e.g. by changing [this line](https://github.com/ministryofjustice/laa-apply-for-legal-aid/blob/9d53972897c1f67923fd74e9e25b64e219e29d1e/features/providers/applicant_details.feature#L14) to

`Then I search for proceeding 'XXX'`

it doesn't seem to wait for the 10 seconds for the expectation to be met. Adding a binding.pry to one the integration test steps revealed that (at least when running locally with bundle exec cucumber) default_max_wait_time was being set to 2 - the Capybara default - rather than 10, possibly not long enough for some asynchronous processes to to complete. I have amended the config in features/support/env.rb to apply the default_max_wait_time of 10 for all browsers. Do we think this is worth a go to see if it resolves the integration test failures.


## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3772)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
