### PR TITLE
AP-4906: Update default country handling for addresses

### DIFF
--- a/app/controllers/providers/address_lookups_controller.rb
+++ b/app/controllers/providers/address_lookups_controller.rb
@@ -18,7 +18,7 @@ module Providers
     end
 
     def address
-      applicant.address || applicant.build_address(location: "correspondence")
+      applicant.address || applicant.build_address(location: "correspondence", country: "GBR")
     end
   end
 end

--- a/app/controllers/providers/address_selections_controller.rb
+++ b/app/controllers/providers/address_selections_controller.rb
@@ -33,7 +33,7 @@ module Providers
     end
 
     def address
-      applicant.address || applicant.build_address
+      applicant.address || applicant.build_address(country: "GBR")
     end
 
     def address_lookup

--- a/app/controllers/providers/addresses_controller.rb
+++ b/app/controllers/providers/addresses_controller.rb
@@ -22,7 +22,7 @@ module Providers
     end
 
     def address
-      applicant.address || applicant.build_address
+      applicant.address || applicant.build_address(country: "GBR")
     end
   end
 end

--- a/app/controllers/providers/home_address/addresses_controller.rb
+++ b/app/controllers/providers/home_address/addresses_controller.rb
@@ -17,6 +17,7 @@ module Providers
         Address.new(
           applicant:,
           location: "home",
+          country: "GBR",
         )
       end
 

--- a/app/controllers/providers/home_address/home_address_lookups_controller.rb
+++ b/app/controllers/providers/home_address/home_address_lookups_controller.rb
@@ -16,6 +16,7 @@ module Providers
         Address.new(
           applicant:,
           location: "home",
+          country: "GBR",
         )
       end
 

--- a/app/controllers/providers/home_address/home_address_selections_controller.rb
+++ b/app/controllers/providers/home_address/home_address_selections_controller.rb
@@ -28,7 +28,7 @@ module Providers
     private
 
       def address
-        applicant.home_address || applicant.build_address
+        applicant.home_address || applicant.build_address(country: "GBR")
       end
 
       def address_lookup

--- a/spec/requests/providers/address_lookups_controller_spec.rb
+++ b/spec/requests/providers/address_lookups_controller_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe Providers::AddressLookupsController do
           patch_request
           expect(applicant.address.postcode).to eq(postcode.delete(" ").upcase)
           expect(applicant.address.location).to eq("correspondence")
+          expect(applicant.address.country).to eq("GBR")
         end
 
         it "redirects to the address selection page" do

--- a/spec/requests/providers/address_selections_controller_spec.rb
+++ b/spec/requests/providers/address_selections_controller_spec.rb
@@ -149,6 +149,7 @@ RSpec.describe Providers::AddressSelectionsController do
         expect { patch_request }.to change { applicant.reload.addresses.count }.by(1)
         expect(applicant.address.address_line_one).to eq(selected_address[:address_line_one])
         expect(applicant.address.lookup_id).to eq(lookup_id)
+        expect(applicant.address.country).to eq("GBR")
       end
 
       it "records that the lookup service was used" do

--- a/spec/requests/providers/addresses_controller_spec.rb
+++ b/spec/requests/providers/addresses_controller_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe Providers::AddressesController do
           expect(address.city).to eq(address_params[:address][:city])
           expect(address.county).to eq(address_params[:address][:county])
           expect(address.postcode).to eq(address_params[:address][:postcode].delete(" ").upcase)
+          expect(address.country).to eq("GBR")
         end
       end
 

--- a/spec/requests/providers/home_address/addresses_controller_spec.rb
+++ b/spec/requests/providers/home_address/addresses_controller_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe Providers::HomeAddress::AddressesController do
           expect(home_address.city).to eq(address_params[:address][:city])
           expect(home_address.county).to eq(address_params[:address][:county])
           expect(home_address.postcode).to eq(address_params[:address][:postcode].delete(" ").upcase)
+          expect(home_address.country).to eq("GBR")
         end
       end
 

--- a/spec/requests/providers/home_address/home_address_lookups_controller_spec.rb
+++ b/spec/requests/providers/home_address/home_address_lookups_controller_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe Providers::HomeAddress::HomeAddressLookupsController do
           patch_request
           expect(applicant.home_address.postcode).to eq(postcode.delete(" ").upcase)
           expect(applicant.home_address.location).to eq("home")
+          expect(applicant.home_address.country).to eq("GBR")
         end
 
         it "redirects to the home address selection page" do

--- a/spec/requests/providers/home_address/home_address_selections_controller_spec.rb
+++ b/spec/requests/providers/home_address/home_address_selections_controller_spec.rb
@@ -149,6 +149,7 @@ RSpec.describe Providers::HomeAddress::HomeAddressSelectionsController do
         expect { patch_request }.to change { applicant.reload.addresses.count }.by(1)
         expect(applicant.home_address.address_line_one).to eq(selected_address[:address_line_one])
         expect(applicant.home_address.lookup_id).to eq(lookup_id)
+        expect(applicant.home_address.country).to eq("GBR")
       end
 
       it "records that the lookup service was used" do
@@ -207,6 +208,7 @@ RSpec.describe Providers::HomeAddress::HomeAddressSelectionsController do
           expect(applicant.home_address.address_line_two).to eq("FAKE ROAD")
           expect(applicant.home_address.city).to eq("TEST CITY")
           expect(applicant.home_address.postcode).to eq("AA11AA")
+          expect(applicant.home_address.country).to eq("GBR")
         end
       end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4906)

When adding Non-UK countries we forgot to set the default to GBR when storing a new address, this updates the creation of address and ensures they get set to the default value, GBR

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
