### PR TITLE
Fix: reduce Staging sentry alerts

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/_helpers.tpl
+++ b/helm_deploy/apply-for-legal-aid/templates/_helpers.tpl
@@ -48,6 +48,23 @@ https://pauladamsmith.com/blog/2011/05/go_time.html
 {{- end -}}
 
 {{/*
+Define cron hour for staging
+On staging we turn off the database at 10PM and restart it at 6AM UTC (11PM and 7AM BST) to save money
+This means that overnight cronjobs on staging all fail as the DB is not present
+*/}}
+{{- define "apply-for-legal-aid.cronjob-hour-to-start-offset" -}}
+  {{- if contains "-staging" .Release.Namespace -}}
+    {{- 7 -}}
+  {{- else if contains "-uat" .Release.Namespace -}}
+    {{- 1 -}}
+  {{- else -}}
+    {{ 0 }}
+  {{- end -}}
+{{- end -}}
+
+
+
+{{/*
 Function to return the name for a UAT redis chart master node host
 This duplicates bitnami/redis chart's internal logic whereby
 If branch name contains "redis" then the redis-release-name appends "-master", otherwise it appends "-redis-master"

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-admin-report.yaml
@@ -1,3 +1,6 @@
+{{- $defaultStartHour := 2 }}
+{{- $startHourOffset := include "apply-for-legal-aid.cronjob-hour-to-start-offset" . -}}
+{{- $startHour := add $defaultStartHour $startHourOffset }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -8,7 +11,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: '0 2 * * *'
+  schedule: '0 {{ $startHour }} * * *'
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-destroy-purgeable.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-destroy-purgeable.yaml
@@ -1,3 +1,6 @@
+{{- $defaultStartHour := 1 }}
+{{- $startHourOffset := include "apply-for-legal-aid.cronjob-hour-to-start-offset" . -}}
+{{- $startHour := add $defaultStartHour $startHourOffset }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -8,7 +11,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: '30 1 * * *'
+  schedule: '30 {{ $startHour }} * * *'
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-export-digest.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-export-digest.yaml
@@ -1,3 +1,6 @@
+{{- $defaultStartHour := 2 }}
+{{- $startHourOffset := include "apply-for-legal-aid.cronjob-hour-to-start-offset" . -}}
+{{- $startHour := add $defaultStartHour $startHourOffset }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -8,7 +11,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: '15 2 * * *'
+  schedule: '15 {{ $startHour }} * * *'
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-extract-digest.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-extract-digest.yaml
@@ -1,3 +1,6 @@
+{{- $defaultStartHour := 2 }}
+{{- $startHourOffset := include "apply-for-legal-aid.cronjob-hour-to-start-offset" . -}}
+{{- $startHour := add $defaultStartHour $startHourOffset }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -8,7 +11,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: '0 2 * * *'
+  schedule: '0 {{ $startHour }} * * *'
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1

--- a/helm_deploy/apply-for-legal-aid/templates/cronjob-mark-purgeable.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/cronjob-mark-purgeable.yaml
@@ -1,3 +1,6 @@
+{{- $defaultStartHour := 1 }}
+{{- $startHourOffset := include "apply-for-legal-aid.cronjob-hour-to-start-offset" . -}}
+{{- $startHour := add $defaultStartHour $startHourOffset }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -8,7 +11,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: '0 1 * * *'
+  schedule: '0 {{ $startHour }} * * *'
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1


### PR DESCRIPTION
## What

The overnight jobs all require a database to function but, as we turn it off overnight, they all fail and cause errors which eat into the sentry allowance.
![image](https://github.com/ministryofjustice/laa-apply-for-legal-aid/assets/6757677/f9d690d9-06e7-4e70-b47b-bdf10cb4dd40)

This PR tries adding a 7 hour offset to staging to allow them to run once the DB has restarted.

It currently adds a 1 hour offset to UAT so I can test if the theory works without deploying to staging and potentially breaking everything!

It sets an offset of 0 otherwise so production remain at the normal scheduled times

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
