### PR TITLE
Chore: Enable circle test rerun

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,10 +205,7 @@ jobs:
         command: |
           TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings --timings-type=filename)
           echo "${TESTFILES}"
-          bundle exec rspec --format progress \
-          --format RspecJunitFormatter \
-          -o /tmp/test-results/rspec/rspec.xml \
-          -- ${TESTFILES}
+          echo "${TESTFILES}" | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml"
 
     - store_test_results:
         path: /tmp/test-results/rspec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,7 +241,7 @@ jobs:
         command: |
           TESTFILES=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings)
           echo "${TESTFILES}"
-          echo "${TESTFILES}" | circleci tests run --command="xargs bundle exec cucumber --format junit,fileattribute=true --out /tmp/test-results/cucumber --format pretty -- ${TESTFILES}"
+          echo "${TESTFILES}" | circleci tests run --command="xargs bundle exec cucumber --format junit,fileattribute=true --out /tmp/test-results/cucumber --format pretty"
     - store_artifacts:
         path: tmp/capybara
     - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,9 +203,10 @@ jobs:
     - run:
         name: Run ruby tests
         command: |
-          TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings --timings-type=filename)
-          echo "${TESTFILES}"
-          echo "${TESTFILES}" | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml"
+          mkdir -p /tmp/test-results/rspec
+          TEST_FILES=$(circleci tests glob "spec/**/*_spec.rb")
+          echo "${TEST_FILES}"
+          echo "${TEST_FILES}" | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml" --verbose --split-by=timings --timings-type=filename
 
     - store_test_results:
         path: /tmp/test-results/rspec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,7 +241,7 @@ jobs:
         command: |
           TESTFILES=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings)
           echo "${TESTFILES}"
-          bundle exec cucumber --format junit,fileattribute=true --out /tmp/test-results/cucumber --format pretty -- ${TESTFILES}
+          echo "${TESTFILES}" | circleci tests run --command="xargs bundle exec cucumber --format junit,fileattribute=true --out /tmp/test-results/cucumber --format pretty -- ${TESTFILES}"
     - store_artifacts:
         path: tmp/capybara
     - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,13 +200,11 @@ jobs:
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./tmp/cc-test-reporter
           chmod +x ./tmp/cc-test-reporter
     - run: bundle exec rails assets:precompile
+    - run: mkdir -p /tmp/test-results/rspec
     - run:
         name: Run ruby tests
         command: |
-          mkdir -p /tmp/test-results/rspec
-          TEST_FILES=$(circleci tests glob "spec/**/*_spec.rb")
-          echo "${TEST_FILES}"
-          echo "${TEST_FILES}" | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml" --verbose --split-by=timings --timings-type=filename
+          circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o ~/rspec/rspec.xml" --verbose --split-by=timings
 
     - store_test_results:
         path: /tmp/test-results/rspec
@@ -237,12 +235,11 @@ jobs:
     - run: bundle exec rails assets:precompile
     - browser-tools/install-chrome
     # - browser-tools/install-chromedriver # removed 31 Aug 2023 because version of chrome 116.0.5845.140 was not downloadable
+    - run: mkdir -p /tmp/test-results/cucumber
     - run:
         name: Run integration tests
         command: |
-          TESTFILES=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings)
-          echo "${TESTFILES}"
-          echo "${TESTFILES}" | circleci tests run --command="xargs bundle exec cucumber --format junit,fileattribute=true --out /tmp/test-results/cucumber --format pretty"
+          circleci tests glob "features/**/*.feature" | circleci tests run --command="xargs bundle exec cucumber --format junit,fileattribute=true --out /tmp/test-results/cucumber" --verbose --split-by=timings
     - store_artifacts:
         path: tmp/capybara
     - store_test_results:

--- a/spec/forms/applicants/email_form_spec.rb
+++ b/spec/forms/applicants/email_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Applicants::EmailForm, type: :form do
 
   describe ".model_name" do
     it 'is "Applicant"' do
-      expect(described_class.model_name).to eq("Applicant")
+      expect(described_class.model_name).to eq("Client")
     end
   end
 


### PR DESCRIPTION
## What

This turns on the ability to re-run only failing tests in circleci (hopefully) so that we don't have to re-run _all_ the tests

It's a proof of concept, following the instructions from Circle CI  so I will re-run the test jobs and hope they fail... or add a temp commit with a broken test to see if I can trigger it!

Checks for this PR:
- [ ] Do the rspec and cucumber tests run correctly?
- [ ] If something fails can I re-run just the failures

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
