### PR TITLE
AP-4759: Update partner means

### DIFF
--- a/app/models/cfe/submission.rb
+++ b/app/models/cfe/submission.rb
@@ -6,7 +6,7 @@ module CFE
     has_many :submission_histories, -> { order(created_at: :asc) }, inverse_of: :submission
     has_one :result, class_name: "BaseResult", dependent: :destroy
 
-    delegate :passported?, :non_passported?, :uploading_bank_statements?, to: :legal_aid_application
+    delegate :passported?, :non_passported?, :uploading_bank_statements?, :client_uploading_bank_statements?, to: :legal_aid_application
 
     def version_6?
       return false if cfe_result.nil?

--- a/app/services/cfe_civil/component_list.rb
+++ b/app/services/cfe_civil/component_list.rb
@@ -64,7 +64,7 @@ module CFECivil
     def service_set
       if object.passported?
         PASSPORTED_SERVICES
-      elsif object.non_passported? && object.uploading_bank_statements?
+      elsif object.non_passported? && object.client_uploading_bank_statements?
         NON_PASSPORTED_WITH_REGULAR_TRANSACTIONS_SERVICES
       elsif object.non_passported?
         NON_PASSPORTED_WITH_BANK_TRANSACTIONS_SERVICES

--- a/app/views/providers/means/check_income_answers/_applicant_income_assessment.html.erb
+++ b/app/views/providers/means/check_income_answers/_applicant_income_assessment.html.erb
@@ -1,4 +1,4 @@
-<% bank_statement_upload = @legal_aid_application.uploading_bank_statements? %>
+<% bank_statement_upload = @legal_aid_application.client_uploading_bank_statements? %>
 
 <section class="applicant">
   <h2 class="govuk-heading-l govuk-!-margin-bottom-8"><%= t(".income-heading") %></h2>

--- a/app/views/shared/check_answers/_assets.html.erb
+++ b/app/views/shared/check_answers/_assets.html.erb
@@ -35,7 +35,7 @@
 
       <h3 class="govuk-heading-m"><%= t(".assets.money_in_bank_accounts") %></h3>
 
-      <%= govuk_summary_list(classes: "govuk-!-margin-bottom-0", html_attributes: { "data-test": "applicant-bank-accounts" }) do |summary_list| %>
+      <%= govuk_summary_list(classes: "govuk-!-margin-bottom-9", html_attributes: { "data-test": "applicant-bank-accounts" }) do |summary_list| %>
         <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__online_current_accounts" }) do |row| %>
           <%= row.with_key(text: @legal_aid_application&.applicant&.has_partner? ? t(".assets.client_current_account") : t(".assets.current_accounts"), classes: "govuk-!-width-one-half") %>
           <%= row.with_value { online_current_accounts.present? ? gds_number_to_currency(online_current_accounts) : t("generic.none") } %>
@@ -65,7 +65,7 @@
         </div>
       <% end %>
     </div>
-    <%= govuk_summary_list(classes: "govuk-!-margin-bottom-0", html_attributes: { id: "app-check-your-answers__bank_accounts_items", "data-test": "applicant-bank-accounts" }) do |summary_list| %>
+    <%= govuk_summary_list(classes: "govuk-!-margin-bottom-9", html_attributes: { id: "app-check-your-answers__bank_accounts_items", "data-test": "applicant-bank-accounts" }) do |summary_list| %>
       <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__offline_current_accounts" }) do |row| %>
         <%= row.with_key(text: @legal_aid_application&.applicant&.has_partner? ? t(".assets.client_current_account") : t(".assets.current_accounts"), classes: "govuk-!-width-one-half") %>
         <%= row.with_value { @legal_aid_application&.savings_amount&.offline_current_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.offline_current_accounts) : t("generic.none") } %>
@@ -83,7 +83,7 @@
                     else
                       :offline_accounts
                     end %>
-    <div class="govuk-grid-row govuk-!-padding-top-9" id="app-check-your-answers__partner_offline_accounts_link">
+    <div class="govuk-grid-row" id="app-check-your-answers__partner_offline_accounts_link">
       <% if read_only == false %>
         <div class="govuk-grid-column-two-thirds">
           <h3 class="govuk-heading-m"><%= t(".assets.partner_bank_accounts") %></h3>
@@ -99,7 +99,7 @@
         </div>
       <% end %>
     </div>
-    <%= govuk_summary_list(classes: "govuk-!-margin-bottom-0", html_attributes: { "data-test": "partner-bank-accounts" }) do |summary_list| %>
+    <%= govuk_summary_list(classes: "govuk-!-margin-bottom-9", html_attributes: { "data-test": "partner-bank-accounts" }) do |summary_list| %>
       <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__partner_offline_current_accounts" }) do |row| %>
         <%= row.with_key(text: t(".assets.partner_current_account"), classes: "govuk-!-width-one-half") %>
         <%= row.with_value { @legal_aid_application.savings_amount.partner_offline_current_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.partner_offline_current_accounts) : t("generic.none") } %>
@@ -111,7 +111,7 @@
     <% end %>
 
     <% if @legal_aid_application.uploading_bank_statements? || !@legal_aid_application.non_passported? %>
-      <div class="govuk-grid-row govuk-!-padding-top-9" id="app-check-your-answers__joint_offline_accounts_link">
+      <div class="govuk-grid-row" id="app-check-your-answers__joint_offline_accounts_link">
         <% if read_only == false %>
           <div class="govuk-grid-column-two-thirds">
             <h3 class="govuk-heading-m"><%= t(".assets.joint_bank_accounts") %></h3>
@@ -127,7 +127,7 @@
           </div>
         <% end %>
       </div>
-      <%= govuk_summary_list(classes: "govuk-!-margin-bottom-0", html_attributes: { "data-test": "joint-bank-accounts" }) do |summary_list| %>
+      <%= govuk_summary_list(classes: "govuk-!-margin-bottom-9", html_attributes: { "data-test": "joint-bank-accounts" }) do |summary_list| %>
         <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__joint_offline_current_accounts" }) do |row| %>
           <%= row.with_key(text: t(".assets.joint_current_account"), classes: "govuk-!-width-one-half") %>
           <%= row.with_value { @legal_aid_application.savings_amount.joint_offline_current_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.joint_offline_current_accounts) : t("generic.none") } %>
@@ -141,12 +141,12 @@
   <% end %>
 
   <% if @legal_aid_application.non_passported? && !@legal_aid_application.uploading_bank_statements? %>
-    <div class="govuk-!-padding-top-9">
+    <div class="govuk-!-padding-bottom-9">
       <%= render "shared/check_answers/offline_savings_accounts", read_only: %>
     </div>
   <% end %>
 
-  <div class="govuk-!-padding-top-9">
+  <div class="govuk-!-padding-bottom-9">
     <%= render(
           "shared/check_answers/one_link_section",
           name: :savings_and_investments,

--- a/app/views/shared/check_answers/_assets.html.erb
+++ b/app/views/shared/check_answers/_assets.html.erb
@@ -1,6 +1,10 @@
 <% read_only = false unless local_assigns.key?(:read_only) %>
 <% online_savings_accounts = @legal_aid_application.online_savings_accounts_balance %>
 <% online_current_accounts = @legal_aid_application.online_current_accounts_balance %>
+<% showing_bank_accounts = @legal_aid_application.partner_uploading_bank_statements? ||
+     (@legal_aid_application.applicant.bank_accounts.empty? && read_only) ||
+     @legal_aid_application&.savings_amount&.offline_savings_accounts.present? ||
+     @legal_aid_application&.savings_amount&.offline_current_accounts.present? %>
 
 <section class="print-no-break">
   <%= render "shared/check_answers/property", read_only:, individual: %>
@@ -9,7 +13,9 @@
 <section class="print-no-break">
   <%= render "shared/check_answers/vehicles", read_only:, individual: %>
 
+<% if showing_bank_accounts %>
   <h2 class="govuk-heading-m"><%= t(".assets.bank_accounts") %></h2>
+<% end %>
   <% if @legal_aid_application.non_passported? && !@legal_aid_application.client_uploading_bank_statements? %>
     <!-- non-passported truelayer only -->
 

--- a/app/views/shared/check_answers/_assets.html.erb
+++ b/app/views/shared/check_answers/_assets.html.erb
@@ -10,7 +10,7 @@
   <%= render "shared/check_answers/vehicles", read_only:, individual: %>
 
   <h2 class="govuk-heading-m"><%= t(".assets.bank_accounts") %></h2>
-  <% if @legal_aid_application.non_passported? && !@legal_aid_application.uploading_bank_statements? %>
+  <% if @legal_aid_application.non_passported? && !@legal_aid_application.client_uploading_bank_statements? %>
     <!-- non-passported truelayer only -->
 
     <% if read_only %>

--- a/app/views/shared/check_answers/_income_details.html.erb
+++ b/app/views/shared/check_answers/_income_details.html.erb
@@ -3,7 +3,7 @@
     <% income_detail_items(@legal_aid_application).each do |item| %>
       <%= render "shared/means_report/item", item.to_h %>
     <% end %>
-    <%= render "shared/means_report/total", name: "total_income", value_method: :total_gross_income_assessed %>
+    <%= render "shared/means_report/total", name: "total_income", value_method: :combined_total_gross_income_assessed %>
   </dl>
 
 </section>

--- a/spec/services/cfe_civil/component_list_spec.rb
+++ b/spec/services/cfe_civil/component_list_spec.rb
@@ -23,7 +23,7 @@ module CFECivil
       end
 
       context "when object is non_passported? but not uploading_bank_statements?" do
-        let(:object) { instance_double(CFE::Submission, passported?: false, non_passported?: true, uploading_bank_statements?: false) }
+        let(:object) { instance_double(CFE::Submission, passported?: false, non_passported?: true, client_uploading_bank_statements?: false) }
 
         it "returns set of non passported CFE::Service classes" do
           expect(call).to match([
@@ -47,7 +47,7 @@ module CFECivil
       end
 
       context "when object is non_passported? and uploading_bank_statements?" do
-        let(:object) { instance_double(LegalAidApplication, passported?: false, non_passported?: true, uploading_bank_statements?: true) }
+        let(:object) { instance_double(LegalAidApplication, passported?: false, non_passported?: true, client_uploading_bank_statements?: true) }
 
         it "returns set of non passported CFE::Service classes" do
           expect(call).to match([


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4759)

Based off the work on #6254 which was undertaken before the stakeholder run through - feel free to review entirely but the first three commits have been reviewed on the original PR

### Original work 
After a partner run through we saw some issues and this fixes some of them

* Update the means report income summary to use the combined total instead of the client total
* Update asset partial to show truelayer bank accounts as well as the manually entered values
* Update the CFECivil component list to ensure that truelayer data is sent when the partner uploads bank statements

### Updated work
* Update applicant_income_assessment view - Only switch when the client is uploading bank statements not
either party
* Update asset view - ensure the heading is only shown when bank account data
is present and should be shown

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
