### PR TITLE
Faraday soap call

### DIFF
--- a/app/services/faraday/soap_call.rb
+++ b/app/services/faraday/soap_call.rb
@@ -1,4 +1,6 @@
 module Faraday
+  class SoapError < StandardError; end
+
   class SoapCall
     attr_reader :url, :type
 
@@ -13,6 +15,10 @@ module Faraday
         request.body = xml_body
       end
       response.body
+    rescue StandardError => e
+      AlertManager.capture_exception(e)
+      Rails.logger.error(e.message)
+      raise SoapError, e.message
     end
 
     def headers

--- a/app/services/faraday/soap_call.rb
+++ b/app/services/faraday/soap_call.rb
@@ -1,0 +1,46 @@
+module Faraday
+  class SoapCall
+    attr_reader :url
+
+    def initialize(wsdl_url)
+      raise StandardError, "Unable to parse url" unless parse_url(wsdl_url)
+    end
+
+    def call(xml_body)
+      response = conn.post do |request|
+        request.url url
+        request.body = xml_body
+      end
+      response.body
+    end
+
+  private
+
+    def parse_url(input)
+      if input.match?(URI::DEFAULT_PARSER.regexp[:ABS_URI])
+        # if wsdl_url is a URL return it
+        @url = input
+      elsif File.file?(input)
+        # extract url from wsdl
+        File.open(input) do |f|
+          doc = Nokogiri::XML(f)
+          @url = doc.xpath("//soap:address").attribute("location").value
+        end
+      else
+        false
+      end
+    end
+
+    def conn
+      @conn ||= Faraday.new(url:, headers:)
+    end
+
+    def headers
+      @headers ||= {
+        "x-api-key": Rails.configuration.x.ccms_soa.aws_gateway_api_key,
+        SOAPAction: "#POST",
+        "Content-Type": "text/xml",
+      }
+    end
+  end
+end

--- a/spec/cassettes/benefit_check_service/savon_successful_call.yml
+++ b/spec/cassettes/benefit_check_service/savon_successful_call.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://benefitchecker.stg.legalservices.gov.uk/lsx/lsc-services/benefitChecker?wsdl
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"> <env:Body><wsdl:check>
+        <clientReference>df56670b-aecf-49cc-8f1b-1c410cace3c5</clientReference> <nino>JA293483A</nino>
+        <surname>WALKER</surname> <dateOfBirth>19800110</dateOfBirth> <dateOfAward>20220719</dateOfAward>
+        <lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName> <clientOrgId><BC_CLIENT_ORG_ID></clientOrgId>
+        <clientUserId><BC_CLIENT_USER_ID></clientUserId> </wsdl:check></env:Body></env:Envelope>
+    headers:
+      Soapaction:
+      - "#POST"
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - Faraday v2.9.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 05 Feb 2024 15:03:48 GMT
+      Content-Type:
+      - text/xml;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Amzn-Trace-Id:
+      - Root=1-65c0f8d4-6cb04c660b900d4e59eeda61;
+      Vary:
+      - Accept-Encoding
+    body:
+      encoding: ASCII-8BIT
+      string: <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><benefitCheckerResponse
+        xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns1:originalClientRef
+        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">df56670b-aecf-49cc-8f1b-1c410cace3c5</ns1:originalClientRef><ns2:benefitCheckerStatus
+        xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">Yes</ns2:benefitCheckerStatus><ns3:confirmationRef
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1707145428938</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
+  recorded_at: Mon, 05 Feb 2024 15:03:48 GMT
+recorded_with: VCR 6.2.0

--- a/spec/services/faraday/soap_call_spec.rb
+++ b/spec/services/faraday/soap_call_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe Faraday::SoapCall do
+  subject(:faraday_soap_call) { described_class.new(initial_object) }
+
+  describe "initializing" do
+    describe "with a bad attribute" do
+      let(:initial_object) { "clearly not a url" }
+
+      it "raises an error" do
+        expect { faraday_soap_call }.to raise_error("Unable to parse url")
+      end
+    end
+
+    describe "with a url" do
+      let(:initial_object) { "https://fake/wsdl/url" }
+
+      it { expect(faraday_soap_call.url).to eql("https://fake/wsdl/url") }
+    end
+
+    describe "with a wsdl file" do
+      let(:initial_object) { Rails.root.join("app/services/ccms/wsdls/", Rails.configuration.x.ccms_soa.getReferenceDataWsdl).to_s }
+      let(:expected) { "https://ccmssoagateway.dev.legalservices.gov.uk/ccmssoa/soa-infra/services/default/GetReferenceData!1.5*soa_92fe5600-6b1b-4d91-a97f-36e3955ae196/getreferencedata_ep" }
+
+      it { expect(faraday_soap_call.url).to eql(expected) }
+    end
+  end
+
+  describe ".call", vcr: { cassette_name: "benefit_check_service/savon_successful_call" } do
+    let(:calling) { faraday_soap_call.call(payload) }
+    let(:initial_object) { "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check" }
+    let(:payload) do
+      <<~PAYLOAD.squish
+        <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wsdl="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+        <env:Body><wsdl:check>
+        <clientReference>df56670b-aecf-49cc-8f1b-1c410cace3c5</clientReference>
+        <nino>JA293483A</nino>
+        <surname>WALKER</surname>
+        <dateOfBirth>19800110</dateOfBirth>
+        <dateOfAward>20220719</dateOfAward>
+        <lscServiceName><BC_LSC_SERVICE_NAME></lscServiceName><clientOrgId><BC_CLIENT_ORG_ID></clientOrgId><clientUserId><BC_CLIENT_USER_ID></clientUserId></wsdl:check></env:Body></env:Envelope>
+      PAYLOAD
+    end
+    let(:expected) do
+      <<~XML.squish
+        <?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><benefitCheckerResponse
+        xmlns="https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"><ns1:originalClientRef
+        xmlns:ns1="http://lsc.gov.uk/benefitchecker/data/1.0">df56670b-aecf-49cc-8f1b-1c410cace3c5</ns1:originalClientRef><ns2:benefitCheckerStatus
+        xmlns:ns2="http://lsc.gov.uk/benefitchecker/data/1.0">Yes</ns2:benefitCheckerStatus><ns3:confirmationRef
+        xmlns:ns3="http://lsc.gov.uk/benefitchecker/data/1.0">T1658229558145</ns3:confirmationRef></benefitCheckerResponse></soapenv:Body></soapenv:Envelope>
+      XML
+    end
+
+    it "returns expected xml body" do
+      expect(calling).to eql(expected)
+    end
+  end
+end

--- a/spec/services/faraday/soap_call_spec.rb
+++ b/spec/services/faraday/soap_call_spec.rb
@@ -95,5 +95,16 @@ RSpec.describe Faraday::SoapCall do
     it "returns expected xml body" do
       expect(calling).to eql(expected)
     end
+
+    context "when there is a connection error" do
+      let(:expected_message) { "my faraday connection failed" }
+
+      it "creates a CFE::Submission error and writes a history record with a backtrace" do
+        stub_request(:post, initial_object).to_raise(Faraday::ConnectionFailed.new(expected_message))
+        expect(AlertManager).to receive(:capture_exception).with(message_contains(expected_message))
+        expect(Rails.logger).to receive(:error).with(expected_message)
+        expect { calling }.to raise_error Faraday::SoapError, expected_message
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4767)
[Link to story](https://dsdmoj.atlassian.net/browse/AP-4771)

Class to allow Faraday to make SOAP calls - this will allow us to replace Savon but the aim is to add this and allow us to update the Savon calls individually before removing the gem.

It was developed during a mob session and has been overseen by all current developers

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
