### PR TITLE
Fix: Remove govuk-typography-responsive deprecation warning

### DIFF
--- a/app/assets/stylesheets/language-switcher.scss
+++ b/app/assets/stylesheets/language-switcher.scss
@@ -1,5 +1,5 @@
 .language-switcher {
-  @include govuk-typography-responsive($size: 16);
+  @include govuk-font-size($size: 16);
   margin-top: govuk-spacing(3);
   margin-bottom: govuk-spacing(3);
   text-align: right;


### PR DESCRIPTION
## What

This has been warning for a while on yarn build
```
Warning: govuk-typography-responsive is deprecated. Use govuk-font-size instead. To silence this warning, update $govuk-suppressed-warnings with key: "govuk-typography-responsive"
    node_modules/govuk-frontend/dist/govuk/settings/_warnings.scss 49:5    -warning()
    node_modules/govuk-frontend/dist/govuk/helpers/_typography.scss 117:3  govuk-typography-responsive()
    app/assets/stylesheets/language-switcher.scss 2:3                      @import
    app/assets/stylesheets/application.scss 19:9                           root stylesheet
```

Changing the import to govuk-font-size removes the warning and causes no issues on the citizen views when the (incomplete) welsh translation flag is enabled

### Screenshot from main branch
![image](https://github.com/ministryofjustice/laa-apply-for-legal-aid/assets/6757677/e024ab4f-7557-43e1-b1a2-f46f460ae41d)

### Screenshot from this branch
![image](https://github.com/ministryofjustice/laa-apply-for-legal-aid/assets/6757677/2d51bef0-080f-47af-a1f4-dfc6b0d22b00)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
