### PR TITLE
Fix: update DotEnv

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,7 @@ gem "strong_migrations"
 group :development, :test do
   gem "awesome_print", "~> 1.9.2"
   gem "byebug", platforms: %i[mri mingw x64_mingw]
-  gem "dotenv-rails", ">= 2.7.6"
+  gem "dotenv"
   gem "erb_lint", "0.5.0", require: false
   gem "hirb"
   gem "htmlentities"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,9 +240,6 @@ GEM
       activerecord (>= 4.2, < 8)
     docile (1.4.0)
     dotenv (2.8.1)
-    dotenv-rails (2.8.1)
-      dotenv (= 2.8.1)
-      railties (>= 3.2)
     drb (2.2.0)
       ruby2_keywords
     dumb_delegator (1.0.0)
@@ -796,7 +793,7 @@ DEPENDENCIES
   devise_saml_authenticatable (>= 1.7.0)
   dibber
   discard (~> 1.3)
-  dotenv-rails (>= 2.7.6)
+  dotenv
   erb_lint (= 0.5.0)
   factory_bot_rails (>= 6.2.0)
   faker (>= 1.9.1)


### PR DESCRIPTION
## What

The gem has been update to 3.0.0 and started a deprecation process to replace dotenv-rails with a single-use dotenv gem

closes #6346 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
