### PR TITLE
AP-4831: Manual home address

### DIFF
--- a/app/controllers/providers/addresses_controller.rb
+++ b/app/controllers/providers/addresses_controller.rb
@@ -17,7 +17,7 @@ module Providers
 
     def form_params
       merge_with_model(address) do
-        params.require(:address).permit(*address_attributes)
+        params.require(:address).permit(*address_attributes).merge(location: "correspondence")
       end
     end
 

--- a/app/controllers/providers/home_address/addresses_controller.rb
+++ b/app/controllers/providers/home_address/addresses_controller.rb
@@ -1,0 +1,31 @@
+module Providers
+  module HomeAddress
+    class AddressesController < ProviderBaseController
+      prefix_step_with :home
+      def show
+        @form = Addresses::AddressForm.new(model: address)
+      end
+
+      def update
+        @form = Addresses::AddressForm.new(form_params)
+        render :show unless save_continue_or_draft(@form)
+      end
+
+    private
+
+      def address_attributes
+        %i[address_line_one address_line_two city county postcode lookup_postcode lookup_error]
+      end
+
+      def form_params
+        merge_with_model(address) do
+          params.require(:address).permit(*address_attributes).merge(location: "home")
+        end
+      end
+
+      def address
+        applicant.home_address || applicant.build_address(location: "home")
+      end
+    end
+  end
+end

--- a/app/controllers/providers/home_address/addresses_controller.rb
+++ b/app/controllers/providers/home_address/addresses_controller.rb
@@ -13,6 +13,13 @@ module Providers
 
     private
 
+      def build_address
+        Address.new(
+          applicant:,
+          location: "home",
+        )
+      end
+
       def address_attributes
         %i[address_line_one address_line_two city county postcode lookup_postcode lookup_error]
       end
@@ -24,7 +31,7 @@ module Providers
       end
 
       def address
-        applicant.home_address || applicant.build_address(location: "home")
+        @address ||= applicant.home_address || build_address
       end
     end
   end

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -59,7 +59,9 @@ module Flow
         addresses: {
           path: ->(application) { urls.providers_legal_aid_application_address_path(application) },
           forward: lambda do |application|
-            if Setting.linked_applications?
+            if Setting.home_address?
+              :different_addresses
+            elsif Setting.linked_applications?
               :copy_case_invitations
             else
               application.proceedings.any? ? :has_other_proceedings : :proceedings_types
@@ -91,6 +93,17 @@ module Flow
           # :nocov:
           path: ->(application) { urls.providers_legal_aid_application_home_address_non_uk_home_address_path(application) },
           # :nocov:
+          forward: lambda do |application|
+            if Setting.linked_applications?
+              :copy_case_invitations
+            else
+              application.proceedings.any? ? :has_other_proceedings : :proceedings_types
+            end
+          end,
+          check_answers: :check_provider_answers,
+        },
+        home_addresses: {
+          path: ->(application) { urls.providers_legal_aid_application_home_address_address_path(application) },
           forward: lambda do |application|
             if Setting.linked_applications?
               :copy_case_invitations

--- a/app/views/providers/addresses/show.html.erb
+++ b/app/views/providers/addresses/show.html.erb
@@ -7,39 +7,5 @@
       local: true,
     ) do |form| %>
 
-  <%= page_template(
-        page_title: t(".heading"),
-        form:,
-      ) do %>
-
-    <% if form.object.lookup_postcode.present? %>
-      <%= form.hidden_field :lookup_postcode %>
-      <div class='govuk-form-group'>
-        <%= label_tag t(".label_1"), class: "govuk-label" do %>
-          <%= t(".postcode") %>
-          <p class='govuk-body govuk-!-font-weight-bold'>
-            <%= form.object.lookup_postcode %>
-            <%= govuk_link_to(
-                  t("generic.change"),
-                  providers_legal_aid_application_address_lookup_path(@legal_aid_application),
-                  class: "govuk-body change-link change-postcode-link",
-                ) %>
-          </p>
-        <% end %>
-      </div>
-    <% end %>
-
-    <% if form.object.lookup_error.present? %>
-      <%= form.hidden_field :lookup_error %>
-      <%= govuk_inset_text(text: t("errors.address.#{form.object.lookup_error}")) %>
-    <% end %>
-
-    <%= form.govuk_text_field :address_line_one, label: { text: t(".address_line_one") } %>
-    <%= form.govuk_text_field :address_line_two, label: { text: t(".address_line_two") } %>
-    <%= form.govuk_text_field :city, label: { text: t(".city") }, width: "two-thirds" %>
-    <%= form.govuk_text_field :county, label: { text: t(".county") }, width: "two-thirds" %>
-    <%= form.govuk_text_field :postcode, label: { text: t(".postcode") }, hint: nil, width: 10 %>
-
-    <%= next_action_buttons(show_draft: true, form:) %>
-  <% end %>
+  <%= render "shared/addresses", location: "correspondence", form: %>
 <% end %>

--- a/app/views/providers/home_address/addresses/show.html.erb
+++ b/app/views/providers/home_address/addresses/show.html.erb
@@ -6,17 +6,5 @@
       local: true,
     ) do |form| %>
 
-  <%= page_template(
-        page_title: t(".heading"),
-        form:,
-      ) do %>
-
-        <%= form.govuk_text_field :address_line_one, label: { text: t(".address_line_one") } %>
-        <%= form.govuk_text_field :address_line_two, label: { text: t(".address_line_two") } %>
-        <%= form.govuk_text_field :city, label: { text: t(".city") }, width: "two-thirds" %>
-        <%= form.govuk_text_field :county, label: { text: t(".county") }, width: "two-thirds" %>
-        <%= form.govuk_text_field :postcode, label: { text: t(".postcode") }, hint: nil, width: 10 %>
-
-        <%= next_action_buttons(show_draft: true, form:) %>
-  <% end %>
+  <%= render "shared/addresses", location: "home", form: %>
 <% end %>

--- a/app/views/providers/home_address/addresses/show.html.erb
+++ b/app/views/providers/home_address/addresses/show.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(
+      model: @form,
+      scope: :address,
+      url: providers_legal_aid_application_home_address_address_path(@legal_aid_application),
+      method: :patch,
+      local: true,
+    ) do |form| %>
+
+  <%= page_template(
+        page_title: t(".heading"),
+        form:,
+      ) do %>
+
+        <%= form.govuk_text_field :address_line_one, label: { text: t(".address_line_one") } %>
+        <%= form.govuk_text_field :address_line_two, label: { text: t(".address_line_two") } %>
+        <%= form.govuk_text_field :city, label: { text: t(".city") }, width: "two-thirds" %>
+        <%= form.govuk_text_field :county, label: { text: t(".county") }, width: "two-thirds" %>
+        <%= form.govuk_text_field :postcode, label: { text: t(".postcode") }, hint: nil, width: 10 %>
+
+        <%= next_action_buttons(show_draft: true, form:) %>
+  <% end %>
+<% end %>

--- a/app/views/shared/_address_lookup.html.erb
+++ b/app/views/shared/_address_lookup.html.erb
@@ -10,11 +10,10 @@
     <%= govuk_warning_text(text: t(".helper_text")) %>
   <% end %>
 
-  <% if location == "correspondence" %>
-    <p class="govuk-body"><%= govuk_link_to t(".address_manual_link"), providers_legal_aid_application_address_path %></p>
-  <% elsif location == "home" %>
+  <% if location == "home" %>
     <p class="govuk-body"><%= govuk_link_to t(".non_uk_address_link"), providers_legal_aid_application_home_address_non_uk_home_address_path %></p>
   <% end %>
+  <p class="govuk-body"><%= govuk_link_to t(".address_manual_link"), location == "correspondence" ? providers_legal_aid_application_address_path : providers_legal_aid_application_home_address_address_path %></p>
 
   <%= next_action_buttons(
         form:,

--- a/app/views/shared/_addresses.html.erb
+++ b/app/views/shared/_addresses.html.erb
@@ -1,0 +1,35 @@
+  <%= page_template(
+        page_title: t(".heading", location:),
+        form:,
+      ) do %>
+
+    <% if form.object.lookup_postcode.present? %>
+      <%= form.hidden_field :lookup_postcode %>
+      <div class='govuk-form-group'>
+        <%= label_tag t(".label_1"), class: "govuk-label" do %>
+          <%= t(".postcode") %>
+          <p class='govuk-body govuk-!-font-weight-bold'>
+            <%= form.object.lookup_postcode %>
+            <%= govuk_link_to(
+                  t("generic.change"),
+                  providers_legal_aid_application_address_lookup_path(@legal_aid_application),
+                  class: "govuk-body change-link change-postcode-link",
+                ) %>
+          </p>
+        <% end %>
+      </div>
+    <% end %>
+
+    <% if form.object.lookup_error.present? %>
+      <%= form.hidden_field :lookup_error %>
+      <%= govuk_inset_text(text: t("errors.address.#{form.object.lookup_error}")) %>
+    <% end %>
+
+    <%= form.govuk_text_field :address_line_one, label: { text: t(".address_line_one") } %>
+    <%= form.govuk_text_field :address_line_two, label: { text: t(".address_line_two") } %>
+    <%= form.govuk_text_field :city, label: { text: t(".city") }, width: "two-thirds" %>
+    <%= form.govuk_text_field :county, label: { text: t(".county") }, width: "two-thirds" %>
+    <%= form.govuk_text_field :postcode, label: { text: t(".postcode") }, hint: nil, width: 10 %>
+
+    <%= next_action_buttons(show_draft: true, form:) %>
+  <% end %>

--- a/app/views/shared/address_selection/_confirm_address.html.erb
+++ b/app/views/shared/address_selection/_confirm_address.html.erb
@@ -37,9 +37,13 @@
       <%= form.hidden_field :postcode, value: @addresses.first.postcode %>
       <%= form.hidden_field :lookup_postcode, value: @addresses.first.postcode %>
 
-      <% if location == "correspondence" %>
-        <p><%= govuk_link_to t(".link_text"), providers_legal_aid_application_address_path(@legal_aid_application) %></p>
-      <% end %>
+      <p>
+        <%= govuk_link_to(
+              t(".link_text"),
+              location == "correspondence" ? providers_legal_aid_application_address_path(@legal_aid_application) : providers_legal_aid_application_home_address_address_path(@legal_aid_application),
+            ) %>
+      </p>
+
       <%= next_action_buttons(
             continue_id: "select-address-button",
             show_draft: false,

--- a/app/views/shared/address_selection/_no_address.html.erb
+++ b/app/views/shared/address_selection/_no_address.html.erb
@@ -22,8 +22,11 @@
       <p class="govuk-body"><%= t(".paragraph_2") %></p>
 
       <p><%= govuk_link_to(t(".change_postcode"), location == "correspondence" ? providers_legal_aid_application_address_lookup_path(@legal_aid_application) : providers_legal_aid_application_home_address_home_address_lookup_path(@legal_aid_application)) %></p>
-      <% if location == "correspondence" %>
-        <p><%= govuk_link_to(t(".manual_address"), providers_legal_aid_application_address_path) %></p>
-      <% end %>
+      <p>
+        <%= govuk_link_to(
+              t(".manual_address"),
+              location == "correspondence" ? providers_legal_aid_application_address_path(@legal_aid_application) : providers_legal_aid_application_home_address_address_path(@legal_aid_application),
+            ) %>
+      </p>
       <p><%= govuk_button_link_to(t("generic.save_and_come_back_later"), providers_legal_aid_applications_path, secondary: true) %></p>
 <% end %>

--- a/app/views/shared/address_selection/_select_address.html.erb
+++ b/app/views/shared/address_selection/_select_address.html.erb
@@ -37,9 +37,12 @@
       </p>
   <% end %>
 
-  <% if location == "correspondence" %>
-    <p><%= govuk_link_to t(".link_text"), providers_legal_aid_application_address_path(@legal_aid_application) %></p>
-  <% end %>
+  <p>
+    <%= govuk_link_to(
+          t(".link_text"),
+          location == "correspondence" ? providers_legal_aid_application_address_path(@legal_aid_application) : providers_legal_aid_application_home_address_address_path(@legal_aid_application),
+        ) %>
+  </p>
   <%= next_action_buttons(
         continue_id: "select-address-button",
         show_draft: false,

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -171,12 +171,12 @@ en:
               blank: Please select an address from the list
             postcode:
               blank: Enter a postcode
-              invalid: Enter a postcode in the right format
+              invalid: Enter a postcode in the correct format
         applicants/address_lookup_form:
           attributes:
             postcode:
               blank: Enter a postcode
-              invalid: Enter a postcode in the right format
+              invalid: Enter a postcode in the correct format
         applicants/address_selection_form:
           attributes:
             address:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -25,17 +25,6 @@ en:
         secure_link_para: Send an email to your client with a secure link to the online assessment.
         send_client_link: Send link
         title: Send your client a link to access the service
-    addresses:
-      show:
-        heading: Enter your client's correspondence address
-        address_manual_link: Enter address manually
-        label_1: postcode
-        address_line_one: Address line 1
-        address_line_two: Address line 2 (optional)
-        city: Town or city
-        county: County (optional)
-        postcode: Postcode
-        submit_button: Find address
     applicant_employed:
       index:
         heading_1: What is your client's employment status?
@@ -421,16 +410,6 @@ en:
           address_line_two: Address line 2 (optional)
           address_line_three: Address line 3 (optional)
           address_line_four: Address line 4 (optional)
-      addresses:
-        show:
-          heading: Enter your client's home address
-          label_1: postcode
-          address_line_one: Address line 1
-          address_line_two: Address line 2 (optional)
-          city: Town or city
-          county: County (optional)
-          postcode: Postcode
-          submit_button: Find address
     link_case:
       invitations:
         show:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -421,6 +421,16 @@ en:
           address_line_two: Address line 2 (optional)
           address_line_three: Address line 3 (optional)
           address_line_four: Address line 4 (optional)
+      addresses:
+        show:
+          heading: Enter your client's home address
+          label_1: postcode
+          address_line_one: Address line 1
+          address_line_two: Address line 2 (optional)
+          city: Town or city
+          county: County (optional)
+          postcode: Postcode
+          submit_button: Find address
     link_case:
       invitations:
         show:

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -138,6 +138,16 @@ en:
         paragraph_2: You can change the postcode or enter the address manually.
         change_postcode: Change the postcode
         manual_address: Enter an address manually
+    addresses:
+      heading: Enter your client's %{location} address
+      address_manual_link: Enter address manually
+      label_1: postcode
+      address_line_one: Address line 1
+      address_line_two: Address line 2 (optional)
+      city: Town or city
+      county: County (optional)
+      postcode: Postcode
+      submit_button: Find address
     application_ref:
       apply_ref: 'Apply service case reference:'
       ccms_ref_html: "<abbr title='Client and Cost Management System'>CCMS</abbr> case reference:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,6 +174,7 @@ Rails.application.routes.draw do
         resource :confirmation, only: %i[show update]
       end
       namespace :home_address do
+        resource :address, only: %i[show update], path: "enter_home_address"
         resource :different_address, only: %i[show update], path: "correspondence_is_home_address"
         resource :different_address_reason, only: %i[show update], path: "why_addresses_differ"
         resource :home_address_lookup, only: %i[show update], path: "find_home_address"

--- a/spec/helpers/providers_helper_spec.rb
+++ b/spec/helpers/providers_helper_spec.rb
@@ -15,12 +15,19 @@ RSpec.describe ProvidersHelper do
   end
   let(:controllers_with_params) { %w[incoming_transactions outgoing_transactions remove_dependants] }
   let(:excluded_controllers) { %w[bank_transactions] + controllers_with_params }
+  let(:home_address_controllers) do
+    %w[home_addresses
+       home_address_lookups
+       home_address_selections
+       home_address_different_address_reaons
+       home_address_different_addresses]
+  end
 
   describe "#url_for_application" do
     subject(:url_helper) { url_for_application(legal_aid_application) }
 
     it "does not crash" do
-      (provider_controller_names - excluded_controllers).each do |controller_name|
+      (provider_controller_names - excluded_controllers + home_address_controllers).each do |controller_name|
         legal_aid_application.provider_step = controller_name
         expect { url_for_application(legal_aid_application) }.not_to raise_error
       end

--- a/spec/requests/providers/addresses_controller_spec.rb
+++ b/spec/requests/providers/addresses_controller_spec.rb
@@ -75,12 +75,12 @@ RSpec.describe Providers::AddressesController do
       end
 
       context "with a valid address" do
-        context "when linked_applications flag is disabled" do
-          before { Setting.update!(linked_applications: false) }
+        context "when home_address flag is enabled" do
+          before { Setting.update!(home_address: true) }
 
-          it "redirects successfully to the next step" do
+          it "redirects to different addresses page" do
             patch_request
-            expect(response).to redirect_to(providers_legal_aid_application_proceedings_types_path)
+            expect(response).to redirect_to(providers_legal_aid_application_home_address_different_address_path)
           end
         end
 
@@ -90,6 +90,13 @@ RSpec.describe Providers::AddressesController do
           it "redirects successfully to the next step" do
             patch_request
             expect(response).to redirect_to(providers_legal_aid_application_copy_case_invitation_path)
+          end
+        end
+
+        context "when neither linking_applications nor home_address feature flags are enabled" do
+          it "redirects successfully to the next step" do
+            patch_request
+            expect(response).to redirect_to(providers_legal_aid_application_proceedings_types_path)
           end
         end
 

--- a/spec/requests/providers/home_address/addresses_controller_spec.rb
+++ b/spec/requests/providers/home_address/addresses_controller_spec.rb
@@ -1,0 +1,166 @@
+require "rails_helper"
+
+RSpec.describe Providers::HomeAddress::AddressesController do
+  let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
+  let(:applicant) { legal_aid_application.applicant }
+  let(:provider) { legal_aid_application.provider }
+  let(:home_address) { applicant.home_address }
+  let(:address_params) do
+    {
+      address:
+      {
+        address_line_one: "123",
+        address_line_two: "High Street",
+        city: "London",
+        county: "Greater London",
+        postcode: "SW1H 9AJ",
+      },
+    }
+  end
+
+  describe "GET /providers/applications/:legal_aid_application_id/home_address/enter_home_address" do
+    subject(:get_request) { get providers_legal_aid_application_home_address_address_path(legal_aid_application) }
+
+    context "when the provider is not authenticated" do
+      before { get_request }
+
+      it_behaves_like "a provider not authenticated"
+    end
+
+    context "when the provider is authenticated" do
+      before do
+        login_as provider
+      end
+
+      it "returns success" do
+        get_request
+        expect(response).to be_successful
+        expect(unescaped_response_body).to include("Enter your client's home address")
+      end
+
+      context "when the applicant already entered an address" do
+        let!(:home_address) { create(:address, applicant:) }
+
+        it "fills the form with the existing address" do
+          get_request
+          expect(unescaped_response_body).to include(home_address.address_line_one)
+          expect(unescaped_response_body).to include(home_address.address_line_two)
+          expect(unescaped_response_body).to include(home_address.city)
+          expect(unescaped_response_body).to include(home_address.county)
+          expect(unescaped_response_body).to include(home_address.postcode)
+        end
+      end
+    end
+  end
+
+  describe "PATCH /providers/applications/:legal_aid_application_id/home_address/enter_home_address" do
+    subject(:patch_request) do
+      patch(
+        providers_legal_aid_application_home_address_address_path(legal_aid_application),
+        params: address_params.merge(submit_button),
+      )
+    end
+
+    let(:submit_button) { {} }
+
+    context "when the provider is not authenticated" do
+      before { patch_request }
+
+      it_behaves_like "a provider not authenticated"
+    end
+
+    context "when the provider is authenticated" do
+      before do
+        login_as provider
+      end
+
+      context "with a valid address" do
+        context "when linking_applications flag is enabled" do
+          before { Setting.update!(linked_applications: true) }
+
+          it "redirects successfully to the next step" do
+            patch_request
+            expect(response).to redirect_to(providers_legal_aid_application_copy_case_invitation_path)
+          end
+        end
+
+        context "when linked_applications flag is disabled" do
+          it "redirects successfully to the next step" do
+            patch_request
+            expect(response).to redirect_to(providers_legal_aid_application_proceedings_types_path)
+          end
+        end
+
+        it "creates an address record" do
+          expect { patch_request }.to change { applicant.addresses.count }.by(1)
+          expect(home_address.address_line_one).to eq(address_params[:address][:address_line_one])
+          expect(home_address.address_line_two).to eq(address_params[:address][:address_line_two])
+          expect(home_address.city).to eq(address_params[:address][:city])
+          expect(home_address.county).to eq(address_params[:address][:county])
+          expect(home_address.postcode).to eq(address_params[:address][:postcode].delete(" ").upcase)
+        end
+      end
+
+      context "with an invalid address" do
+        before { address_params[:address].delete(:postcode) }
+
+        it "renders the form again if validation fails" do
+          patch_request
+          expect(unescaped_response_body).to include("Enter your client's home address")
+          expect(response.body).to include("Enter a postcode")
+        end
+      end
+
+      context "with an already existing address" do
+        before { create(:address, applicant:) }
+
+        it "does not create a new address record" do
+          expect { patch_request }.not_to change { applicant.addresses.count }
+        end
+
+        it "updates the current address" do
+          patch_request
+          expect(home_address.address_line_one).to eq(address_params[:address][:address_line_one])
+          expect(home_address.address_line_two).to eq(address_params[:address][:address_line_two])
+          expect(home_address.city).to eq(address_params[:address][:city])
+          expect(home_address.county).to eq(address_params[:address][:county])
+          expect(home_address.postcode).to eq(address_params[:address][:postcode].delete(" ").upcase)
+        end
+      end
+
+      context "when a previous address lookup failed" do
+        let(:address_params) do
+          {
+            address:
+            {
+              lookup_postcode: "SW1H 9AJ",
+              address_line_one: "123",
+              address_line_two: "High Street",
+              city: "London",
+              county: "Greater London",
+              postcode: "SW1H 9AJ",
+            },
+          }
+        end
+
+        it "records that address lookup was used" do
+          patch_request
+          expect(home_address.lookup_used).to be(true)
+        end
+      end
+
+      context "with form submitted using Save as draft button" do
+        let(:submit_button) { { draft_button: "Save as draft" } }
+
+        it "redirects provider to provider's applications page" do
+          patch_request
+          expect(response).to redirect_to(providers_legal_aid_applications_path)
+        end
+
+        it "sets the application as draft" do
+          expect { patch_request }.to change { legal_aid_application.reload.draft? }.from(false).to(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/providers/home_address/addresses_controller_spec.rb
+++ b/spec/requests/providers/home_address/addresses_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Providers::HomeAddress::AddressesController do
       end
 
       context "when the applicant already entered an address" do
-        let!(:home_address) { create(:address, applicant:) }
+        let!(:home_address) { create(:address, applicant:, location: "home") }
 
         it "fills the form with the existing address" do
           get_request
@@ -112,7 +112,7 @@ RSpec.describe Providers::HomeAddress::AddressesController do
       end
 
       context "with an already existing address" do
-        before { create(:address, applicant:) }
+        before { create(:address, applicant:, location: "home") }
 
         it "does not create a new address record" do
           expect { patch_request }.not_to change { applicant.addresses.count }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4831)

- Update flow for manual correspondence address path when `home_address` feature flag is enabled
- Added home_address/addresses_controller and  corresponding views
- Created shared addresses partial for manual correspondence and home address entry

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
