### PR TITLE
Fix: Update leap-date check

### DIFF
--- a/features/step_definitions/applicant_detail_steps.rb
+++ b/features/step_definitions/applicant_detail_steps.rb
@@ -13,7 +13,11 @@ When("I enter a date of birth that will make me 18 tomorrow") do
 end
 
 When("I enter a date of birth that will make me 18 today") do
-  dob = 18.years.ago
+  dob = if Time.zone.today.month == 2 && Time.zone.today.day == 29
+          18.years.ago + 1.day
+        else
+          18.years.ago
+        end
   fill_in("applicant_date_of_birth_3i", with: dob.day)
   fill_in("applicant_date_of_birth_2i", with: dob.month)
   fill_in("applicant_date_of_birth_1i", with: dob.year)

--- a/spec/forms/proceedings/delegated_functions_form_spec.rb
+++ b/spec/forms/proceedings/delegated_functions_form_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Proceedings::DelegatedFunctionsForm, type: :form do
 
       context "when the date is more than a year old" do
         let(:used_df?) { true }
-        let(:df_date) { Time.zone.yesterday - 1.year }
+        let(:df_date) { Time.zone.yesterday - 13.months }
 
         it "is invalid" do
           expect(df_form).not_to be_valid


### PR DESCRIPTION
## What

minus 1 year from 29th February = 28th February and that 'counts' as the same date so fails validation.  This increases the check to 13 months old to reduce the risk of recurrence


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
