### PR TITLE
Fix: reduce overnight sentry alerts

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-deliver-scheduled-mail.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-deliver-scheduled-mail.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: '11,41 * * * *'
+  schedule: '11,41 8-19 * * *'
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 0


### PR DESCRIPTION
## What

The scheduled mail job runs at 11 and 41 minutes past the hour, every hour.  This meant that on staging, where we shut the database down overnight, it would error 16 times a night.

This sets the job to run 8pm to 7pm on _all_ environemnts as that is when the service is mainly active

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
