### PR TITLE
AP-4953: Bug - improve validation of address city and county

### DIFF
--- a/app/forms/addresses/address_form.rb
+++ b/app/forms/addresses/address_form.rb
@@ -11,7 +11,7 @@ module Addresses
               unless: :draft?
 
     validates :postcode, format: { with: POSTCODE_REGEXP, allow_blank: true }
-    validates :city, :county, format: { with: /\A[A-Za-z ]*\z/, allow_blank: true }
+    validates :city, :county, format: { with: /\A[A-Za-z\.\-\' ]*\z/, allow_blank: true }
 
     def exclude_from_model
       %i[lookup_postcode lookup_error]


### PR DESCRIPTION
## What

[(Addresses) undefined method `many?' for nil (ActionView::Template::Error)](https://dsdmoj.atlassian.net/browse/AP-4953)

Bug: undefined method `many?` for nil

@address_collection was returning nil
Further investigation indicates address city and or county with special characters cause errors

This fix improves validation for address city and county

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
