### PR TITLE
Fix: Resolve flickering address test

### DIFF
--- a/spec/requests/providers/home_address/addresses_controller_spec.rb
+++ b/spec/requests/providers/home_address/addresses_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Providers::HomeAddress::AddressesController do
       end
 
       context "when the applicant already entered a non-UK home address" do
-        let!(:home_address) { create(:address, applicant:, location: "home", country_code: "DEU", country_name: "Germany") }
+        let!(:home_address) { create(:address, applicant:, address_line_one: Faker::Address.street_name, location: "home", country_code: "DEU", country_name: "Germany") }
 
         it "does not fill the form with the existing address" do
           get_request


### PR DESCRIPTION
## What

The default factory for address populates address_line_one with a building number.  
Sometimes the randomly generated building number is included elsewhere in the HTML rendering this test failing.  

In this failing screenshot, the house number was set to 268, which is part of the colour polyfill for the govuk logo!
![image](https://github.com/ministryofjustice/laa-apply-for-legal-aid/assets/6757677/df117abc-cf42-4436-9310-311b2858b9a6)

This PR replaces the one off flickery test with a building_name to prevent it recurring.  
Changing the factory could have affected many more tests and caused more fragility so was left as-is for now. 
If we see more of this type of flickering, it may be worth switching the factory to always use street_name.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
