### PR TITLE
AP-4728: Update CCMS address handling

### DIFF
--- a/app/helpers/address_helper.rb
+++ b/app/helpers/address_helper.rb
@@ -6,7 +6,8 @@ module AddressHelper
               address.address_line_two,
               address.city,
               address.county,
-              address.pretty_postcode].compact.compact_blank.join("<br>"), tags: %w[br]
+              address.pretty_postcode,
+              address.country?].compact.compact_blank.join("<br>"), tags: %w[br]
   end
 
   def address_one_line(address)
@@ -16,6 +17,7 @@ module AddressHelper
               address.address_line_two,
               address.city,
               address.county,
-              address.pretty_postcode].compact.compact_blank.join(", ")
+              address.pretty_postcode,
+              address.country?].compact.compact_blank.join(", ")
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -9,7 +9,7 @@ class Address < ApplicationRecord
   end
 
   def full_address
-    [address_line_one, address_line_two, city, county, postcode].compact.compact_blank.join(", ")
+    [address_line_one, address_line_two, city, county, postcode, country?].compact.compact_blank.join(", ")
   end
 
   def pretty_postcode
@@ -20,6 +20,14 @@ class Address < ApplicationRecord
 
   def pretty_postcode?
     postcode[-4] == " "
+  end
+
+  def country?
+    country if include_country?
+  end
+
+  def include_country?
+    country != "GBR"
   end
 
   def to_json(*_args)

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -135,4 +135,10 @@ class Applicant < ApplicationRecord
   def employment_payments
     employments.map(&:employment_payments).flatten
   end
+
+  def home_address_for_ccms
+    return if no_fixed_residence?
+
+    same_correspondence_and_home_address? ? address : home_address
+  end
 end

--- a/app/services/ccms/requestors/applicant_add_requestor.rb
+++ b/app/services/ccms/requestors/applicant_add_requestor.rb
@@ -5,7 +5,7 @@ module CCMS
 
       attr_reader :applicant
 
-      delegate :address, to: :applicant
+      delegate :home_address_for_ccms, to: :applicant
 
       def initialize(applicant, provider_username)
         super()
@@ -34,8 +34,8 @@ module CCMS
         xml.__send__(:"clientbio:Name") { name(xml) }
         xml.__send__(:"clientbio:PersonalInformation") { personal_information(xml) }
         xml.__send__(:"clientbio:Contacts") { contacts(xml) }
-        xml.__send__(:"clientbio:NoFixedAbode", false)
-        xml.__send__(:"clientbio:Address") { applicant_address(xml) }
+        xml.__send__(:"clientbio:NoFixedAbode", applicant.no_fixed_residence || false)
+        xml.__send__(:"clientbio:Address") { applicant_address(xml) unless applicant.no_fixed_residence }
         xml.__send__(:"clientbio:EthnicMonitoring", 0)
       end
 
@@ -64,12 +64,12 @@ module CCMS
       end
 
       def applicant_address(xml)
-        xml.__send__(:"common:AddressLine1", address.address_line_one)
-        xml.__send__(:"common:AddressLine2", address.address_line_two)
-        xml.__send__(:"common:City", address.city)
-        xml.__send__(:"common:County", address.county)
-        xml.__send__(:"common:Country", "GBR")
-        xml.__send__(:"common:PostalCode", address.pretty_postcode)
+        xml.__send__(:"common:AddressLine1", home_address_for_ccms.address_line_one)
+        xml.__send__(:"common:AddressLine2", home_address_for_ccms.address_line_two)
+        xml.__send__(:"common:City", home_address_for_ccms.city)
+        xml.__send__(:"common:County", home_address_for_ccms.county)
+        xml.__send__(:"common:Country", home_address_for_ccms.country)
+        xml.__send__(:"common:PostalCode", home_address_for_ccms.pretty_postcode) if home_address_for_ccms.postcode.present?
       end
     end
   end

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     address_line_two { Faker::Address.street_address }
     city { Faker::Address.city }
     county { Faker::Address.city }
+    country { "GBR" }
     postcode { ["SW10 9LB", "W6 0LQ", "SW1A 1AA", "RG2 7PU", "BH22 7HR"].sample }
     building_number_name { "" }
     location { "correspondence" }
@@ -15,6 +16,10 @@ FactoryBot.define do
 
     trait :with_address_for_xml_fixture do
       postcode { "GH08NY" }
+    end
+
+    trait :as_home_address do
+      location { "home" }
     end
   end
 end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -61,7 +61,7 @@ FactoryBot.define do
       transient do
         with_bank_accounts { 0 }
       end
-      applicant { build(:applicant, :with_address, with_bank_accounts:) }
+      applicant { build(:applicant, :with_address, with_bank_accounts:, same_correspondence_and_home_address: true) }
     end
 
     trait :with_applicant_with_student_loan do

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -490,4 +490,35 @@ RSpec.describe Applicant do
       end
     end
   end
+
+  describe "#home_address_for_ccms" do
+    subject(:home_address) { applicant.home_address_for_ccms }
+
+    let(:applicant) { create(:applicant, same_correspondence_and_home_address:, addresses:) }
+    let(:correspondence_address) { create(:address, address_line_one: "109 Correspondence Avenue") }
+
+    context "when the provider has set a different home address" do
+      let(:same_correspondence_and_home_address) { false }
+      let(:home_address) { create(:address, :as_home_address, address_line_one: "27 Home Street") }
+      let(:addresses) { [home_address, correspondence_address] }
+
+      it "is set to the expected, separate, home address" do
+        expect(applicant.home_address_for_ccms.address_line_one).to eql "27 Home Street"
+        expect(applicant.home_address.address_line_one).to eql "27 Home Street"
+        expect(applicant.address.address_line_one).to eql "109 Correspondence Avenue"
+      end
+    end
+
+    context "when the provider has set the home address to the same as correspondence" do
+      let(:same_correspondence_and_home_address) { true }
+      let(:home_address) { nil }
+      let(:addresses) { [correspondence_address] }
+
+      it "is set to the correspondence address" do
+        expect(applicant.home_address_for_ccms.address_line_one).to eql "109 Correspondence Avenue"
+        expect(applicant.home_address).to be_nil
+        expect(applicant.address.address_line_one).to eql "109 Correspondence Avenue"
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4728)

This PR is to update the address handling when submitting data to CCMS
It updates the Applicant model:
* with a `home_address_for_ccms` method that checks for a home address and falls back to the correspondence address if one is not found
* it does not send a home address if the provider has said they have no fixed residence

It updates the ApplicantAddRequestor to:
* use the new method from the Applicant model
* to submit a calculated value to `clientbio:NoFixedAbode` rather than using a fixed, `false` response

It updates the Address model and AddressHelper to return the country value if it is anything other than GBR, this allows us to display the chosen country code on CYA, review pages etc for non-UK home addresses


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
