### PR TITLE
AP-4917: Add merits to cloner service

### DIFF
--- a/app/services/copy_case/cloner_service.rb
+++ b/app/services/copy_case/cloner_service.rb
@@ -13,7 +13,7 @@ module CopyCase
 
     def call
       clone_proceedings
-      clone_merits
+      clone_application_merits
     end
 
   private
@@ -22,7 +22,16 @@ module CopyCase
       new_proceedings = source.proceedings.each_with_object([]) do |proceeding, memo|
         memo << proceeding.deep_clone(
           except: %i[legal_aid_application_id proceeding_case_id],
-          include: [:scope_limitations],
+          include: %i[
+            scope_limitations
+            attempts_to_settle
+            chances_of_success
+            opponents_application
+            proceeding_linked_children
+            prohibited_steps
+            specific_issue
+            vary_order
+          ],
         )
       end
 
@@ -30,8 +39,8 @@ module CopyCase
       target.save!
     end
 
-    def clone_merits
-      application_merits = %i[
+    def clone_application_merits
+      merits = %i[
         allegation
         domestic_abuse_summary
         latest_incident
@@ -43,7 +52,7 @@ module CopyCase
         urgency
       ]
 
-      application_merits.each do |merit|
+      merits.each do |merit|
         attribute = source.public_send(merit)
 
         next if attribute.nil?

--- a/app/services/copy_case/cloner_service.rb
+++ b/app/services/copy_case/cloner_service.rb
@@ -19,42 +19,7 @@ module CopyCase
   private
 
     def clone_proceedings
-      new_proceedings = source.proceedings.each_with_object([]) do |proceeding, memo|
-        memo << proceeding.deep_clone(
-          except: %i[legal_aid_application_id proceeding_case_id],
-          include: %i[
-            scope_limitations
-            attempts_to_settle
-            chances_of_success
-            opponents_application
-            involved_children
-            proceeding_linked_children
-            prohibited_steps
-            specific_issue
-            vary_order
-          ],
-        )
-
-        # TODO: Fix this so that involved_children and proceeding_linked_children are correctly saved
-        # Previous attempts left in below
-
-        # memo << proceeding.deep_clone(
-        #   except: %i[legal_aid_application_id proceeding_case_id],
-        #   include: [
-        #     { involved_children: :proceeding_linked_children },
-        #   ],
-        # )
-
-        # next unless proceeding.proceeding_linked_children.any?
-
-        # linked_children = proceeding.proceeding_linked_children.each_with_object([]) do |child, child_memo|
-        #   child_memo << child.deep_clone
-        # end
-
-        # memo.last.proceeding_linked_children = linked_children
-      end
-
-      target.proceedings = new_proceedings
+      target.proceedings = source.proceedings.deep_dup
       target.save!
     end
 
@@ -76,19 +41,7 @@ module CopyCase
 
         next if attribute.nil?
 
-        copy = case merit
-               when :opponents
-                 attribute.each_with_object([]) do |item, memo|
-                   memo << item.deep_clone(include: [:opposable])
-                 end
-               when :involved_children
-                 attribute.each_with_object([]) do |item, memo|
-                   memo << item.deep_clone
-                 end
-               else
-                 attribute.deep_clone
-               end
-
+        copy = attribute.deep_dup
         target.update!("#{merit}": copy)
       end
     end

--- a/app/services/copy_case/cloner_service.rb
+++ b/app/services/copy_case/cloner_service.rb
@@ -27,12 +27,31 @@ module CopyCase
             attempts_to_settle
             chances_of_success
             opponents_application
+            involved_children
             proceeding_linked_children
             prohibited_steps
             specific_issue
             vary_order
           ],
         )
+
+        # TODO: Fix this so that involved_children and proceeding_linked_children are correctly saved
+        # Previous attempts left in below
+
+        # memo << proceeding.deep_clone(
+        #   except: %i[legal_aid_application_id proceeding_case_id],
+        #   include: [
+        #     { involved_children: :proceeding_linked_children },
+        #   ],
+        # )
+
+        # next unless proceeding.proceeding_linked_children.any?
+
+        # linked_children = proceeding.proceeding_linked_children.each_with_object([]) do |child, child_memo|
+        #   child_memo << child.deep_clone
+        # end
+
+        # memo.last.proceeding_linked_children = linked_children
       end
 
       target.proceedings = new_proceedings

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -692,6 +692,30 @@ FactoryBot.define do
       end
     end
 
+    trait :with_prohibited_steps do
+      after(:create) do |application|
+        proceeding = create(:proceeding, :se003)
+        create(:prohibited_steps, :with_data, proceeding:)
+        application.proceedings << proceeding
+      end
+    end
+
+    trait :with_specific_issue do
+      after(:create) do |application|
+        proceeding = create(:proceeding, :se004)
+        create(:specific_issue, proceeding:)
+        application.proceedings << proceeding
+      end
+    end
+
+    trait :with_vary_order do
+      after(:create) do |application|
+        proceeding = create(:proceeding, :da002)
+        create(:vary_order, proceeding:)
+        application.proceedings << proceeding
+      end
+    end
+
     trait :draft do
       draft { true }
     end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -443,6 +443,11 @@ FactoryBot.define do
       end
     end
 
+    trait :with_proceeding_linked_children do
+      # create { :proceeding_linked_child, proceeding:, involved_child: second_child }
+      # create { :proceeding_linked_child, proceeding:, involved_child: third_child }
+    end
+
     trait :with_dwp_override do
       dwp_override { build(:dwp_override) }
       with_non_passported_state_machine

--- a/spec/factories/specific_issue.rb
+++ b/spec/factories/specific_issue.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :specific_issue, class: "ProceedingMeritsTask::SpecificIssue" do
+    proceeding
+  end
+end

--- a/spec/factories/urgency.rb
+++ b/spec/factories/urgency.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :urgency, class: "ApplicationMeritsTask::Urgency" do
+    legal_aid_application
+    nature_of_urgency { "This is the nature of the urgency" }
+  end
+end

--- a/spec/services/copy_case/cloner_service_spec.rb
+++ b/spec/services/copy_case/cloner_service_spec.rb
@@ -146,7 +146,8 @@ RSpec.describe CopyCase::ClonerService do
           create(:proceeding_linked_child, proceeding:, involved_child: third_child)
 
           expect { call }
-            .to change { target.reload.proceedings.first&.proceeding_linked_children&.size }.from(0).to(1)
+            .to change { target.reload.proceedings.first&.proceeding_linked_children&.size }.from(nil).to(2)
+            .and change { target.reload.proceedings.first&.involved_children&.size }.from(nil).to(2)
         end
       end
     end

--- a/spec/services/copy_case/cloner_service_spec.rb
+++ b/spec/services/copy_case/cloner_service_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CopyCase::ClonerService do
   subject(:instance) { described_class.new(target, source) }
 
   let(:target) { create(:legal_aid_application, :with_applicant) }
-  let(:source) { create(:legal_aid_application, :with_proceedings) }
+  let(:source) { create(:legal_aid_application, :with_proceedings, :with_everything, :with_involved_children) }
 
   describe ".call" do
     subject(:call) { described_class.call(target, source) }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4917)

First 3 commits attempt to add merits to the cloner service using `deep_cloneable` gem
Final commit replaces that and uses `deep_dup` method instead


Failing test can be addressed when this is implemented

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
