### PR TITLE
fix: amend typo in address test

### DIFF
--- a/spec/forms/addresses/address_form_spec.rb
+++ b/spec/forms/addresses/address_form_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Addresses::AddressForm, type: :form do
       context "when an invalid input has been entered" do
         let(:county) { "12county" }
 
-        it "returns an error on city field" do
+        it "returns an error on county field" do
           expect(form).not_to be_valid
           expect(form.errors[:county]).to contain_exactly("Enter a real county")
         end
@@ -113,7 +113,7 @@ RSpec.describe Addresses::AddressForm, type: :form do
       expect(address.postcode).to eq(postcode)
     end
 
-    context "when an city is empty" do
+    context "when a city is empty" do
       let(:city) { "" }
 
       it "creates a new address for the applicant" do


### PR DESCRIPTION

## What

Amend typo in address test. Test description referred to city instead of county. 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
