### PR TITLE
Fix: Flickering SAML tests

### DIFF
--- a/spec/requests/saml_sessions_spec.rb
+++ b/spec/requests/saml_sessions_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe "SamlSessionsController" do
   let(:provider_details_api_reponse) { api_response.to_json }
   let(:enable_mock_saml) { false }
 
-  before { allow(Rails.configuration.x.laa_portal).to receive(:mock_saml).and_return(enable_mock_saml) }
+  before do
+    allow(Rails.configuration.x.laa_portal).to receive(:mock_saml).and_return(enable_mock_saml)
+    Redis.new(url: Rails.configuration.x.redis.page_history_url).flushdb
+  end
 
   describe "DELETE /providers/sign_out" do
     subject(:delete_request) { delete destroy_provider_session_path }


### PR DESCRIPTION
## What

This is a race condition that checks the count of values in the page history, if other tests visit pages first it causes a false positive in these tests.

The fix clears the test redis instance for the page_history database before each test in this block

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
