### PR TITLE
Fix: Add securityContext.runAsNonRoot=true to some of the pods

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
@@ -34,4 +34,6 @@ spec:
               requests:
                 cpu: 100m
                 memory: 1024Mi
+            securityContext:
+              runAsNonRoot: true
           restartPolicy: Never

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-deliver-scheduled-mail.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-deliver-scheduled-mail.yaml
@@ -31,4 +31,6 @@ spec:
               requests:
                 cpu: 100m
                 memory: 128Mi
+            securityContext:
+              runAsNonRoot: true
           restartPolicy: Never

--- a/helm_deploy/apply-for-legal-aid/templates/deployment_web.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/deployment_web.yaml
@@ -65,6 +65,8 @@ spec:
             preStop:
               exec:
                 command: [ "sh", "-c", "sleep 30" ] # Workaround for occasional lost requests - see https://github.com/puma/puma/blob/master/docs/kubernetes.md#running-puma-in-kubernetes
+          securityContext:
+            runAsNonRoot: true
           resources:
             limits:
               cpu: 1000m

--- a/helm_deploy/apply-for-legal-aid/templates/deployment_worker.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/deployment_worker.yaml
@@ -31,6 +31,8 @@ spec:
           imagePullPolicy: IfNotPresent
           command: ['bundle', 'exec', 'sidekiq']
 {{ include "apply-for-legal-aid.envs" . | nindent 10 }}
+          securityContext:
+            runAsNonRoot: true
           resources:
             limits:
               cpu: 500m


### PR DESCRIPTION
## What

This is to test if:
a) it works, and ;
b) it reduces the number of warnings is reduced

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
