### PR TITLE
AP-4767: Use faraday for CCMS soap calls

### DIFF
--- a/app/services/ccms/requestors/applicant_add_status_requestor.rb
+++ b/app/services/ccms/requestors/applicant_add_status_requestor.rb
@@ -12,7 +12,7 @@ module CCMS
       end
 
       def call
-        soap_client.call(:get_client_txn_status, xml: request_xml)
+        Faraday::SoapCall.new(wsdl_location, :ccms).call(request_xml)
       end
 
     private

--- a/app/services/ccms/requestors/base_requestor.rb
+++ b/app/services/ccms/requestors/base_requestor.rb
@@ -46,22 +46,6 @@ module CCMS
 
     private
 
-      def soap_client
-        @soap_client ||= Savon.client(
-          headers: { "x-api-key" => config.aws_gateway_api_key },
-          env_namespace: :soap,
-          wsdl: wsdl_location,
-          namespaces:,
-          pretty_print_xml: true,
-          convert_request_keys_to: :none,
-          namespace_identifier: "ns2",
-          log: false,
-          log_level: :debug,
-          open_timeout: 180,
-          read_timeout: 180,
-        )
-      end
-
       def soap_envelope(namespaces)
         Nokogiri::XML::Builder.new(encoding: "UTF-8") do |xml|
           xml.__send__(:"soap:Envelope", namespaces) do

--- a/app/services/ccms/requestors/case_add_status_requestor.rb
+++ b/app/services/ccms/requestors/case_add_status_requestor.rb
@@ -12,7 +12,7 @@ module CCMS
       end
 
       def call
-        soap_client.call(:get_case_txn_status, xml: request_xml)
+        Faraday::SoapCall.new(wsdl_location, :ccms).call(request_xml)
       end
 
     private

--- a/app/services/ccms/requestors/document_id_requestor.rb
+++ b/app/services/ccms/requestors/document_id_requestor.rb
@@ -13,7 +13,7 @@ module CCMS
       end
 
       def call
-        soap_client.call(:upload_document, xml: request_xml)
+        Faraday::SoapCall.new(wsdl_location, :ccms).call(request_xml)
       end
 
     private

--- a/app/services/ccms/requestors/document_upload_requestor.rb
+++ b/app/services/ccms/requestors/document_upload_requestor.rb
@@ -15,7 +15,7 @@ module CCMS
       end
 
       def call
-        soap_client.call(:upload_document, xml: request_xml)
+        Faraday::SoapCall.new(wsdl_location, :ccms).call(request_xml)
       end
 
     private

--- a/app/services/ccms/requestors/reference_data_requestor.rb
+++ b/app/services/ccms/requestors/reference_data_requestor.rb
@@ -9,7 +9,7 @@ module CCMS
       end
 
       def call
-        soap_client.call(:process, xml: request_xml)
+        Faraday::SoapCall.new(wsdl_location, :ccms).call(request_xml)
       end
 
       def request_xml

--- a/app/services/ccms/submitters/base_submission_service.rb
+++ b/app/services/ccms/submitters/base_submission_service.rb
@@ -2,9 +2,8 @@ module CCMS
   CCMS_SUBMISSION_ERRORS = [
     CCMSError,
     CCMSUnsuccessfulResponseError,
-    Savon::HTTPError,
-    Savon::SOAPFault,
-    Savon::Error,
+    Faraday::Error,
+    Faraday::SoapError,
     StandardError,
   ].freeze
 

--- a/app/services/ccms/submitters/base_submission_service.rb
+++ b/app/services/ccms/submitters/base_submission_service.rb
@@ -1,4 +1,5 @@
 module CCMS
+  require Rails.root.join("app/services/faraday/soap_call.rb")
   CCMS_SUBMISSION_ERRORS = [
     CCMSError,
     CCMSUnsuccessfulResponseError,

--- a/spec/services/ccms/requestors/applicant_add_status_requestor_spec.rb
+++ b/spec/services/ccms/requestors/applicant_add_status_requestor_spec.rb
@@ -31,16 +31,17 @@ module CCMS
       end
 
       describe "#call" do
-        let(:soap_client_double) { Savon.client(env_namespace: :soap, wsdl: requestor.__send__(:wsdl_location)) }
-        let(:expected_soap_operation) { :get_client_txn_status }
-        let(:expected_xml) { requestor.__send__(:request_xml) }
-
         before do
-          allow(requestor).to receive(:soap_client).and_return(soap_client_double)
+          allow(Faraday::SoapCall).to receive(:new).and_return(soap_call)
+          stub_request(:post, expected_url)
         end
 
-        it "calls the savon soap client" do
-          expect(soap_client_double).to receive(:call).with(expected_soap_operation, xml: expected_xml)
+        let(:soap_call) { instance_double(Faraday::SoapCall) }
+        let(:expected_xml) { requestor.__send__(:request_xml) }
+        let(:expected_url) { extract_url_from(requestor.__send__(:wsdl_location)) }
+
+        it "invokes the faraday soap_call" do
+          expect(soap_call).to receive(:call).with(expected_xml).once
           requestor.call
         end
       end

--- a/spec/services/ccms/requestors/case_add_status_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_status_requestor_spec.rb
@@ -28,16 +28,17 @@ module CCMS
       end
 
       describe "#call" do
-        let(:soap_client_double) { Savon.client(env_namespace: :soap, wsdl: requestor.__send__(:wsdl_location)) }
-        let(:expected_soap_operation) { :get_case_txn_status }
-        let(:expected_xml) { requestor.__send__(:request_xml) }
-
         before do
-          allow(requestor).to receive(:soap_client).and_return(soap_client_double)
+          allow(Faraday::SoapCall).to receive(:new).and_return(soap_call)
+          stub_request(:post, expected_url)
         end
 
-        it "calls the savon soap client" do
-          expect(soap_client_double).to receive(:call).with(expected_soap_operation, xml: expected_xml)
+        let(:soap_call) { instance_double(Faraday::SoapCall) }
+        let(:expected_xml) { requestor.__send__(:request_xml) }
+        let(:expected_url) { extract_url_from(requestor.__send__(:wsdl_location)) }
+
+        it "invokes the faraday soap_call" do
+          expect(soap_call).to receive(:call).with(expected_xml).once
           requestor.call
         end
       end

--- a/spec/services/ccms/requestors/document_id_requestor_spec.rb
+++ b/spec/services/ccms/requestors/document_id_requestor_spec.rb
@@ -92,16 +92,17 @@ module CCMS
       end
 
       describe "#call" do
-        let(:soap_client_double) { Savon.client(env_namespace: :soap, wsdl: requestor.__send__(:wsdl_location)) }
-        let(:expected_soap_operation) { :upload_document }
-        let(:expected_xml) { requestor.__send__(:request_xml) }
-
         before do
-          allow(requestor).to receive(:soap_client).and_return(soap_client_double)
+          allow(Faraday::SoapCall).to receive(:new).and_return(soap_call)
+          stub_request(:post, expected_url)
         end
 
-        it "calls the savon soap client" do
-          expect(soap_client_double).to receive(:call).with(expected_soap_operation, xml: expected_xml)
+        let(:soap_call) { instance_double(Faraday::SoapCall) }
+        let(:expected_xml) { requestor.__send__(:request_xml) }
+        let(:expected_url) { extract_url_from(requestor.__send__(:wsdl_location)) }
+
+        it "invokes the faraday soap_call" do
+          expect(soap_call).to receive(:call).with(expected_xml).once
           requestor.call
         end
       end

--- a/spec/services/ccms/requestors/document_upload_requestor_spec.rb
+++ b/spec/services/ccms/requestors/document_upload_requestor_spec.rb
@@ -91,16 +91,17 @@ module CCMS
       end
 
       describe "#call" do
-        let(:soap_client_double) { Savon.client(env_namespace: :soap, wsdl: requestor.__send__(:wsdl_location)) }
-        let(:expected_soap_operation) { :upload_document }
-        let(:expected_xml) { requestor.__send__(:request_xml) }
-
         before do
-          allow(requestor).to receive(:soap_client).and_return(soap_client_double)
+          allow(Faraday::SoapCall).to receive(:new).and_return(soap_call)
+          stub_request(:post, expected_url)
         end
 
-        it "calls the savon soap client" do
-          expect(soap_client_double).to receive(:call).with(expected_soap_operation, xml: expected_xml)
+        let(:soap_call) { instance_double(Faraday::SoapCall) }
+        let(:expected_xml) { requestor.__send__(:request_xml) }
+        let(:expected_url) { extract_url_from(requestor.__send__(:wsdl_location)) }
+
+        it "invokes the faraday soap_call" do
+          expect(soap_call).to receive(:call).with(expected_xml).once
           requestor.call
         end
       end

--- a/spec/services/ccms/requestors/reference_data_requestor_spec.rb
+++ b/spec/services/ccms/requestors/reference_data_requestor_spec.rb
@@ -31,17 +31,17 @@ module CCMS
       end
 
       describe "#call" do
-        let(:soap_client_double) { Savon.client(env_namespace: :soap, wsdl: requestor.__send__(:wsdl_location)) }
-        let(:expected_soap_operation) { :process }
-        let(:expected_xml) { requestor.__send__(:request_xml) }
-
         before do
-          freeze_time
-          allow(requestor).to receive(:soap_client).and_return(soap_client_double)
+          allow(Faraday::SoapCall).to receive(:new).and_return(soap_call)
+          stub_request(:post, expected_url)
         end
 
-        it "calls the savon soap client" do
-          expect(soap_client_double).to receive(:call).with(expected_soap_operation, xml: expected_xml)
+        let(:soap_call) { instance_double(Faraday::SoapCall) }
+        let(:expected_xml) { requestor.__send__(:request_xml) }
+        let(:expected_url) { extract_url_from(requestor.__send__(:wsdl_location)) }
+
+        it "invokes the faraday soap_call" do
+          expect(soap_call).to receive(:call).with(expected_xml).once
           requestor.call
         end
       end

--- a/spec/services/ccms/submitters/add_applicant_service_spec.rb
+++ b/spec/services/ccms/submitters/add_applicant_service_spec.rb
@@ -73,7 +73,7 @@ module CCMS
 
       context "when the operation is in error" do
         context "and it errors when adding an applicant" do
-          let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
+          let(:error) { [CCMS::CCMSError, Faraday::Error, Faraday::SoapError, StandardError] }
           let(:sample_error) { error.sample }
 
           before do

--- a/spec/services/ccms/submitters/add_case_service_spec.rb
+++ b/spec/services/ccms/submitters/add_case_service_spec.rb
@@ -156,7 +156,7 @@ module CCMS
 
       context "when operation encounters error" do
         context "with error while adding a case" do
-          let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
+          let(:error) { [CCMS::CCMSError, Faraday::Error, Faraday::SoapError, StandardError] }
           let(:fake_error) { error.sample }
 
           before do

--- a/spec/services/ccms/submitters/check_applicant_status_service_spec.rb
+++ b/spec/services/ccms/submitters/check_applicant_status_service_spec.rb
@@ -126,7 +126,7 @@ module CCMS
         end
 
         context "when the operation is unsuccessful" do
-          let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
+          let(:error) { [CCMS::CCMSError, Faraday::Error, Faraday::SoapError, StandardError] }
           let(:fake_error) { error.sample }
 
           before do

--- a/spec/services/ccms/submitters/check_case_status_service_spec.rb
+++ b/spec/services/ccms/submitters/check_case_status_service_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe CCMS::Submitters::CheckCaseStatusService, :ccms do
 
     context "when the operation is unsuccessful" do
       let(:transaction_request_id_in_example_response) { "20190301030405123456" }
-      let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
+      let(:error) { [CCMS::CCMSError, Faraday::Error, Faraday::SoapError, StandardError] }
       let(:fake_error) { error.sample }
 
       before do

--- a/spec/services/ccms/submitters/obtain_applicant_reference_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_applicant_reference_service_spec.rb
@@ -129,7 +129,7 @@ module CCMS
 
       context "when the operation is unsuccessful" do
         context "and an error is raised when searching for applicant" do
-          let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
+          let(:error) { [CCMS::CCMSError, Faraday::Error, Faraday::SoapError, StandardError] }
           let(:fake_error) { error.sample }
 
           before do

--- a/spec/services/ccms/submitters/obtain_case_reference_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_case_reference_service_spec.rb
@@ -59,7 +59,7 @@ module CCMS
       end
 
       context "when the operation raises an error" do
-        let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
+        let(:error) { [CCMS::CCMSError, Faraday::Error, Faraday::SoapError, StandardError] }
         let(:fake_error) { error.sample } # TODO: avoid this pattern
 
         before do

--- a/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
@@ -153,7 +153,7 @@ module CCMS
         # the microsecond :(
 
         context "when populating documents" do
-          let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
+          let(:error) { [CCMS::CCMSError, Faraday::Error, Faraday::SoapError, StandardError] }
           let(:fake_error) { error.sample }
 
           before do

--- a/spec/services/ccms/submitters/upload_documents_service_spec.rb
+++ b/spec/services/ccms/submitters/upload_documents_service_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe CCMS::Submitters::UploadDocumentsService, :ccms do
     let(:history) { histories.where(request: nil, response: nil, to_state: "failed").last }
 
     context "and the operation fails due to a CCMS::CCMSError exception" do
-      let(:error) { [CCMS::CCMSError, Savon::Error, StandardError] }
+      let(:error) { [CCMS::CCMSError, Faraday::Error, Faraday::SoapError, StandardError] }
       let(:fake_error) { error.sample }
 
       before do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4767)

Replace Savon calls in the CCMS namespace with Faraday::SoapCall
Set the faraday_soap class to load in test: This is eager loaded in dev and production but ignored in test so needs an explicit require

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
