### PR TITLE
AP-4798: Update find correspondence address

### DIFF
--- a/app/controllers/providers/address_lookups_controller.rb
+++ b/app/controllers/providers/address_lookups_controller.rb
@@ -13,7 +13,7 @@ module Providers
 
     def form_params
       merge_with_model(address) do
-        params.require(:address_lookup).permit(:postcode)
+        params.require(:address_lookup).permit(:postcode, :building_number_name)
       end
     end
 

--- a/app/controllers/providers/address_lookups_controller.rb
+++ b/app/controllers/providers/address_lookups_controller.rb
@@ -18,7 +18,7 @@ module Providers
     end
 
     def address
-      applicant.address || applicant.build_address
+      applicant.address || applicant.build_address(location: "correspondence")
     end
   end
 end

--- a/app/forms/addresses/address_lookup_form.rb
+++ b/app/forms/addresses/address_lookup_form.rb
@@ -2,6 +2,6 @@ module Addresses
   class AddressLookupForm < BaseAddressLookupForm
     form_for Address
 
-    attr_accessor :applicant_id, :postcode
+    attr_accessor :applicant_id, :postcode, :building_number_name
   end
 end

--- a/app/views/providers/address_lookups/show.html.erb
+++ b/app/views/providers/address_lookups/show.html.erb
@@ -13,9 +13,12 @@
       ) do %>
 
     <%= form.govuk_fieldset legend: { size: "xl", tag: "h1", text: t(".heading") }  do %>
-      <p class="govuk-body"><%= t(".helper_text") %></p>
-      <%= form.govuk_text_field :postcode, label: { text: t(".label"), tag: "h2", size: "m" }, width: 10 %>
+      <%= form.govuk_text_field :postcode, label: { text: t(".label.postcode"), tag: "h2", size: "m" }, width: 10 %>
+      <%= form.govuk_text_field :building_number_name, label: { text: t(".label.building_number_name"), tag: "h2", size: "m" }, width: 10 %>
+      <%= govuk_warning_text(text: t(".helper_text")) %>
     <% end %>
+
+    <p><%= govuk_link_to t(".address_manual_link"), providers_legal_aid_application_address_path %></p>
 
     <%= next_action_buttons(
           form:,
@@ -23,7 +26,5 @@
           continue_id: "find-address",
           continue_button_text: t(".submit_button"),
         ) %>
-
-    <p><%= govuk_link_to t(".address_manual_link"), providers_legal_aid_application_address_path %></p>
   <% end %>
 <% end %>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -9,6 +9,7 @@ en:
     hint:
       address_lookup:
         postcode: This must be a UK postcode, for example SW1A 2AA.
+        building_number_name: For example, 15 or Prospect Cottage.
       applicant:
         national_insurance_number: For example, QQ 12 34 56 C
       legal_aid_application:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -29,7 +29,9 @@ en:
       show:
         address_manual_link: Enter address manually
         heading: Enter your client's correspondence address
-        label: Postcode
+        label:
+          postcode: Postcode
+          building_number_name: Building number or name (optional)
         submit_button: Find address
         helper_text:
           The address you provide is only for this application. If your client has
@@ -1565,7 +1567,7 @@ en:
         dont_use_service:
           list_title: "But do not use this service if:"
           partner_list_item: the client has a partner, unless the partner is the opponent
-          list: 
+          list:
             - the client is under 16 years old
             - the client is self-employed or is a member of the armed forces
             - you want to make an emergency application and delegated functions have not been used

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -28,7 +28,7 @@ en:
     address_lookups:
       show:
         address_manual_link: Enter address manually
-        heading: Enter your client's correspondence address
+        heading: Find your client's correspondence address
         label:
           postcode: Postcode
           building_number_name: Building number or name (optional)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -179,7 +179,7 @@ Rails.application.routes.draw do
       resource :limitations, only: %i[show update]
       resource :applicant_details, only: %i[show update]
       resource :address, only: %i[show update], path: "enter_correspondence_address"
-      resource :address_lookup, only: %i[show update]
+      resource :address_lookup, only: %i[show update], path: "find_correspondence_address"
       resource :address_selection, only: %i[show update]
       resource :check_benefit, only: %i[index update]
       resource :has_national_insurance_number, only: %i[show update]

--- a/db/migrate/20240216110009_add_type_to_address.rb
+++ b/db/migrate/20240216110009_add_type_to_address.rb
@@ -1,0 +1,7 @@
+class AddTypeToAddress < ActiveRecord::Migration[7.1]
+  def change
+    add_column :addresses, :location, :string
+    # Set default values for existing records
+    Address.update_all(location: "correspondence")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_15_131834) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_16_110009) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -65,6 +65,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_15_131834) do
     t.boolean "lookup_used", default: false, null: false
     t.string "lookup_id"
     t.string "building_number_name"
+    t.string "location"
     t.index ["applicant_id"], name: "index_addresses_on_applicant_id"
   end
 

--- a/features/providers/check_provider_answers.feature
+++ b/features/providers/check_provider_answers.feature
@@ -77,7 +77,7 @@ Feature: Checking client details answers backwards and forwards
     And I should see "Transport For London"
 
     When I click Check Your Answers Change link for "address"
-    Then I should be on a page with title "Enter your client's correspondence address"
+    Then I should be on a page with title "Find your client's correspondence address"
 
     When I click 'Find address'
     And I select an address 'British Transport Police, 98 Petty France, London, SW1H 9EA'

--- a/features/providers/no_nino_flow.feature
+++ b/features/providers/no_nino_flow.feature
@@ -9,7 +9,7 @@ Feature: No national insurance number for applicant
     Then I choose 'No'
     And I enter the date of birth '10-1-1980'
     And I click 'Save and continue'
-    Then I should be on a page with title "Enter your client's correspondence address"
+    Then I should be on a page with title "Find your client's correspondence address"
 
     When I enter a postcode 'SW1H 9EA'
     And I click "Find address"

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -1134,7 +1134,7 @@ Then("I pause") do
 end
 
 Then("I am on the postcode entry page") do
-  expect(page).to have_content("Enter your client's correspondence address")
+  expect(page).to have_content("Find your client's correspondence address")
 end
 
 Then(/^I click find address$/) do

--- a/spec/requests/providers/address_lookups_controller_spec.rb
+++ b/spec/requests/providers/address_lookups_controller_spec.rb
@@ -70,9 +70,10 @@ RSpec.describe Providers::AddressLookupsController do
       context "with a valid postcode" do
         let(:postcode) { "SW1H 9EA" }
 
-        it "saves the postcode" do
+        it "saves the postcode and the location" do
           patch_request
           expect(applicant.address.postcode).to eq(postcode.delete(" ").upcase)
+          expect(applicant.address.location).to eq("correspondence")
         end
 
         it "redirects to the address selection page" do

--- a/spec/requests/providers/address_lookups_controller_spec.rb
+++ b/spec/requests/providers/address_lookups_controller_spec.rb
@@ -79,6 +79,15 @@ RSpec.describe Providers::AddressLookupsController do
           patch_request
           expect(response).to redirect_to(providers_legal_aid_application_address_selection_path)
         end
+
+        context "and a building number" do
+          before { params[:address_lookup][:building_number_name] = "Prospect Cottage" }
+
+          it "saves the building name/number value" do
+            patch_request
+            expect(applicant.address.building_number_name).to eq("Prospect Cottage")
+          end
+        end
       end
 
       context "with form submitted using Save as draft button" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4798)

Update the find correspondence address page
* Add the new house number/name field
* Add a `correspondence` field to allow extending to home addresses in the near future

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
