### PR TITLE
AP-4821: Fix client relationship ccms values

### DIFF
--- a/app/models/dependant.rb
+++ b/app/models/dependant.rb
@@ -50,7 +50,7 @@ class Dependant < ApplicationRecord
   end
 
   def ccms_relationship_to_client
-    return "Dependant adult" if adult_relative?
+    return "Dependent adult" if adult_relative?
 
     return "Child aged 15 and under" if fifteen_or_less?
 

--- a/spec/models/dependant_spec.rb
+++ b/spec/models/dependant_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Dependant do
       let(:dob) { 20.years.ago }
 
       it "returns adult relative" do
-        expect(dependant.ccms_relationship_to_client).to eq "Dependant adult"
+        expect(dependant.ccms_relationship_to_client).to eq "Dependent adult"
       end
     end
 

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_dependant_child_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_dependant_child_attributes_spec.rb
@@ -104,8 +104,8 @@ module CCMS
                     expect(blocks.size).to eq 1
                   end
 
-                  it "generated Dependant adult as relationship" do
-                    expect(blocks.first).to have_text_response "Dependant adult"
+                  it "generated Dependent adult as relationship" do
+                    expect(blocks.first).to have_text_response "Dependent adult"
                   end
                 end
 
@@ -114,7 +114,7 @@ module CCMS
                   let(:dob) { 14.years.ago }
                   let(:blocks) { XmlExtractor.call(xml, :client_residing_person, "CLI_RES_PER_INPUT_T_12WP3_17A") }
 
-                  it "generated Dependant adult as relationship" do
+                  it "generated under 15 child as relationship" do
                     expect(blocks.first).to have_text_response "Child aged 15 and under"
                   end
                 end
@@ -124,7 +124,7 @@ module CCMS
                   let(:dob) { 17.years.ago }
                   let(:blocks) { XmlExtractor.call(xml, :client_residing_person, "CLI_RES_PER_INPUT_T_12WP3_17A") }
 
-                  it "generated Dependant adult as relationship" do
+                  it "generated over 16 child as relationship" do
                     expect(blocks.first).to have_text_response "Child aged 16 and over"
                   end
                 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4821)

Ensure the `Dependent adult` values in `CLI_RES_PER_INPUT_T_12WP3_17A` fields are spelled correctly when submitting to CCMS

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
