### PR TITLE
AP-4933: Replace out-of-date text with voided

### DIFF
--- a/config/locales/en/enums.yml
+++ b/config/locales/en/enums.yml
@@ -45,6 +45,6 @@ en:
         submission_paused: Submission paused
         use_ccms: use_ccms
       summary_state:
-        expired: Out of date
+        expired: Voided
         in_progress: In progress
         submitted: Submitted

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1655,7 +1655,7 @@ en:
       blocks:
         show:
           title_html: You cannot submit this application
-          body_text: This is because it’s out of date. The application will be missing information because of service updates.
+          body_text: This is because the application will be missing information after recent updates to the service.
           options: "You can (choose one of the following):"
           option_bullets:
             - make a new application for your client if you still need to submit one

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -257,7 +257,7 @@ Rails.application.routes.draw do
         patch :reset
       end
       scope module: :interrupt do
-        resource :block, only: %i[show], path: "out-of-date-application"
+        resource :block, only: %i[show], path: "voided-application"
       end
       scope module: :proceeding_loop do
         resources :delegated_functions, only: %i[show update]

--- a/spec/helpers/providers_helper_spec.rb
+++ b/spec/helpers/providers_helper_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe ProvidersHelper do
 
         it "routes to the block page" do
           application_id = legal_aid_application.id
-          expect(url_for_application(legal_aid_application)).to eq("/providers/applications/#{application_id}/out-of-date-application?locale=en")
+          expect(url_for_application(legal_aid_application)).to eq("/providers/applications/#{application_id}/voided-application?locale=en")
         end
       end
 


### PR DESCRIPTION

## What

[Update design to stop providers from submitting existing draft applications](https://dsdmoj.atlassian.net/browse/AP-4933)

Replace "out of date" with "voided" and update text on the interrupt page to match updated design. 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
