### PR TITLE
Chore: Update devise warning

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -11,7 +11,7 @@ Devise.setup do |config|
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default.
   # This is set explicitly to remove a deprecation warning during the Rails 7.1
-  # to 7.2 transition, if Devise is set above 4.9.3, try removing it to see if
+  # to 7.2 transition, if Devise is set above 4.9.4, try removing it to see if
   # the deprecation warning has been removed
   config.secret_key = Rails.application.secret_key_base
 


### PR DESCRIPTION
## What

After a regular reminder to check this, and seeing that Devise had updated, I checked but the deprecation warning still occurs in Devise 4.9.4.  This updates the explanation so we can monitor after future updates.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
