### PR TITLE
ap-4854: add home address to check_provider_answers

### DIFF
--- a/app/forms/home_address/different_address_form.rb
+++ b/app/forms/home_address/different_address_form.rb
@@ -5,5 +5,13 @@ module HomeAddress
     attr_accessor :same_correspondence_and_home_address
 
     validates :same_correspondence_and_home_address, presence: true, unless: :draft?
+
+    def save
+      if same_correspondence_and_home_address.eql?("true") && model.home_address
+        model.home_address.destroy!
+      end
+      super
+    end
+    alias_method :save!, :save
   end
 end

--- a/app/forms/home_address/different_address_reason_form.rb
+++ b/app/forms/home_address/different_address_reason_form.rb
@@ -5,5 +5,13 @@ module HomeAddress
     attr_accessor :no_fixed_residence
 
     validates :no_fixed_residence, presence: true, unless: :draft?
+
+    def save
+      if no_fixed_residence.eql?("true") && model.home_address
+        model.home_address.destroy!
+      end
+      super
+    end
+    alias_method :save!, :save
   end
 end

--- a/app/helpers/check_provider_answers_helper.rb
+++ b/app/helpers/check_provider_answers_helper.rb
@@ -1,7 +1,22 @@
 module CheckProviderAnswersHelper
-  def change_address_link(applicant)
-    return providers_legal_aid_application_address_lookup_path(anchor: :postcode) if applicant.address&.lookup_used?
+  def change_address_link(legal_aid_application, location)
+    if location == "correspondence"
+      return providers_legal_aid_application_address_lookup_path(legal_aid_application.id, anchor: :postcode) if legal_aid_application.applicant&.address&.lookup_used?
 
-    providers_legal_aid_application_address_path(anchor: :postcode)
+      providers_legal_aid_application_address_path(legal_aid_application.id, anchor: :postcode)
+
+    elsif location == "home"
+      providers_legal_aid_application_home_address_different_address_path(legal_aid_application.id)
+    end
+  end
+
+  def home_address_text(applicant)
+    if applicant.same_correspondence_and_home_address?
+      "Same as correspondence address"
+    elsif applicant.no_fixed_residence?
+      "No fixed residence"
+    else
+      address_with_line_breaks(applicant.home_address)
+    end
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,12 +1,7 @@
 class Address < ApplicationRecord
   belongs_to :applicant
 
-  validates :city, :postcode, presence: true
-
-  before_validation :normalize_postcode
-
-  validates :postcode, format: { with: POSTCODE_REGEXP }
-  validate :validate_address_lines
+  before_save :normalize_postcode
 
   def self.from_json(json)
     attrs = JSON.parse(json)
@@ -18,6 +13,8 @@ class Address < ApplicationRecord
   end
 
   def pretty_postcode
+    return unless postcode
+
     pretty_postcode? ? postcode : postcode.insert(-4, " ")
   end
 
@@ -37,12 +34,6 @@ class Address < ApplicationRecord
   end
 
 private
-
-  def validate_address_lines
-    return if address_line_one.present? || address_line_two.present?
-
-    errors.add(:address_line_one, :blank)
-  end
 
   def normalize_postcode
     return if postcode.blank?

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -78,6 +78,8 @@ module Flow
               :different_address_reasons
             end
           end,
+          check_answers: :check_provider_answers,
+          carry_on_sub_flow: ->(application) { !application.applicant.same_correspondence_and_home_address? },
         },
         different_address_reasons: {
           path: ->(application) { urls.providers_legal_aid_application_home_address_different_address_reason_path(application) },
@@ -88,6 +90,8 @@ module Flow
               :home_address_lookups
             end
           end,
+          check_answers: :check_provider_answers,
+          carry_on_sub_flow: ->(application) { !application.applicant.no_fixed_residence? },
         },
         non_uk_home_addresses: {
           # :nocov:

--- a/app/views/providers/check_provider_answers/_shared.html.erb
+++ b/app/views/providers/check_provider_answers/_shared.html.erb
@@ -2,7 +2,7 @@
 
   <%= render(
         "shared/check_answers/client_details",
-        attributes: %i[first_name last_name last_name_at_birth changed_last_name date_of_birth national_insurance_number employment_status address],
+        attributes: %i[first_name last_name last_name_at_birth changed_last_name date_of_birth national_insurance_number employment_status address home_address],
         applicant: @applicant,
         address: @address,
         read_only: @read_only,

--- a/app/views/shared/check_answers/_client_details.html.erb
+++ b/app/views/shared/check_answers/_client_details.html.erb
@@ -81,7 +81,19 @@
       <%= row.with_value(text: address_with_line_breaks(address)) %>
       <%= row.with_action(
             text: t("generic.change"),
-            href: change_address_link(applicant),
+            href: change_address_link(@legal_aid_application, "correspondence"),
+            visually_hidden_text: "#{t('.aria_prefix')} #{t('.address')}",
+          ) %>
+    <% end %>
+  <% end %>
+
+  <% if Setting.home_address? && :home_address.in?(attributes) %>
+    <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__address" }) do |row| %>
+      <%= row.with_key(text: t(".home_address"), classes: "govuk-!-width-one-half") %>
+      <%= row.with_value(text: home_address_text(applicant)) %>
+      <%= row.with_action(
+            text: t("generic.change"),
+            href: change_address_link(@legal_aid_application, "home"),
             visually_hidden_text: "#{t('.aria_prefix')} #{t('.address')}",
           ) %>
     <% end %>

--- a/app/views/shared/check_answers/_client_details.html.erb
+++ b/app/views/shared/check_answers/_client_details.html.erb
@@ -88,7 +88,7 @@
   <% end %>
 
   <% if Setting.home_address? && :home_address.in?(attributes) %>
-    <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__address" }) do |row| %>
+    <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__home_address" }) do |row| %>
       <%= row.with_key(text: t(".home_address"), classes: "govuk-!-width-one-half") %>
       <%= row.with_value(text: home_address_text(applicant)) %>
       <%= row.with_action(

--- a/app/views/shared/check_answers/_client_details.html.erb
+++ b/app/views/shared/check_answers/_client_details.html.erb
@@ -94,7 +94,7 @@
       <%= row.with_action(
             text: t("generic.change"),
             href: change_address_link(@legal_aid_application, "home"),
-            visually_hidden_text: "#{t('.aria_prefix')} #{t('.address')}",
+            visually_hidden_text: "#{t('.aria_prefix')} #{t('.home_address')}",
           ) %>
     <% end %>
   <% end %>

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -386,6 +386,7 @@ en:
         total: Total capital assessed
       client_details:
         address: Correspondence address
+        home_address: Home address
         aria_prefix: client's
         employment_status: Employment status
         age: "%{years} years old"

--- a/features/cassettes/Checking_client_details_answers_backwards_and_forwards/I_am_able_to_return_and_amend_the_client_s_home_address.yml
+++ b/features/cassettes/Checking_client_details_answers_backwards_and_forwards/I_am_able_to_return_and_amend_the_client_s_home_address.yml
@@ -1,0 +1,134 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.os.uk/search/places/v1/postcode?key=<ORDNANCE_SURVEY_API_KEY>&lr=EN&postcode=SW1H9EA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.9.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Mon, 18 Mar 2024 08:38:22 GMT
+      content-type:
+      - application/json;charset=UTF-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      vary:
+      - Origin,Accept-Encoding,key
+      omse-category:
+      - premium
+      omse-transaction-count:
+      - '60'
+      omse-premium-count:
+      - '0'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: "{\r\n  \"header\" : {\r\n    \"uri\" : \"https://api.os.uk/search/places/v1/postcode?lr=EN&postcode=SW1H9EA\",\r\n
+        \   \"query\" : \"postcode=SW1H9EA\",\r\n    \"offset\" : 0,\r\n    \"totalresults\"
+        : 5,\r\n    \"format\" : \"JSON\",\r\n    \"dataset\" : \"DPA\",\r\n    \"lr\"
+        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"108\",\r\n    \"lastupdate\"
+        : \"2024-03-15\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
+        : [ {\r\n    \"DPA\" : {\r\n      \"UPRN\" : \"100023337883\",\r\n      \"UDPRN\"
+        : \"23749699\",\r\n      \"ADDRESS\" : \"SUPER FIRM LTD, 84, PETTY FRANCE,
+        LONDON, SW1H 9EA\",\r\n      \"ORGANISATION_NAME\" : \"SUPER FIRM LTD\",\r\n
+        \     \"BUILDING_NUMBER\" : \"84\",\r\n      \"THOROUGHFARE_NAME\" : \"PETTY
+        FRANCE\",\r\n      \"POST_TOWN\" : \"LONDON\",\r\n      \"POSTCODE\" : \"SW1H
+        9EA\",\r\n      \"RPC\" : \"2\",\r\n      \"X_COORDINATE\" : 529526.39,\r\n
+        \     \"Y_COORDINATE\" : 179490.43,\r\n      \"STATUS\" : \"APPROVED\",\r\n
+        \     \"LOGICAL_STATUS_CODE\" : \"1\",\r\n      \"CLASSIFICATION_CODE\" :
+        \"CR07\",\r\n      \"CLASSIFICATION_CODE_DESCRIPTION\" : \"Restaurant / Cafeteria\",\r\n
+        \     \"LOCAL_CUSTODIAN_CODE\" : 5990,\r\n      \"LOCAL_CUSTODIAN_CODE_DESCRIPTION\"
+        : \"CITY OF WESTMINSTER\",\r\n      \"COUNTRY_CODE\" : \"E\",\r\n      \"COUNTRY_CODE_DESCRIPTION\"
+        : \"This record is within England\",\r\n      \"POSTAL_ADDRESS_CODE\" : \"D\",\r\n
+        \     \"POSTAL_ADDRESS_CODE_DESCRIPTION\" : \"A record which is linked to
+        PAF\",\r\n      \"BLPU_STATE_CODE\" : \"2\",\r\n      \"BLPU_STATE_CODE_DESCRIPTION\"
+        : \"In use\",\r\n      \"TOPOGRAPHY_LAYER_TOID\" : \"osgb1000042216527\",\r\n
+        \     \"LAST_UPDATE_DATE\" : \"10/02/2016\",\r\n      \"ENTRY_DATE\" : \"19/03/2001\",\r\n
+        \     \"BLPU_STATE_DATE\" : \"19/03/2001\",\r\n      \"LANGUAGE\" : \"EN\",\r\n
+        \     \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\" : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\"
+        : \"1B\"\r\n    }\r\n  }, {\r\n    \"DPA\" : {\r\n      \"UPRN\" : \"10033650067\",\r\n
+        \     \"UDPRN\" : \"56825040\",\r\n      \"ADDRESS\" : \"BRITISH TRANSPORT
+        POLICE, 98, PETTY FRANCE, LONDON, SW1H 9EA\",\r\n      \"ORGANISATION_NAME\"
+        : \"BRITISH TRANSPORT POLICE\",\r\n      \"BUILDING_NUMBER\" : \"98\",\r\n
+        \     \"THOROUGHFARE_NAME\" : \"PETTY FRANCE\",\r\n      \"POST_TOWN\" : \"LONDON\",\r\n
+        \     \"POSTCODE\" : \"SW1H 9EA\",\r\n      \"RPC\" : \"2\",\r\n      \"X_COORDINATE\"
+        : 529558.47,\r\n      \"Y_COORDINATE\" : 179482.17,\r\n      \"STATUS\" :
+        \"APPROVED\",\r\n      \"LOGICAL_STATUS_CODE\" : \"1\",\r\n      \"CLASSIFICATION_CODE\"
+        : \"CO01\",\r\n      \"CLASSIFICATION_CODE_DESCRIPTION\" : \"Office / Work
+        Studio\",\r\n      \"LOCAL_CUSTODIAN_CODE\" : 5990,\r\n      \"LOCAL_CUSTODIAN_CODE_DESCRIPTION\"
+        : \"CITY OF WESTMINSTER\",\r\n      \"COUNTRY_CODE\" : \"E\",\r\n      \"COUNTRY_CODE_DESCRIPTION\"
+        : \"This record is within England\",\r\n      \"POSTAL_ADDRESS_CODE\" : \"D\",\r\n
+        \     \"POSTAL_ADDRESS_CODE_DESCRIPTION\" : \"A record which is linked to
+        PAF\",\r\n      \"BLPU_STATE_CODE\" : \"2\",\r\n      \"BLPU_STATE_CODE_DESCRIPTION\"
+        : \"In use\",\r\n      \"TOPOGRAPHY_LAYER_TOID\" : \"osgb1000042217066\",\r\n
+        \     \"PARENT_UPRN\" : \"100023337884\",\r\n      \"LAST_UPDATE_DATE\" :
+        \"14/02/2022\",\r\n      \"ENTRY_DATE\" : \"19/03/2021\",\r\n      \"BLPU_STATE_DATE\"
+        : \"19/03/2021\",\r\n      \"LANGUAGE\" : \"EN\",\r\n      \"MATCH\" : 1.0,\r\n
+        \     \"MATCH_DESCRIPTION\" : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\"
+        : \"1Q\"\r\n    }\r\n  }, {\r\n    \"DPA\" : {\r\n      \"UPRN\" : \"100023337884\",\r\n
+        \     \"UDPRN\" : \"23749702\",\r\n      \"ADDRESS\" : \"TRANSPORT FOR LONDON,
+        98, PETTY FRANCE, LONDON, SW1H 9EA\",\r\n      \"ORGANISATION_NAME\" : \"TRANSPORT
+        FOR LONDON\",\r\n      \"BUILDING_NUMBER\" : \"98\",\r\n      \"THOROUGHFARE_NAME\"
+        : \"PETTY FRANCE\",\r\n      \"POST_TOWN\" : \"LONDON\",\r\n      \"POSTCODE\"
+        : \"SW1H 9EA\",\r\n      \"RPC\" : \"1\",\r\n      \"X_COORDINATE\" : 529558.47,\r\n
+        \     \"Y_COORDINATE\" : 179482.17,\r\n      \"STATUS\" : \"APPROVED\",\r\n
+        \     \"LOGICAL_STATUS_CODE\" : \"1\",\r\n      \"CLASSIFICATION_CODE\" :
+        \"PP\",\r\n      \"CLASSIFICATION_CODE_DESCRIPTION\" : \"Property Shell\",\r\n
+        \     \"LOCAL_CUSTODIAN_CODE\" : 5990,\r\n      \"LOCAL_CUSTODIAN_CODE_DESCRIPTION\"
+        : \"CITY OF WESTMINSTER\",\r\n      \"COUNTRY_CODE\" : \"E\",\r\n      \"COUNTRY_CODE_DESCRIPTION\"
+        : \"This record is within England\",\r\n      \"POSTAL_ADDRESS_CODE\" : \"D\",\r\n
+        \     \"POSTAL_ADDRESS_CODE_DESCRIPTION\" : \"A record which is linked to
+        PAF\",\r\n      \"BLPU_STATE_CODE\" : \"2\",\r\n      \"BLPU_STATE_CODE_DESCRIPTION\"
+        : \"In use\",\r\n      \"TOPOGRAPHY_LAYER_TOID\" : \"osgb1000042217066\",\r\n
+        \     \"LAST_UPDATE_DATE\" : \"30/03/2021\",\r\n      \"ENTRY_DATE\" : \"19/03/2001\",\r\n
+        \     \"BLPU_STATE_DATE\" : \"19/03/2001\",\r\n      \"LANGUAGE\" : \"EN\",\r\n
+        \     \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\" : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\"
+        : \"1F\"\r\n    }\r\n  }, {\r\n    \"DPA\" : {\r\n      \"UPRN\" : \"100023337882\",\r\n
+        \     \"UDPRN\" : \"23749700\",\r\n      \"ADDRESS\" : \"100, PETTY FRANCE,
+        LONDON, SW1H 9EA\",\r\n      \"BUILDING_NUMBER\" : \"100\",\r\n      \"THOROUGHFARE_NAME\"
+        : \"PETTY FRANCE\",\r\n      \"POST_TOWN\" : \"LONDON\",\r\n      \"POSTCODE\"
+        : \"SW1H 9EA\",\r\n      \"RPC\" : \"2\",\r\n      \"X_COORDINATE\" : 529619.99,\r\n
+        \     \"Y_COORDINATE\" : 179499.2,\r\n      \"STATUS\" : \"APPROVED\",\r\n
+        \     \"LOGICAL_STATUS_CODE\" : \"1\",\r\n      \"CLASSIFICATION_CODE\" :
+        \"CT08\",\r\n      \"CLASSIFICATION_CODE_DESCRIPTION\" : \"Station / Interchange
+        / Terminal / Halt\",\r\n      \"LOCAL_CUSTODIAN_CODE\" : 5990,\r\n      \"LOCAL_CUSTODIAN_CODE_DESCRIPTION\"
+        : \"CITY OF WESTMINSTER\",\r\n      \"COUNTRY_CODE\" : \"E\",\r\n      \"COUNTRY_CODE_DESCRIPTION\"
+        : \"This record is within England\",\r\n      \"POSTAL_ADDRESS_CODE\" : \"D\",\r\n
+        \     \"POSTAL_ADDRESS_CODE_DESCRIPTION\" : \"A record which is linked to
+        PAF\",\r\n      \"BLPU_STATE_CODE\" : \"2\",\r\n      \"BLPU_STATE_CODE_DESCRIPTION\"
+        : \"In use\",\r\n      \"TOPOGRAPHY_LAYER_TOID\" : \"osgb1000042216526\",\r\n
+        \     \"LAST_UPDATE_DATE\" : \"24/08/2021\",\r\n      \"ENTRY_DATE\" : \"19/03/2001\",\r\n
+        \     \"BLPU_STATE_DATE\" : \"19/03/2001\",\r\n      \"LANGUAGE\" : \"EN\",\r\n
+        \     \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\" : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\"
+        : \"1A\"\r\n    }\r\n  }, {\r\n    \"DPA\" : {\r\n      \"UPRN\" : \"10033648845\",\r\n
+        \     \"UDPRN\" : \"54770395\",\r\n      \"ADDRESS\" : \"C P S, 102, PETTY
+        FRANCE, LONDON, SW1H 9EA\",\r\n      \"ORGANISATION_NAME\" : \"C P S\",\r\n
+        \     \"BUILDING_NUMBER\" : \"102\",\r\n      \"THOROUGHFARE_NAME\" : \"PETTY
+        FRANCE\",\r\n      \"POST_TOWN\" : \"LONDON\",\r\n      \"POSTCODE\" : \"SW1H
+        9EA\",\r\n      \"RPC\" : \"2\",\r\n      \"X_COORDINATE\" : 529576.0,\r\n
+        \     \"Y_COORDINATE\" : 179549.0,\r\n      \"STATUS\" : \"APPROVED\",\r\n
+        \     \"LOGICAL_STATUS_CODE\" : \"1\",\r\n      \"CLASSIFICATION_CODE\" :
+        \"CO01\",\r\n      \"CLASSIFICATION_CODE_DESCRIPTION\" : \"Office / Work Studio\",\r\n
+        \     \"LOCAL_CUSTODIAN_CODE\" : 5990,\r\n      \"LOCAL_CUSTODIAN_CODE_DESCRIPTION\"
+        : \"CITY OF WESTMINSTER\",\r\n      \"COUNTRY_CODE\" : \"E\",\r\n      \"COUNTRY_CODE_DESCRIPTION\"
+        : \"This record is within England\",\r\n      \"POSTAL_ADDRESS_CODE\" : \"D\",\r\n
+        \     \"POSTAL_ADDRESS_CODE_DESCRIPTION\" : \"A record which is linked to
+        PAF\",\r\n      \"BLPU_STATE_CODE\" : \"2\",\r\n      \"BLPU_STATE_CODE_DESCRIPTION\"
+        : \"In use\",\r\n      \"TOPOGRAPHY_LAYER_TOID\" : \"osgb1000001796535716\",\r\n
+        \     \"PARENT_UPRN\" : \"10033604583\",\r\n      \"LAST_UPDATE_DATE\" : \"06/07/2020\",\r\n
+        \     \"ENTRY_DATE\" : \"15/06/2020\",\r\n      \"BLPU_STATE_DATE\" : \"15/06/2020\",\r\n
+        \     \"LANGUAGE\" : \"EN\",\r\n      \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\"
+        : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\" : \"1N\"\r\n    }\r\n  } ]\r\n}"
+  recorded_at: Mon, 18 Mar 2024 08:38:22 GMT
+recorded_with: VCR 6.2.0

--- a/features/cassettes/Checking_client_details_answers_backwards_and_forwards/I_am_able_to_return_and_amend_the_client_s_overseas_home_address.yml
+++ b/features/cassettes/Checking_client_details_answers_backwards_and_forwards/I_am_able_to_return_and_amend_the_client_s_overseas_home_address.yml
@@ -1,0 +1,111 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/countries/all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v2.9.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Mon, 18 Mar 2024 14:09:30 GMT
+      content-type:
+      - application/json; charset=utf-8
+      content-length:
+      - '10609'
+      connection:
+      - keep-alive
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      x-permitted-cross-domain-policies:
+      - none
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      vary:
+      - Accept, Origin
+      etag:
+      - W/"a6709cb4760a6ce4b0ae574fc3c030cc"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 172c75af5f90aab64a154deb29a7323d
+      x-runtime:
+      - '0.006356'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '[{"code":"AFG","description":"Afghanistan"},{"code":"ALA","description":"Aland
+        Islands"},{"code":"ALB","description":"Albania"},{"code":"DZA","description":"Algeria"},{"code":"ASM","description":"American
+        Samoa"},{"code":"AND","description":"Andorra"},{"code":"AGO","description":"Angola"},{"code":"AIA","description":"Anguilla"},{"code":"ATA","description":"Antarctica"},{"code":"ATG","description":"Antigua
+        and Barbuda"},{"code":"ARG","description":"Argentina"},{"code":"ARM","description":"Armenia"},{"code":"ABW","description":"Aruba"},{"code":"AUS","description":"Australia"},{"code":"AUT","description":"Austria"},{"code":"AZE","description":"Azerbaijan"},{"code":"BHS","description":"Bahamas"},{"code":"BHR","description":"Bahrain"},{"code":"BGD","description":"Bangladesh"},{"code":"BRB","description":"Barbados"},{"code":"BLR","description":"Belarus"},{"code":"BEL","description":"Belgium"},{"code":"BLZ","description":"Belize"},{"code":"BEN","description":"Benin"},{"code":"BMU","description":"Bermuda"},{"code":"BTN","description":"Bhutan"},{"code":"BOL","description":"Bolivia,
+        Plurinational State of"},{"code":"BIH","description":"Bosnia and Herzegovina"},{"code":"BWA","description":"Botswana"},{"code":"BVT","description":"Bouvet
+        Island"},{"code":"BRA","description":"Brazil"},{"code":"IOT","description":"British
+        Indian Ocean Territory"},{"code":"BRN","description":"Brunei Darussalam"},{"code":"BGR","description":"Bulgaria"},{"code":"BFA","description":"Burkina
+        Faso"},{"code":"BDI","description":"Burundi"},{"code":"KHM","description":"Cambodia"},{"code":"CMR","description":"Cameroon"},{"code":"CAN","description":"Canada"},{"code":"CPV","description":"Cape
+        Verde"},{"code":"CYM","description":"Cayman Islands"},{"code":"CAF","description":"Central
+        African Republic"},{"code":"TCD","description":"Chad"},{"code":"CHL","description":"Chile"},{"code":"CHN","description":"China"},{"code":"CXR","description":"Christmas
+        Island"},{"code":"CCK","description":"Cocos (Keeling) Islands"},{"code":"COL","description":"Colombia"},{"code":"COM","description":"Comoros"},{"code":"COG","description":"Congo"},{"code":"COD","description":"Congo,
+        The Democratic Republic of the"},{"code":"COK","description":"Cook Islands"},{"code":"CRI","description":"Costa
+        Rica"},{"code":"CIV","description":"Cote d''Ivoire"},{"code":"HRV","description":"Croatia"},{"code":"CUB","description":"Cuba"},{"code":"CYP","description":"Cyprus"},{"code":"CZE","description":"Czech
+        Republic"},{"code":"DNK","description":"Denmark"},{"code":"DJI","description":"Djibouti"},{"code":"DMA","description":"Dominica"},{"code":"DOM","description":"Dominican
+        Republic"},{"code":"ECU","description":"Ecuador"},{"code":"EGY","description":"Egypt"},{"code":"SLV","description":"El
+        Salvador"},{"code":"GNQ","description":"Equatorial Guinea"},{"code":"ERI","description":"Eritrea"},{"code":"EST","description":"Estonia"},{"code":"ETH","description":"Ethiopia"},{"code":"FLK","description":"Falkland
+        Islands (Malvinas)"},{"code":"FRO","description":"Faroe Islands"},{"code":"FJI","description":"Fiji"},{"code":"FIN","description":"Finland"},{"code":"FRA","description":"France"},{"code":"GUF","description":"French
+        Guiana"},{"code":"PYF","description":"French Polynesia"},{"code":"ATF","description":"French
+        Southern Territories"},{"code":"GAB","description":"Gabon"},{"code":"GMB","description":"Gambia"},{"code":"GEO","description":"Georgia"},{"code":"DEU","description":"Germany"},{"code":"GHA","description":"Ghana"},{"code":"GIB","description":"Gibraltar"},{"code":"GRC","description":"Greece"},{"code":"GRL","description":"Greenland"},{"code":"GRD","description":"Grenada"},{"code":"GLP","description":"Guadeloupe"},{"code":"GUM","description":"Guam"},{"code":"GTM","description":"Guatemala"},{"code":"GGY","description":"Guernsey"},{"code":"GIN","description":"Guinea"},{"code":"GNB","description":"Guinea-Bissau"},{"code":"GUY","description":"Guyana"},{"code":"HTI","description":"Haiti"},{"code":"HMD","description":"Heard
+        Island and McDonald Islands"},{"code":"VAT","description":"Holy See (Vatican
+        City State)"},{"code":"HND","description":"Honduras"},{"code":"HKG","description":"Hong
+        Kong"},{"code":"HUN","description":"Hungary"},{"code":"ISL","description":"Iceland"},{"code":"IND","description":"India"},{"code":"IDN","description":"Indonesia"},{"code":"IRN","description":"Iran,
+        Islamic Republic of"},{"code":"IRQ","description":"Iraq"},{"code":"IRL","description":"Ireland"},{"code":"IMN","description":"Isle
+        of Man"},{"code":"ISR","description":"Israel"},{"code":"ITA","description":"Italy"},{"code":"JAM","description":"Jamaica"},{"code":"JPN","description":"Japan"},{"code":"JEY","description":"Jersey"},{"code":"JOR","description":"Jordan"},{"code":"KAZ","description":"Kazakhstan"},{"code":"KEN","description":"Kenya"},{"code":"KIR","description":"Kiribati"},{"code":"PRK","description":"Korea,
+        Democratic People''s Republic of"},{"code":"KOR","description":"Korea, Republic
+        of"},{"code":"KWT","description":"Kuwait"},{"code":"KGZ","description":"Kyrgyzstan"},{"code":"LAO","description":"Lao
+        People''s Democratic Republic"},{"code":"LVA","description":"Latvia"},{"code":"LBN","description":"Lebanon"},{"code":"LSO","description":"Lesotho"},{"code":"LBR","description":"Liberia"},{"code":"LBY","description":"Libyan
+        Arab Jamahiriya"},{"code":"LIE","description":"Liechtenstein"},{"code":"LTU","description":"Lithuania"},{"code":"LUX","description":"Luxembourg"},{"code":"MAC","description":"Macao"},{"code":"MKD","description":"Macedonia,
+        The Former Yugoslav Republic of"},{"code":"MDG","description":"Madagascar"},{"code":"MWI","description":"Malawi"},{"code":"MYS","description":"Malaysia"},{"code":"MDV","description":"Maldives"},{"code":"MLI","description":"Mali"},{"code":"MLT","description":"Malta"},{"code":"MHL","description":"Marshall
+        Islands"},{"code":"MTQ","description":"Martinique"},{"code":"MRT","description":"Mauritania"},{"code":"MUS","description":"Mauritius"},{"code":"MYT","description":"Mayotte"},{"code":"MEX","description":"Mexico"},{"code":"FSM","description":"Micronesia,
+        Federated States of"},{"code":"MDA","description":"Moldova"},{"code":"MCO","description":"Monaco"},{"code":"MNG","description":"Mongolia"},{"code":"MNE","description":"Montenegro"},{"code":"MSR","description":"Montserrat"},{"code":"MAR","description":"Morocco"},{"code":"MOZ","description":"Mozambique"},{"code":"MMR","description":"Myanmar"},{"code":"NAM","description":"Namibia"},{"code":"NRU","description":"Nauru"},{"code":"NPL","description":"Nepal"},{"code":"NLD","description":"Netherlands"},{"code":"ANT","description":"Netherlands
+        Antilles"},{"code":"NCL","description":"New Caledonia"},{"code":"NZL","description":"New
+        Zealand"},{"code":"NIC","description":"Nicaragua"},{"code":"NER","description":"Niger"},{"code":"NGA","description":"Nigeria"},{"code":"NIU","description":"Niue"},{"code":"NFK","description":"Norfolk
+        Island"},{"code":"MNP","description":"Northern Mariana Islands"},{"code":"NOR","description":"Norway"},{"code":"OMN","description":"Oman"},{"code":"PAK","description":"Pakistan"},{"code":"PLW","description":"Palau"},{"code":"PSE","description":"Palestinian
+        Territory,Occupied"},{"code":"PAN","description":"Panama"},{"code":"PNG","description":"Papua
+        New Guinea"},{"code":"PRY","description":"Paraguay"},{"code":"PER","description":"Peru"},{"code":"PHL","description":"Philippines"},{"code":"PCN","description":"Pitcairn"},{"code":"POL","description":"Poland"},{"code":"PRT","description":"Portugal"},{"code":"PRI","description":"Puerto
+        Rico"},{"code":"QAT","description":"Qatar"},{"code":"REU","description":"Reunion"},{"code":"ROU","description":"Romania"},{"code":"RUS","description":"Russian
+        Federation"},{"code":"RWA","description":"Rwanda"},{"code":"BLM","description":"Saint
+        Barthelemy"},{"code":"SHN","description":"Saint Helena"},{"code":"KNA","description":"Saint
+        Kitts and Nevis"},{"code":"LCA","description":"Saint Lucia"},{"code":"MAF","description":"Saint
+        Martin (French part)"},{"code":"SPM","description":"Saint Pierre and Miquelon"},{"code":"VCT","description":"Saint
+        Vincent and the Grenadines"},{"code":"WSM","description":"Samoa"},{"code":"SMR","description":"San
+        Marino"},{"code":"STP","description":"Sao Tome and Principe"},{"code":"SAU","description":"Saudi
+        Arabia"},{"code":"SEN","description":"Senegal"},{"code":"SRB","description":"Serbia"},{"code":"SYC","description":"Seychelles"},{"code":"SLE","description":"Sierra
+        Leone"},{"code":"SGP","description":"Singapore"},{"code":"SVK","description":"Slovakia"},{"code":"SVN","description":"Slovenia"},{"code":"SLB","description":"Solomon
+        Islands"},{"code":"SOM","description":"Somalia"},{"code":"ZAF","description":"South
+        Africa"},{"code":"SGS","description":"South Georgia and the South Sandwich
+        Islands"},{"code":"ESP","description":"Spain"},{"code":"LKA","description":"Sri
+        Lanka"},{"code":"SDN","description":"Sudan"},{"code":"SUR","description":"Suriname"},{"code":"SJM","description":"Svalbard
+        and Jan Mayen"},{"code":"SWZ","description":"Swaziland"},{"code":"SWE","description":"Sweden"},{"code":"CHE","description":"Switzerland"},{"code":"SYR","description":"Syrian
+        Arab Republic"},{"code":"TWN","description":"Taiwan"},{"code":"TJK","description":"Tajikistan"},{"code":"TZA","description":"Tanzania,
+        United Republic of"},{"code":"THA","description":"Thailand"},{"code":"TLS","description":"Timor-Leste"},{"code":"TGO","description":"Togo"},{"code":"TKL","description":"Tokelau"},{"code":"TON","description":"Tonga"},{"code":"TTO","description":"Trinidad
+        and Tobago"},{"code":"TUN","description":"Tunisia"},{"code":"TUR","description":"Turkey"},{"code":"TKM","description":"Turkmenistan"},{"code":"TCA","description":"Turks
+        and Caicos Islands"},{"code":"TUV","description":"Tuvalu"},{"code":"UGA","description":"Uganda"},{"code":"UKR","description":"Ukraine"},{"code":"ARE","description":"United
+        Arab Emirates"},{"code":"GBR","description":"United Kingdom"},{"code":"USA","description":"United
+        States"},{"code":"UMI","description":"United States Minor Outlying Islands"},{"code":"URY","description":"Uruguay"},{"code":"UZB","description":"Uzbekistan"},{"code":"VUT","description":"Vanuatu"},{"code":"VEN","description":"Venezuela,
+        Bolivarian Republic of"},{"code":"VNM","description":"Viet Nam"},{"code":"VGB","description":"Virgin
+        Islands, British"},{"code":"VIR","description":"Virgin Islands, U.S."},{"code":"WLF","description":"Wallis
+        and Futuna"},{"code":"ESH","description":"Western Sahara"},{"code":"YEM","description":"Yemen"},{"code":"ZMB","description":"Zambia"},{"code":"ZWE","description":"Zimbabwe"}]'
+  recorded_at: Mon, 18 Mar 2024 14:09:30 GMT
+recorded_with: VCR 6.2.0

--- a/features/providers/check_provider_answers.feature
+++ b/features/providers/check_provider_answers.feature
@@ -75,6 +75,7 @@ Feature: Checking client details answers backwards and forwards
   Scenario: I am able to return and amend the client's address
     Given I complete the passported journey as far as check your answers for client details
     And I should see "Transport For London"
+    And I should not see "Home address"
 
     When I click Check Your Answers Change link for "address"
     Then I should be on a page with title "Find your client's correspondence address"
@@ -84,6 +85,32 @@ Feature: Checking client details answers backwards and forwards
     And I click 'Use this address'
     Then I should be on a page with title "Check your answers"
     And I should see "British Transport Police"
+  
+  @javascript @vcr
+  Scenario: I am able to return and amend the client's home address
+    Given the feature flag for home_address is enabled
+    And I complete the passported journey as far as check your answers for client details
+    And the "Client details" check your answers section should contain:
+      | question | answer |
+      | Correspondence address | Transport For London\n98 Petty France\nLondon\nSW1H 9EA |
+      | Home address | Same as correspondence address |
+    When I click Check Your Answers Change link for "home address"
+    Then I should be on a page with title "Is this also your client's home address?"
+    And I choose 'No'
+    Then I click 'Save and continue'
+    Then I should be on a page with title "Why is your client's home address different to their correspondence address?"
+    And I choose 'They have a different home address'
+    Then I click 'Save and continue'
+    Then I should be on a page with title "Find your client's home address"
+    Then I enter a postcode 'SW1H 9EA'
+    When I click 'Find address'
+    And I choose an address 'British Transport Police, 98 Petty France, London, SW1H 9EA'
+    And I click 'Use this address'
+    Then I should be on a page with title "Check your answers"
+    And the "Client details" check your answers section should contain:
+      | question | answer |
+      | Correspondence address | Transport For London\n98 Petty France\nLondon\nSW1H 9EA |
+      | Home address | British Transport Police\n98 Petty France\nLondon\nSW1H 9EA |
 
   @javascript
   Scenario: I am able to return and remove the client's national insurance number

--- a/features/providers/check_provider_answers.feature
+++ b/features/providers/check_provider_answers.feature
@@ -112,6 +112,33 @@ Feature: Checking client details answers backwards and forwards
       | Correspondence address | Transport For London\n98 Petty France\nLondon\nSW1H 9EA |
       | Home address | British Transport Police\n98 Petty France\nLondon\nSW1H 9EA |
 
+
+  @javascript @vcr
+  Scenario: I am able to return and amend the client's overseas home address
+    Given the feature flag for home_address is enabled
+    And I complete the passported journey as far as check your answers with an overseas address
+    And the "Client details" check your answers section should contain:
+      | question | answer |
+      | Correspondence address | Transport For London\n98 Petty France\nLondon\nSW1H 9EA |
+      | Home address | Alemannenstrasse 1\nStuttgart D-12345 |
+    When I click Check Your Answers Change link for "home address"
+    Then I should be on a page with title "Is this also your client's home address?"
+    And I choose 'No'
+    Then I click 'Save and continue'
+    Then I should be on a page with title "Why is your client's home address different to their correspondence address?"
+    And I choose 'They have a different home address'
+    Then I click 'Save and continue'
+    Then I should be on a page with title "Find your client's home address"
+    And I click link "Enter a non-UK address"
+    And I choose "Germany"
+    Then I complete overseas home address 'address line one' with 'Alemannenstrasse 2'
+    Then I complete overseas home address 'address line two' with 'Stuttgart D-54321'
+    Then I click 'Save and continue'
+    And the "Client details" check your answers section should contain:
+      | question | answer |
+      | Correspondence address | Transport For London\n98 Petty France\nLondon\nSW1H 9EA |
+      | Home address | Alemannenstrasse 2\nStuttgart D-54321 |
+
   @javascript
   Scenario: I am able to return and remove the client's national insurance number
     Given I complete the passported journey as far as check your answers for client details

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -641,6 +641,7 @@ Given("I complete the passported journey as far as check your answers for client
     national_insurance_number: "JA293483A",
     date_of_birth: "10-01-1980",
     email: "test@test.com",
+    same_correspondence_and_home_address: true,
   )
   create(
     :address,

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -670,6 +670,56 @@ Given("I complete the passported journey as far as check your answers for client
   steps %(Then I should be on a page showing 'Check your answers')
 end
 
+Given("I complete the passported journey as far as check your answers with an overseas address") do
+  applicant = create(
+    :applicant,
+    first_name: "Test",
+    last_name: "Walker",
+    national_insurance_number: "JA293483A",
+    date_of_birth: "10-01-1980",
+    email: "test@test.com",
+    same_correspondence_and_home_address: false,
+  )
+  create(
+    :address,
+    address_line_one: "Transport For London",
+    address_line_two: "98 Petty France",
+    city: "London",
+    county: nil,
+    postcode: "SW1H 9EA",
+    location: "correspondence",
+    lookup_used: true,
+    applicant:,
+  )
+  create(
+    :address,
+    country: "DEU",
+    address_line_one: "Alemannenstrasse 1",
+    address_line_two: "Stuttgart D-12345",
+    city: nil,
+    county: nil,
+    postcode: nil,
+    location: "home",
+    lookup_used: false,
+    applicant:,
+  )
+  @legal_aid_application = create(
+    :legal_aid_application,
+    :with_passported_state_machine,
+    :at_entering_applicant_details,
+    :with_proceedings,
+    explicit_proceedings: [:da001],
+    set_lead_proceeding: :da001,
+    applicant:,
+  )
+  create(:legal_framework_merits_task_list, :da001, legal_aid_application: @legal_aid_application)
+  login_as @legal_aid_application.provider
+
+  visit(providers_legal_aid_application_check_provider_answers_path(@legal_aid_application))
+
+  steps %(Then I should be on a page showing 'Check your answers')
+end
+
 Given("I complete the journey as far as check passported answers with multiple proceedings") do
   @legal_aid_application = create(
     :application,
@@ -1116,6 +1166,12 @@ Then(/^I enter ((a|an|the)\s)?([\w\s]+?) ["']([\w\s]+)["']$/) do |_ignore, field
   field_name.gsub!(/\s+/, "_")
   name = find("input[name*=#{field_name}], ##{field_id}")[:name]
   fill_in(name, with: entry)
+end
+
+Then("I complete overseas home address {string} with {string}") do |line, value|
+  line.gsub!(/\s+/, "_")
+  name = "non_uk_home_address[#{line}]"
+  fill_in(name, with: value)
 end
 
 Then(/^I select the first checkbox$/) do

--- a/spec/forms/home_address/different_address_form_spec.rb
+++ b/spec/forms/home_address/different_address_form_spec.rb
@@ -1,0 +1,100 @@
+require "rails_helper"
+
+RSpec.describe HomeAddress::DifferentAddressForm, type: :form do
+  subject(:instance) { described_class.new(params) }
+
+  let(:applicant) { create(:applicant, home_address:) }
+  let(:home_address) { create(:address, location: "home") }
+
+  let(:params) do
+    {
+      model: applicant,
+      same_correspondence_and_home_address:,
+    }
+  end
+
+  describe "#save" do
+    subject(:call_save) { instance.save }
+
+    before { call_save }
+
+    context "with yes chosen" do
+      let(:same_correspondence_and_home_address) { "true" }
+
+      it "sets same_correspondence_and_home_address to true" do
+        expect(applicant.same_correspondence_and_home_address?).to be true
+      end
+
+      it "destroys any existing home address" do
+        expect(applicant.reload.home_address).to be_nil
+      end
+    end
+
+    context "with no chosen" do
+      let(:same_correspondence_and_home_address) { "false" }
+
+      it "sets same_correspondence_and_home_address to true" do
+        expect(applicant.same_correspondence_and_home_address?).to be false
+      end
+
+      it "does not destroy any existing home address" do
+        expect(applicant.home_address).to eq home_address
+      end
+    end
+
+    context "with no answer chosen" do
+      let(:same_correspondence_and_home_address) { "" }
+
+      it "is invalid" do
+        expect(instance).not_to be_valid
+      end
+
+      it "adds custom blank error message" do
+        error_messages = instance.errors.messages.values.flatten
+        expect(error_messages).to include("Select yes if this is your client's home address")
+      end
+    end
+  end
+
+  describe "#save_as_draft" do
+    subject(:save_as_draft) { instance.save_as_draft }
+
+    before { save_as_draft }
+
+    context "with yes chosen" do
+      let(:same_correspondence_and_home_address) { "true" }
+
+      it "sets same_correspondence_and_home_address to true" do
+        expect(applicant.same_correspondence_and_home_address?).to be true
+      end
+
+      it "destroys any existing home address" do
+        expect(applicant.reload.home_address).to be_nil
+      end
+    end
+
+    context "with no chosen" do
+      let(:same_correspondence_and_home_address) { "false" }
+
+      it "sets same_correspondence_and_home_address to true" do
+        expect(applicant.same_correspondence_and_home_address?).to be false
+      end
+
+      it "does not destroy any existing home address" do
+        expect(applicant.reload.home_address).to eq home_address
+      end
+    end
+
+    context "with no answer chosen" do
+      let(:same_correspondence_and_home_address) { "" }
+
+      it "is valid" do
+        expect(instance).to be_valid
+      end
+
+      it "does not update same_correspondence_and_home_addresss" do
+        expect(applicant.same_correspondence_and_home_address).to be_nil
+      end
+    end
+  end
+end

--- a/spec/forms/home_address/different_address_reason_form_spec.rb
+++ b/spec/forms/home_address/different_address_reason_form_spec.rb
@@ -1,0 +1,100 @@
+require "rails_helper"
+
+RSpec.describe HomeAddress::DifferentAddressReasonForm, type: :form do
+  subject(:instance) { described_class.new(params) }
+
+  let(:applicant) { create(:applicant, home_address:) }
+  let(:home_address) { create(:address, location: "home") }
+
+  let(:params) do
+    {
+      model: applicant,
+      no_fixed_residence:,
+    }
+  end
+
+  describe "#save" do
+    subject(:call_save) { instance.save }
+
+    before { call_save }
+
+    context "with yes chosen" do
+      let(:no_fixed_residence) { "true" }
+
+      it "sets no_fixed_residence to true" do
+        expect(applicant.no_fixed_residence?).to be true
+      end
+
+      it "destroys any existing home address" do
+        expect(applicant.reload.home_address).to be_nil
+      end
+    end
+
+    context "with no chosen" do
+      let(:no_fixed_residence) { "false" }
+
+      it "sets no_fixed_residence to true" do
+        expect(applicant.no_fixed_residence?).to be false
+      end
+
+      it "does not destroy any existing home address" do
+        expect(applicant.home_address).to eq home_address
+      end
+    end
+
+    context "with no answer chosen" do
+      let(:no_fixed_residence) { "" }
+
+      it "is invalid" do
+        expect(instance).not_to be_valid
+      end
+
+      it "adds custom blank error message" do
+        error_messages = instance.errors.messages.values.flatten
+        expect(error_messages).to include("Select why the client's home address is different to their correspondence address")
+      end
+    end
+  end
+
+  describe "#save_as_draft" do
+    subject(:save_as_draft) { instance.save_as_draft }
+
+    before { save_as_draft }
+
+    context "with yes chosen" do
+      let(:no_fixed_residence) { "true" }
+
+      it "sets no_fixed_residence to true" do
+        expect(applicant.no_fixed_residence?).to be true
+      end
+
+      it "destroys any existing home address" do
+        expect(applicant.reload.home_address).to be_nil
+      end
+    end
+
+    context "with no chosen" do
+      let(:no_fixed_residence) { "false" }
+
+      it "sets no_fixed_residence to true" do
+        expect(applicant.no_fixed_residence?).to be false
+      end
+
+      it "does not destroy any existing home address" do
+        expect(applicant.reload.home_address).to eq home_address
+      end
+    end
+
+    context "with no answer chosen" do
+      let(:no_fixed_residence) { "" }
+
+      it "is valid" do
+        expect(instance).to be_valid
+      end
+
+      it "does not update no_fixed_residences" do
+        expect(applicant.no_fixed_residence).to be_nil
+      end
+    end
+  end
+end

--- a/spec/helpers/check_provider_answers_helper_spec.rb
+++ b/spec/helpers/check_provider_answers_helper_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe CheckProviderAnswersHelper do
+  let(:legal_aid_application) { create(:legal_aid_application, applicant:) }
+  let(:applicant) { create(:applicant, address:, same_correspondence_and_home_address:, no_fixed_residence:) }
+  let(:address) { create(:address, lookup_used:) }
+  let(:lookup_used) { false }
+  let(:same_correspondence_and_home_address) { false }
+  let(:no_fixed_abode) { false }
+  let(:no_fixed_residence) { false }
+
+  describe ".change_address_link" do
+    subject(:link) { helper.change_address_link(legal_aid_application, location) }
+
+    context "when location is home" do
+      let(:location) { "home" }
+
+      it "returns the home_address_different_address path" do
+        expect(link).to eq "/providers/applications/#{legal_aid_application.id}/home_address/correspondence_is_home_address?locale=en"
+      end
+    end
+
+    context "when location is correspondence" do
+      let(:location) { "correspondence" }
+
+      context "when lookup_used is false" do
+        it "returns the manual address entry path" do
+          expect(link).to eq "/providers/applications/#{legal_aid_application.id}/enter_correspondence_address?locale=en#postcode"
+        end
+      end
+
+      context "when lookup_used is true" do
+        let(:lookup_used) { true }
+
+        it "returns the address lookup path" do
+          expect(link).to eq "/providers/applications/#{legal_aid_application.id}/find_correspondence_address?locale=en#postcode"
+        end
+      end
+    end
+  end
+
+  describe ".home_address_text" do
+    subject(:text) { helper.home_address_text(applicant) }
+
+    let(:address) { create(:address, location: "home") }
+
+    context "when applicant has same home and correspondence address" do
+      let(:same_correspondence_and_home_address) { true }
+
+      it { expect(text).to eq "Same as correspondence address" }
+    end
+
+    context "when applicant has no fixed residence" do
+      let(:no_fixed_residence) { true }
+
+      it { expect(text).to eq "No fixed residence" }
+    end
+
+    context "when applicant has a home address" do
+      it { expect(text).to eq "#{address.address_line_one}<br>#{address.address_line_two}<br>#{address.city}<br>#{address.county}<br>#{address.pretty_postcode}" }
+    end
+  end
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -3,47 +3,23 @@ require "rails_helper"
 RSpec.describe Address do
   subject(:model) { build(:address) }
 
-  it "is valid with all valid attributes" do
-    expect(model).to be_valid
+  describe ".pretty_postcode" do
+    it "can display the postcode with a space reinserted" do
+      model.postcode = "SW1H9AJ"
+      expect(model.pretty_postcode).to eq("SW1H 9AJ")
+    end
+
+    it "returns nil if the postcode is nil" do
+      model.postcode = nil
+      expect(model.pretty_postcode).to be_nil
+    end
   end
 
-  it "is not valid without a building name and street address" do
-    model.address_line_one = ""
-    model.address_line_two = ""
-    expect(model).not_to be_valid
-    expect(model.errors[:address_line_one]).to include("can't be blank")
-  end
-
-  it "is valid without a building name" do
-    model.address_line_one = ""
-    expect(model).to be_valid
-  end
-
-  it "is valid without a street address" do
-    model.address_line_two = ""
-    expect(model).to be_valid
-  end
-
-  it "is not valid without a town or city" do
-    model.city = nil
-    expect(model).not_to be_valid
-    expect(model.errors[:city]).to include("can't be blank")
-  end
-
-  it "is not valid when a postcode is not provided" do
-    model.postcode = nil
-    expect(model).not_to be_valid
-    expect(model.errors[:postcode]).to include("can't be blank")
-  end
-
-  it "is not valid if the postcode entered is not in the correct format" do
-    model.postcode = "1GIR00A"
-    expect(model).not_to be_valid
-    expect(model.errors[:postcode]).to include("is not in the right format")
-  end
-
-  it "can display the postcode with a space reinserted" do
-    model.postcode = "SW1H9AJ"
-    expect(model.pretty_postcode).to eq("SW1H 9AJ")
+  describe ".save" do
+    it "converts the postcode to uppercase and deletes whitespace" do
+      model.postcode = "sw1h 9aj"
+      model.save!
+      expect(model.postcode).to eq("SW1H9AJ")
+    end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4854)

- Added home address to cya.

- Fix to remove existing home address where a user sets no_fixed_residence? or same_correspondence_and_home_address? to true.
- Removed validation on address model as this is not applicable to overseas addresses and we will rely on the forms for validation.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
