### PR TITLE
AP-4431: Add association between change button and context

### DIFF
--- a/app/views/providers/about_the_financial_assessments/show.html.erb
+++ b/app/views/providers/about_the_financial_assessments/show.html.erb
@@ -14,8 +14,9 @@
     </div>
     <div class="govuk-grid-column-one-quarter govuk-!-text-align-right">
       <%= govuk_link_to(
-            t("generic.change_html", context: @applicant.email),
+            t("generic.change"),
             providers_legal_aid_application_email_address_path(anchor: :email),
+            visually_hidden_suffix: t(".section_2.heading"),
             class: "govuk-!-font-size-19",
           ) %>
     </div>

--- a/app/views/providers/about_the_financial_assessments/show.html.erb
+++ b/app/views/providers/about_the_financial_assessments/show.html.erb
@@ -14,7 +14,7 @@
     </div>
     <div class="govuk-grid-column-one-quarter govuk-!-text-align-right">
       <%= govuk_link_to(
-            t("generic.change"),
+            t("generic.change_html", context: @applicant.email),
             providers_legal_aid_application_email_address_path(anchor: :email),
             class: "govuk-!-font-size-19",
           ) %>

--- a/app/views/providers/check_provider_answers/_shared.html.erb
+++ b/app/views/providers/check_provider_answers/_shared.html.erb
@@ -22,7 +22,7 @@
         <h2 class="govuk-heading-m"><%= t ".section_proceeding.heading" %></h2>
       </div>
       <div class="govuk-grid-column-one-third">
-        <p><%= govuk_link_to t(".change"), providers_legal_aid_application_has_other_proceedings_path(@legal_aid_application), class: "govuk-link-right" %></p>
+        <%= govuk_link_to t("generic.change_html", context: t(".section_proceeding.heading").to_s), providers_legal_aid_application_has_other_proceedings_path(@legal_aid_application), class: "govuk-link-right" %>
       </div>
     </div>
     <%= render(

--- a/app/views/providers/check_provider_answers/_shared.html.erb
+++ b/app/views/providers/check_provider_answers/_shared.html.erb
@@ -24,7 +24,7 @@
       <div class="govuk-grid-column-one-third">
         <%= govuk_link_to(
               t("generic.change"), providers_legal_aid_application_has_other_proceedings_path(@legal_aid_application),
-              visually_hidden_suffix: t(".section_proceeding.heading").to_s,
+              visually_hidden_suffix: t(".section_proceeding.heading"),
               class: "govuk-link-right"
             ) %>
       </div>

--- a/app/views/providers/check_provider_answers/_shared.html.erb
+++ b/app/views/providers/check_provider_answers/_shared.html.erb
@@ -48,7 +48,13 @@
         <h2 class="govuk-heading-m"><%= t ".emergency_cost_limit" %></h2>
       </div>
       <div class="govuk-grid-column-one-third">
-        <p><%= govuk_link_to t(".change"), providers_legal_aid_application_limitations_path(@legal_aid_application), class: "govuk-link-right" %></p>
+        <p><%= govuk_link_to(
+                 t(".change"),
+                 providers_legal_aid_application_limitations_path(@legal_aid_application),
+                 visually_hidden_suffix: t(".emergency_cost_limit"),
+                 class: "govuk-link-right",
+               ) %>
+        </p>
       </div>
     </div>
     <%= render(

--- a/app/views/providers/check_provider_answers/_shared.html.erb
+++ b/app/views/providers/check_provider_answers/_shared.html.erb
@@ -22,7 +22,11 @@
         <h2 class="govuk-heading-m"><%= t ".section_proceeding.heading" %></h2>
       </div>
       <div class="govuk-grid-column-one-third">
-        <%= govuk_link_to t("generic.change_html", context: t(".section_proceeding.heading").to_s), providers_legal_aid_application_has_other_proceedings_path(@legal_aid_application), class: "govuk-link-right" %>
+        <%= govuk_link_to(
+              t("generic.change"), providers_legal_aid_application_has_other_proceedings_path(@legal_aid_application),
+              visually_hidden_suffix: t(".section_proceeding.heading").to_s,
+              class: "govuk-link-right"
+            ) %>
       </div>
     </div>
     <%= render(

--- a/app/views/shared/check_answers/_client_details.html.erb
+++ b/app/views/shared/check_answers/_client_details.html.erb
@@ -77,7 +77,7 @@
       <%= row.with_action(
             text: t("generic.change"),
             href: providers_legal_aid_application_has_national_insurance_number_path(@legal_aid_application),
-            visually_hidden_text: "#{t('.aria_prefix')} {#{t('.nino')}",
+            visually_hidden_text: "#{t('.aria_prefix')} #{t('.nino')}",
           ) %>
     <% end %>
   <% end %>

--- a/app/views/shared/check_answers/_proceeding_details.html.erb
+++ b/app/views/shared/check_answers/_proceeding_details.html.erb
@@ -4,7 +4,7 @@
     <h2 class="govuk-heading-m"><%= proceeding.meaning %> proceeding details</h2>
   </div>
   <div class="govuk-grid-column-one-quarter">
-    <p><%= govuk_link_to t("providers.check_provider_answers.shared.change"),
+    <p><%= govuk_link_to t("generic.change_html", context: "#{proceeding.meaning} proceeding details"),
                          providers_legal_aid_application_client_involvement_type_path(@legal_aid_application, proceeding),
                          class: "govuk-link-right" %></p>
   </div>

--- a/app/views/shared/check_answers/_proceeding_details.html.erb
+++ b/app/views/shared/check_answers/_proceeding_details.html.erb
@@ -1,13 +1,13 @@
 <% read_only = false unless local_assigns.key?(:read_only) %>
 <div class="govuk-grid-row" id="app-check-your-answers__proceeding_<%= proceeding.meaning.parameterize(separator: "_") %>">
   <div class="govuk-grid-column-three-quarters">
-    <h2 class="govuk-heading-m"><%= proceeding.meaning %> proceeding details</h2>
+    <h2 class="govuk-heading-m"><%= proceeding.meaning %> <%= t(".description") %></h2>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <%= govuk_link_to(
           t("generic.change"),
           providers_legal_aid_application_client_involvement_type_path(@legal_aid_application, proceeding),
-          visually_hidden_suffix: "#{proceeding.meaning} proceeding details",
+          visually_hidden_suffix: "#{proceeding.meaning} #{t('.description')}",
           class: "govuk-link-right",
         ) %>
   </div>

--- a/app/views/shared/check_answers/_proceeding_details.html.erb
+++ b/app/views/shared/check_answers/_proceeding_details.html.erb
@@ -4,9 +4,12 @@
     <h2 class="govuk-heading-m"><%= proceeding.meaning %> proceeding details</h2>
   </div>
   <div class="govuk-grid-column-one-quarter">
-    <p><%= govuk_link_to t("generic.change_html", context: "#{proceeding.meaning} proceeding details"),
-                         providers_legal_aid_application_client_involvement_type_path(@legal_aid_application, proceeding),
-                         class: "govuk-link-right" %></p>
+    <%= govuk_link_to(
+          t("generic.change"),
+          providers_legal_aid_application_client_involvement_type_path(@legal_aid_application, proceeding),
+          visually_hidden_suffix: "#{proceeding.meaning} proceeding details",
+          class: "govuk-link-right",
+        ) %>
   </div>
 </div>
 

--- a/config/locales/en/generic.yml
+++ b/config/locales/en/generic.yml
@@ -11,7 +11,6 @@ en:
     back_to_your_applications: Back to your applications
     cancel: Cancel
     change: Change
-    change_html: Change <span class='govuk-visually-hidden'>%{context}</span>
     client: your client
     client_means_caption: Client's means assessment
     client_or_partner: your client or their partner

--- a/config/locales/en/generic.yml
+++ b/config/locales/en/generic.yml
@@ -11,6 +11,7 @@ en:
     back_to_your_applications: Back to your applications
     cancel: Cancel
     change: Change
+    change_html: Change <span class='govuk-visually-hidden'>%{context}</span>
     client: your client
     client_means_caption: Client's means assessment
     client_or_partner: your client or their partner

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -489,6 +489,7 @@ en:
           client_involvement_type_applicant: Applicant
           proceeding: What does your client want legal aid for?
       proceeding_details:
+        description: proceeding details
         client_involvement_type_details:
           question: Client role
         delegated_function_details:


### PR DESCRIPTION
## What

[AP-4431](https://dsdmoj.atlassian.net/browse/AP-4431)

Add association between change button and context for screen readers. 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.


[AP-4431]: https://dsdmoj.atlassian.net/browse/AP-4431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ