### PR TITLE
AP-4437: Remove additional element

### DIFF
--- a/app/views/citizens/consents/show.html.erb
+++ b/app/views/citizens/consents/show.html.erb
@@ -5,30 +5,7 @@
       local: true,
     ) do |form| %>
 
-    <%= page_template page_title: t(".title_html"), head_title: t(".head_title"), form: do %>
-
-      <%= govuk_inset_text do %>
-        <p class="govuk-body govuk-!-padding-bottom-2"><%= t(".inset_text") %></p>
-      <% end %>
-
-      <%= govuk_details(summary_text: t(".summary_heading")) do %>
-        <p><%= t(".able_to_see.heading") %></p>
-
-        <ul class="govuk-list govuk-list--bullet">
-          <% t(".able_to_see.list").each_line do |item| %>
-            <li><%= item %></li>
-          <% end %>
-        </ul>
-
-        <p><%= t(".unable_to_see.heading") %></p>
-
-        <ul class="govuk-list govuk-list--bullet">
-          <% t(".unable_to_see.list").each_line do |item| %>
-            <li><%= item %></li>
-          <% end %>
-        </ul>
-      <% end %>
-
+    <%= page_template page_title: t(".title_html"), form:, template: :basic do %>
       <%= form.govuk_collection_radio_buttons(
             :open_banking_consent,
             yes_no_options,
@@ -36,10 +13,33 @@
             :label,
             legend: {
               text: t(".title_html"),
-              hidden: true,
+              tag: "h1",
+              size: "xl",
             },
-          ) %>
+          ) do %>
 
+        <%= govuk_inset_text do %>
+          <p class="govuk-body govuk-!-padding-bottom-2"><%= t(".inset_text") %></p>
+        <% end %>
+
+        <%= govuk_details(summary_text: t(".summary_heading")) do %>
+          <p><%= t(".able_to_see.heading") %></p>
+
+          <ul class="govuk-list govuk-list--bullet">
+            <% t(".able_to_see.list").each_line do |item| %>
+              <li><%= item %></li>
+            <% end %>
+          </ul>
+
+          <p><%= t(".unable_to_see.heading") %></p>
+
+          <ul class="govuk-list govuk-list--bullet">
+            <% t(".unable_to_see.list").each_line do |item| %>
+              <li><%= item %></li>
+            <% end %>
+          </ul>
+        <% end %>
+      <% end %>
     <%= next_action_buttons(form:) %>
   <% end %>
 <% end %>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4437)

Remove hidden element which duplicates the page heading as this could be navigated to using a screen reader. Page should look visually identical

<img width="995" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-legal-aid/assets/13471320/912a785f-c0b5-4742-aea2-78a60e2d527b">


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
