### PR TITLE
Chore: SonarCloud ignore rule

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,3 +1,12 @@
+# defines app core directories & spec
 sonar.sources=app, lib
 sonar.tests=features, spec
 sonar.test.exclusions=features/cassettes/**/*, spec/cassettes/**/*
+
+# defines a named multicriteria
+sonar.issue.ignore.multicriteria=e1
+
+# ignore rule "Methods should not be empty"
+sonar.issue.ignore.multicriteria.e1.ruleKey=ruby:S1186
+# applies the ignore rule to controllers in the project
+sonar.issue.ignore.multicriteria.e1.resourceKey=app/controllers/**/*.rb


### PR DESCRIPTION
## What

Chore: ignore SonarCloud rule:

- Ruby:S1186 (Methods should not be empty)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
