### PR TITLE
AP-4952: Bug - move any step with no path into new step pattern

### DIFF
--- a/app/services/flow/flows/provider_capital.rb
+++ b/app/services/flow/flows/provider_capital.rb
@@ -55,15 +55,7 @@ module Flow
             end
           end,
         },
-        remove_vehicles: {
-          forward: lambda do |_application, applicant_has_any_vehicles|
-            if applicant_has_any_vehicles
-              :add_other_vehicles
-            else
-              :vehicles
-            end
-          end,
-        },
+        remove_vehicles: Steps::ProviderCapital::RemoveVehiclesStep,
         applicant_bank_accounts: {
           path: ->(application) { urls.providers_legal_aid_application_applicant_bank_account_path(application) },
           forward: ->(application) { application.applicant.has_partner_with_no_contrary_interest? ? :partner_bank_accounts : :savings_and_investments },

--- a/app/services/flow/flows/provider_means_state_benefits.rb
+++ b/app/services/flow/flows/provider_means_state_benefits.rb
@@ -32,11 +32,7 @@ module Flow
             add_other_state_benefits ? :state_benefits : :check_income_answers
           end,
         },
-        remove_state_benefits: {
-          forward: lambda do |_application, applicant_has_any_state_benefits|
-            applicant_has_any_state_benefits ? :add_other_state_benefits : :receives_state_benefits
-          end,
-        },
+        remove_state_benefits: Steps::ProviderMeans::RemoveStateBenefitsStep,
       }.freeze
     end
   end

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -61,10 +61,7 @@ module Flow
           forward: :has_other_opponents,
           check_answers: :check_merits_answers,
         },
-        opponent_new_organisations: {
-          forward: :has_other_opponents,
-          check_answers: :check_merits_answers,
-        },
+        opponent_new_organisations: Steps::ProviderMerits::OpponentNewOrganisationStep,
         start_opponent_task: {
           # This allows the task list to check for opponents and route to has_other_opponents
           # if they exist or show the new page if they do not

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -96,11 +96,7 @@ module Flow
             has_other_opponent ? :opponent_types : Flow::MeritsLoop.forward_flow(application, :application)
           },
         },
-        remove_opponent: {
-          forward: lambda { |application|
-            application.opponents.count.positive? ? :has_other_opponents : :opponent_types
-          },
-        },
+        remove_opponent: Steps::ProviderMerits::RemoveOpponentStep,
         opponents_mental_capacities: {
           path: ->(application) { urls.providers_legal_aid_application_opponents_mental_capacity_path(application) },
           forward: ->(application) { Flow::MeritsLoop.forward_flow(application, :application) },

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -45,15 +45,7 @@ module Flow
             end
           },
         },
-        remove_involved_child: {
-          forward: lambda { |application|
-            if application.involved_children.count.positive?
-              :has_other_involved_children
-            else
-              :involved_children
-            end
-          },
-        },
+        remove_involved_child: Steps::ProviderMerits::RemoveInvolvedChildStep,
         date_client_told_incidents: {
           path: ->(application) { urls.providers_legal_aid_application_date_client_told_incident_path(application) },
           forward: ->(application) { Flow::MeritsLoop.forward_flow(application, :application) },

--- a/app/services/flow/flows/provider_partner.rb
+++ b/app/services/flow/flows/provider_partner.rb
@@ -101,11 +101,7 @@ module Flow
             add_other_state_benefits ? :partner_state_benefits : :check_income_answers
           end,
         },
-        partner_remove_state_benefits: {
-          forward: lambda do |_application, partner_has_any_state_benefits|
-            partner_has_any_state_benefits ? :partner_add_other_state_benefits : :partner_receives_state_benefits
-          end,
-        },
+        partner_remove_state_benefits: Steps::Partner::RemoveStateBenefitsStep,
         partner_regular_incomes: {
           path: ->(application) { urls.providers_legal_aid_application_partners_regular_incomes_path(application) },
           forward: lambda do |application|

--- a/app/services/flow/steps/addresses/correspondence_address_manuals_step.rb
+++ b/app/services/flow/steps/addresses/correspondence_address_manuals_step.rb
@@ -2,6 +2,7 @@ module Flow
   module Steps
     module Addresses
       CorrespondenceAddressManualsStep = Step.new(
+        path: ->(application) { Steps.urls.providers_legal_aid_application_correspondence_address_manual_path(application) },
         forward: lambda do |application|
           if Setting.home_address?
             :different_addresses

--- a/app/services/flow/steps/addresses/home_address_manuals_step.rb
+++ b/app/services/flow/steps/addresses/home_address_manuals_step.rb
@@ -2,6 +2,7 @@ module Flow
   module Steps
     module Addresses
       HomeAddressManualsStep = Step.new(
+        path: ->(application) { Steps.urls.providers_legal_aid_application_home_address_manual_path(application) },
         forward: lambda do |application|
           if Setting.linked_applications?
             :link_application_make_links

--- a/app/services/flow/steps/partner/remove_state_benefits_step.rb
+++ b/app/services/flow/steps/partner/remove_state_benefits_step.rb
@@ -1,0 +1,12 @@
+module Flow
+  module Steps
+    module Partner
+      RemoveStateBenefitsStep = Step.new(
+        path: ->(application, transaction) { Steps.urls.providers_legal_aid_application_partners_remove_state_benefit_path(application, transaction) },
+        forward: lambda do |_application, partner_has_any_state_benefits|
+          partner_has_any_state_benefits ? :partner_add_other_state_benefits : :partner_receives_state_benefits
+        end,
+      )
+    end
+  end
+end

--- a/app/services/flow/steps/provider_capital/remove_vehicles_step.rb
+++ b/app/services/flow/steps/provider_capital/remove_vehicles_step.rb
@@ -1,0 +1,16 @@
+module Flow
+  module Steps
+    module ProviderCapital
+      RemoveVehiclesStep = Step.new(
+        path: ->(application, vehicle) { Steps.urls.providers_legal_aid_application_means_remove_vehicle_path(application, vehicle) },
+        forward: lambda do |_application, applicant_has_any_vehicles|
+          if applicant_has_any_vehicles
+            :add_other_vehicles
+          else
+            :vehicles
+          end
+        end,
+      )
+    end
+  end
+end

--- a/app/services/flow/steps/provider_means/remove_state_benefits_step.rb
+++ b/app/services/flow/steps/provider_means/remove_state_benefits_step.rb
@@ -1,0 +1,12 @@
+module Flow
+  module Steps
+    module ProviderMeans
+      RemoveStateBenefitsStep = Step.new(
+        path: ->(application, transaction) { Steps.urls.providers_legal_aid_application_means_remove_state_benefit_path(application, transaction) },
+        forward: lambda do |_application, applicant_has_any_state_benefits|
+          applicant_has_any_state_benefits ? :add_other_state_benefits : :receives_state_benefits
+        end,
+      )
+    end
+  end
+end

--- a/app/services/flow/steps/provider_merits/opponent_new_organisation_step.rb
+++ b/app/services/flow/steps/provider_merits/opponent_new_organisation_step.rb
@@ -1,0 +1,11 @@
+module Flow
+  module Steps
+    module ProviderMerits
+      OpponentNewOrganisationStep = Step.new(
+        path: ->(application) { Steps.urls.new_providers_legal_aid_application_opponent_new_organisation_path(application) },
+        forward: :has_other_opponents,
+        check_answers: :check_merits_answers,
+      )
+    end
+  end
+end

--- a/app/services/flow/steps/provider_merits/remove_involved_child_step.rb
+++ b/app/services/flow/steps/provider_merits/remove_involved_child_step.rb
@@ -1,0 +1,16 @@
+module Flow
+  module Steps
+    module ProviderMerits
+      RemoveInvolvedChildStep = Step.new(
+        path: ->(application, opponent) { Steps.urls.providers_legal_aid_application_remove_involved_child_path(application, opponent) },
+        forward: lambda { |application|
+          if application.involved_children.count.positive?
+            :has_other_involved_children
+          else
+            :involved_children
+          end
+        },
+      )
+    end
+  end
+end

--- a/app/services/flow/steps/provider_merits/remove_opponent_step.rb
+++ b/app/services/flow/steps/provider_merits/remove_opponent_step.rb
@@ -1,0 +1,12 @@
+module Flow
+  module Steps
+    module ProviderMerits
+      RemoveOpponentStep = Step.new(
+        path: ->(application, opponent) { Steps.urls.providers_legal_aid_application_remove_opponent_path(application, opponent) },
+        forward: lambda { |application|
+          application.opponents.count.positive? ? :has_other_opponents : :opponent_types
+        },
+      )
+    end
+  end
+end

--- a/spec/cassettes/Providers_ApplicationMeritsTask_OpponentNewOrganisationsController/update_PATCH_/providers/applications/_legal_aid_application_id/opponent_new_organisation/_opponent_id/redirects_along_the_flow.yml
+++ b/spec/cassettes/Providers_ApplicationMeritsTask_OpponentNewOrganisationsController/update_PATCH_/providers/applications/_legal_aid_application_id/opponent_new_organisation/_opponent_id/redirects_along_the_flow.yml
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.7.10
+      - Faraday v2.9.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 06 Sep 2023 21:22:32 GMT
+      - Thu, 25 Apr 2024 10:58:02 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -31,25 +31,23 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Xss-Protection:
-      - 1; mode=block
+      - '0'
       X-Content-Type-Options:
       - nosniff
-      X-Download-Options:
-      - noopen
       X-Permitted-Cross-Domain-Policies:
       - none
       Referrer-Policy:
       - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
       Etag:
       - W/"6f0aecf3c20f8f5e70a8bda15e4b2f63"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - ac156f977cce6800b42691ad8055a5e6
+      - 0ef27ebd464c6770d49dc1715834f24b
       X-Runtime:
-      - '0.004349'
-      Vary:
-      - Accept, Origin
+      - '0.053024'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
@@ -62,5 +60,5 @@ http_interactions:
         Health Service"},{"ccms_code":"PART","description":"Partnership"},{"ccms_code":"POLICE","description":"Police
         Authority"},{"ccms_code":"PLC","description":"Public Limited Company"},{"ccms_code":"SOLE","description":"Sole
         Trader"}]'
-  recorded_at: Wed, 06 Sep 2023 21:22:32 GMT
+  recorded_at: Thu, 25 Apr 2024 10:58:02 GMT
 recorded_with: VCR 6.2.0

--- a/spec/requests/providers/application_merits_task/opponent_new_organisations_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/opponent_new_organisations_controller_spec.rb
@@ -101,9 +101,9 @@ module Providers
           expect(legal_aid_application.legal_framework_merits_task_list).to have_completed_task(:application, :opponent_name)
         end
 
-        it "redirects to the has another opponent question" do
+        it "redirects along the flow" do
           request_update
-          expect(response).to redirect_to(providers_legal_aid_application_has_other_opponent_path(legal_aid_application))
+          expect(response).to have_http_status(:redirect)
         end
 
         context "when not authenticated" do

--- a/spec/requests/providers/application_merits_task/remove_involved_child_spec.rb
+++ b/spec/requests/providers/application_merits_task/remove_involved_child_spec.rb
@@ -37,19 +37,9 @@ module Providers
             expect { patch_request }.to change { application.involved_children.count }.by(-1)
           end
 
-          context "and it is the only child on the application" do
-            it "redirects to the add new involved child page" do
-              patch_request
-              expect(response).to redirect_to(new_providers_legal_aid_application_involved_child_path(application))
-            end
-          end
-
-          context "and another child exists" do
-            it "redirects back to the has_other_involved_children page" do
-              create(:involved_child, legal_aid_application: application)
-              patch_request
-              expect(response).to redirect_to(providers_legal_aid_application_has_other_involved_children_path(application))
-            end
+          it "redirects along the flow" do
+            patch_request
+            expect(response).to have_http_status(:redirect)
           end
         end
 
@@ -60,9 +50,9 @@ module Providers
             expect { patch_request }.not_to change { application.involved_children.count }
           end
 
-          it "redirects back to the has_other_involved_children page" do
+          it "redirects along the flow" do
             patch_request
-            expect(response).to redirect_to(providers_legal_aid_application_has_other_involved_children_path(application))
+            expect(response).to have_http_status(:redirect)
           end
         end
 
@@ -71,6 +61,7 @@ module Providers
 
           it "shows the correct error message" do
             patch_request
+            expect(response).to have_http_status(:ok)
             expect(unescaped_response_body).to include(I18n.t("providers.application_merits_task.remove_involved_child.show.error", name: child.full_name))
           end
 

--- a/spec/requests/providers/application_merits_task/remove_opponent_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/remove_opponent_controller_spec.rb
@@ -37,20 +37,9 @@ module Providers
             expect { submit_remove }.to change { application.opponents.count }.by(-1)
           end
 
-          context "and it is the only opponent on the application" do
-            it "redirects to the choose opponent type page" do
-              submit_remove
-              expect(response).to redirect_to(providers_legal_aid_application_opponent_type_path(application))
-            end
-          end
-
-          context "and another opponent exists" do
-            before { create(:opponent, legal_aid_application: application) }
-
-            it "redirects to the has_other_opponent page" do
-              submit_remove
-              expect(response).to redirect_to(providers_legal_aid_application_has_other_opponent_path(application))
-            end
+          it "redirects along the flow" do
+            submit_remove
+            expect(response).to have_http_status(:redirect)
           end
         end
 
@@ -61,9 +50,9 @@ module Providers
             expect { submit_remove }.not_to change { application.opponents.count }
           end
 
-          it "redirects back to the has_other_opponents page" do
+          it "redirects along the flow" do
             submit_remove
-            expect(response).to redirect_to(providers_legal_aid_application_has_other_opponent_path(application))
+            expect(response).to have_http_status(:redirect)
           end
         end
 
@@ -72,6 +61,12 @@ module Providers
 
           it "does not delete a record" do
             expect { submit_remove }.not_to change { application.opponents.count }
+          end
+
+          it "re-renders the page" do
+            submit_remove
+            expect(response).to have_http_status(:ok)
+            expect(unescaped_response_body).to include("Are you sure you want to remove #{opponent2.full_name} from the application?")
           end
         end
       end

--- a/spec/requests/providers/home_address/manuals_controller_spec.rb
+++ b/spec/requests/providers/home_address/manuals_controller_spec.rb
@@ -89,15 +89,6 @@ RSpec.describe Providers::HomeAddress::ManualsController do
 
       context "with a valid address" do
         context "when the linked application feature flag is enabled" do
-          # TODO: @Adam Goldstone - due 01/07/24
-          # Is left in to keep coverage passing but can be removed when the
-          # link_application_make_links step is added
-          it "redirects to link applications" do
-            allow(Setting).to receive(:linked_applications?).and_return(true)
-            patch_request
-            expect(response).to redirect_to(providers_legal_aid_application_link_application_make_link_path(legal_aid_application))
-          end
-
           it "redirects to the next page" do
             patch_request
             expect(response).to have_http_status(:redirect)
@@ -120,6 +111,7 @@ RSpec.describe Providers::HomeAddress::ManualsController do
 
         it "renders the form again if validation fails" do
           patch_request
+          expect(response).to have_http_status(:ok)
           expect(unescaped_response_body).to include("Enter your client's home address")
           expect(response.body).to include("Enter a postcode")
         end

--- a/spec/requests/providers/means/remove_state_benefits_controller_spec.rb
+++ b/spec/requests/providers/means/remove_state_benefits_controller_spec.rb
@@ -57,16 +57,16 @@ RSpec.describe Providers::Means::RemoveStateBenefitsController do
       context "and the provider confirms deletion" do
         let(:remove_state_benefit) { "true" }
 
-        it "redirects to the add other state benefits page" do
-          expect(response).to redirect_to(providers_legal_aid_application_means_add_other_state_benefits_path(legal_aid_application))
+        it "redirects along the flow" do
+          expect(response).to have_http_status(:redirect)
         end
       end
 
       context "and the provider rejects deletion" do
         let(:remove_state_benefit) { "false" }
 
-        it "redirects to the add other state benefits page" do
-          expect(response).to redirect_to(providers_legal_aid_application_means_add_other_state_benefits_path(legal_aid_application))
+        it "redirects along the flow" do
+          expect(response).to have_http_status(:redirect)
         end
       end
 
@@ -84,16 +84,16 @@ RSpec.describe Providers::Means::RemoveStateBenefitsController do
       context "and the provider confirms deletion" do
         let(:remove_state_benefit) { "true" }
 
-        it "redirects to the does your client receive state benefits page" do
-          expect(response).to redirect_to(providers_legal_aid_application_means_receives_state_benefits_path(legal_aid_application))
+        it "redirects along the flow" do
+          expect(response).to have_http_status(:redirect)
         end
       end
 
       context "and the provider rejects deletion" do
         let(:remove_state_benefit) { "false" }
 
-        it "redirects to the add other state benefits page" do
-          expect(response).to redirect_to(providers_legal_aid_application_means_add_other_state_benefits_path(legal_aid_application))
+        it "redirects along the flow" do
+          expect(response).to have_http_status(:redirect)
         end
       end
 

--- a/spec/requests/providers/means/remove_vehicles_controller_spec.rb
+++ b/spec/requests/providers/means/remove_vehicles_controller_spec.rb
@@ -40,11 +40,11 @@ RSpec.describe Providers::Means::RemoveVehiclesController do
     context "when the provider chose yes" do
       let(:remove_vehicle) { "true" }
 
-      context "and no vehicles remain after deletion" do
-        it "redirects to the vehicles page" do
-          expect(response).to redirect_to(providers_legal_aid_application_means_vehicle_path(legal_aid_application))
-        end
+      it "redirects along the flow" do
+        expect(response).to have_http_status(:redirect)
+      end
 
+      context "and no vehicles remain after deletion" do
         it { expect(legal_aid_application.vehicles.count).to eq 0 }
 
         it "resets the own_vehicle value" do
@@ -56,8 +56,8 @@ RSpec.describe Providers::Means::RemoveVehiclesController do
       context "and vehicles remain after the deletion" do
         let(:extra_vehicle_count) { 2 }
 
-        it "redirects to the has_other_vehicles page" do
-          expect(response).to redirect_to(providers_legal_aid_application_means_add_other_vehicles_path(legal_aid_application))
+        it "redirects along the flow" do
+          expect(response).to have_http_status(:redirect)
         end
       end
     end
@@ -65,15 +65,16 @@ RSpec.describe Providers::Means::RemoveVehiclesController do
     context "when the provider chose no" do
       let(:remove_vehicle) { "false" }
 
-      it "redirects to the has other vehicles page" do
-        expect(response).to redirect_to(providers_legal_aid_application_means_add_other_vehicles_path(legal_aid_application))
+      it "redirects along the flow" do
+        expect(response).to have_http_status(:redirect)
       end
     end
 
     context "when the provider choose nothing" do
       let(:params) { nil }
 
-      it "show errors" do
+      it "re-renders the page and shows an error" do
+        expect(response).to have_http_status(:ok)
         expect(response.body).to include("Select yes if you want to remove this vehicle from the application.")
       end
     end

--- a/spec/requests/providers/partners/remove_state_benefits_controller_spec.rb
+++ b/spec/requests/providers/partners/remove_state_benefits_controller_spec.rb
@@ -57,16 +57,16 @@ RSpec.describe Providers::Partners::RemoveStateBenefitsController do
       context "and the provider confirms deletion" do
         let(:remove_state_benefit) { "true" }
 
-        it "redirects to the add other state benefits page" do
-          expect(response).to redirect_to(providers_legal_aid_application_partners_add_other_state_benefits_path(legal_aid_application))
+        it "redirects along the flow" do
+          expect(response).to have_http_status(:redirect)
         end
       end
 
       context "and the provider rejects deletion" do
         let(:remove_state_benefit) { "false" }
 
-        it "redirects to the add other state benefits page" do
-          expect(response).to redirect_to(providers_legal_aid_application_partners_add_other_state_benefits_path(legal_aid_application))
+        it "redirects along the flow" do
+          expect(response).to have_http_status(:redirect)
         end
       end
 
@@ -84,16 +84,16 @@ RSpec.describe Providers::Partners::RemoveStateBenefitsController do
       context "and the provider confirms deletion" do
         let(:remove_state_benefit) { "true" }
 
-        it "redirects to the does your client receive state benefits page" do
-          expect(response).to redirect_to(providers_legal_aid_application_partners_receives_state_benefits_path(legal_aid_application))
+        it "redirects along the flow" do
+          expect(response).to have_http_status(:redirect)
         end
       end
 
       context "and the provider rejects deletion" do
         let(:remove_state_benefit) { "false" }
 
-        it "redirects to the add other state benefits page" do
-          expect(response).to redirect_to(providers_legal_aid_application_partners_add_other_state_benefits_path(legal_aid_application))
+        it "redirects along the flow" do
+          expect(response).to have_http_status(:redirect)
         end
       end
 

--- a/spec/services/flow/steps/addresses/correspondence_address_manuals_step_spec.rb
+++ b/spec/services/flow/steps/addresses/correspondence_address_manuals_step_spec.rb
@@ -3,6 +3,12 @@ require "rails_helper"
 RSpec.describe Flow::Steps::Addresses::CorrespondenceAddressManualsStep, type: :request do
   let(:legal_aid_application) { create(:legal_aid_application) }
 
+  describe "#path" do
+    subject { described_class.path.call(legal_aid_application) }
+
+    it { is_expected.to eq providers_legal_aid_application_correspondence_address_manual_path(legal_aid_application) }
+  end
+
   describe "#forward" do
     subject { described_class.forward.call(legal_aid_application) }
 

--- a/spec/services/flow/steps/addresses/home_address_manuals_step_spec.rb
+++ b/spec/services/flow/steps/addresses/home_address_manuals_step_spec.rb
@@ -3,6 +3,12 @@ require "rails_helper"
 RSpec.describe Flow::Steps::Addresses::HomeAddressManualsStep, type: :request do
   let(:legal_aid_application) { create(:legal_aid_application) }
 
+  describe "#path" do
+    subject { described_class.path.call(legal_aid_application) }
+
+    it { is_expected.to eq providers_legal_aid_application_home_address_manual_path(legal_aid_application) }
+  end
+
   describe "#forward" do
     subject { described_class.forward.call(legal_aid_application) }
 

--- a/spec/services/flow/steps/partner/remove_state_benefits_step_spec.rb
+++ b/spec/services/flow/steps/partner/remove_state_benefits_step_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::Partner::RemoveStateBenefitsStep, type: :request do
+  let(:legal_aid_application) { create(:legal_aid_application, :with_applicant_and_partner) }
+  let(:transaction) do
+    create(:regular_transaction,
+           transaction_type: create(:transaction_type, :benefits),
+           legal_aid_application:,
+           description: "Test removal of state benefit",
+           owner_id: legal_aid_application.partner.id,
+           owner_type: "Partner")
+  end
+
+  describe "#path" do
+    subject { described_class.path.call(legal_aid_application, transaction) }
+
+    it { is_expected.to eql providers_legal_aid_application_partners_remove_state_benefit_path(legal_aid_application, transaction) }
+  end
+
+  describe "#forward" do
+    subject { described_class.forward.call(legal_aid_application, partner_has_any_state_benefits) }
+
+    context "when partner_has_any_state_benefits is sent as true" do
+      let(:partner_has_any_state_benefits) { true }
+
+      it { is_expected.to eq :partner_add_other_state_benefits }
+    end
+
+    context "when partner_has_any_state_benefits is sent as false" do
+      let(:partner_has_any_state_benefits) { false }
+
+      it { is_expected.to eq :partner_receives_state_benefits }
+    end
+  end
+end

--- a/spec/services/flow/steps/provider_capital/remove_vehicles_step_spec.rb
+++ b/spec/services/flow/steps/provider_capital/remove_vehicles_step_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::ProviderCapital::RemoveVehiclesStep, type: :request do
+  let(:legal_aid_application) { create(:legal_aid_application) }
+  let(:vehicle) { create(:vehicle, legal_aid_application:) }
+
+  describe "#path" do
+    subject { described_class.path.call(legal_aid_application, vehicle) }
+
+    it { is_expected.to eq providers_legal_aid_application_means_remove_vehicle_path(legal_aid_application, vehicle) }
+  end
+
+  describe "#forward" do
+    subject { described_class.forward.call(legal_aid_application, vehicles_remain) }
+
+    context "when vehicles remain on the application" do
+      let(:vehicles_remain) { true }
+
+      it { is_expected.to eq :add_other_vehicles }
+    end
+
+    context "when no vehicles remain on the application" do
+      let(:vehicles_remain) { false }
+
+      it { is_expected.to eq :vehicles }
+    end
+  end
+end

--- a/spec/services/flow/steps/provider_means/remove_state_benefits_step_spec.rb
+++ b/spec/services/flow/steps/provider_means/remove_state_benefits_step_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::ProviderMeans::RemoveStateBenefitsStep, type: :request do
+  let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
+  let(:transaction) do
+    create(:regular_transaction,
+           transaction_type: create(:transaction_type, :benefits),
+           legal_aid_application:,
+           description: "Test removal of state benefit",
+           owner_id: legal_aid_application.applicant.id,
+           owner_type: "Applicant")
+  end
+
+  describe "#path" do
+    subject { described_class.path.call(legal_aid_application, transaction) }
+
+    it { is_expected.to eql providers_legal_aid_application_means_remove_state_benefit_path(legal_aid_application, transaction) }
+  end
+
+  describe "#forward" do
+    subject { described_class.forward.call(legal_aid_application, applicant_has_any_state_benefits) }
+
+    context "when applicant_has_any_state_benefits is sent as true" do
+      let(:applicant_has_any_state_benefits) { true }
+
+      it { is_expected.to eq :add_other_state_benefits }
+    end
+
+    context "when applicant_has_any_state_benefits is sent as false" do
+      let(:applicant_has_any_state_benefits) { false }
+
+      it { is_expected.to eq :receives_state_benefits }
+    end
+  end
+end

--- a/spec/services/flow/steps/provider_merits/opponent_new_organisation_step_spec.rb
+++ b/spec/services/flow/steps/provider_merits/opponent_new_organisation_step_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::ProviderMerits::OpponentNewOrganisationStep, type: :request do
+  let(:legal_aid_application) { create(:legal_aid_application) }
+
+  describe "#path" do
+    subject { described_class.path.call(legal_aid_application) }
+
+    it { is_expected.to eq new_providers_legal_aid_application_opponent_new_organisation_path(legal_aid_application) }
+  end
+
+  describe "#forward" do
+    subject { described_class.forward }
+
+    it { is_expected.to eq :has_other_opponents }
+  end
+
+  describe "#check_answers" do
+    subject { described_class.check_answers }
+
+    it { is_expected.to eq :check_merits_answers }
+  end
+end

--- a/spec/services/flow/steps/provider_merits/remove_involved_child_step_spec.rb
+++ b/spec/services/flow/steps/provider_merits/remove_involved_child_step_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::ProviderMerits::RemoveInvolvedChildStep, type: :request do
+  let(:legal_aid_application) { create(:legal_aid_application) }
+  let(:child) { create(:involved_child, legal_aid_application:) }
+
+  describe "#path" do
+    subject { described_class.path.call(legal_aid_application, child) }
+
+    it { is_expected.to eq providers_legal_aid_application_remove_involved_child_path(legal_aid_application, child) }
+  end
+
+  describe "#forward" do
+    subject { described_class.forward.call(legal_aid_application) }
+
+    context "when at least one involved child remains on the application" do
+      before { create(:involved_child, legal_aid_application:) }
+
+      it { is_expected.to eq :has_other_involved_children }
+    end
+
+    context "when no involved_children remain on the application" do
+      it { is_expected.to eq :involved_children }
+    end
+  end
+end

--- a/spec/services/flow/steps/provider_merits/remove_opponent_step_spec.rb
+++ b/spec/services/flow/steps/provider_merits/remove_opponent_step_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::ProviderMerits::RemoveOpponentStep, type: :request do
+  let(:legal_aid_application) { create(:legal_aid_application) }
+  let(:opponent) { create(:opponent, legal_aid_application:) }
+
+  describe "#path" do
+    subject { described_class.path.call(legal_aid_application, opponent) }
+
+    it { is_expected.to eq providers_legal_aid_application_remove_opponent_path(legal_aid_application, opponent) }
+  end
+
+  describe "#forward" do
+    subject { described_class.forward.call(legal_aid_application) }
+
+    context "when at least one opponent remains on the application" do
+      before { create(:opponent, legal_aid_application:) }
+
+      it { is_expected.to eq :has_other_opponents }
+    end
+
+    context "when no opponents remain on the application" do
+      it { is_expected.to eq :opponent_types }
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4952)

The bug listed was caused by a provider reaching a page with no flow step and then closing the webpage or returning to the application list.  The list then tried to reach a flow step with no path, errored and re-directed the user to the first page.

This corrects the error seen and all other steps with no path.

It might be easier to review each commit in turn as the changes get scattered in the whole PR review.

The correspondence manual controller tests had already been updated to the new flow and required no additional changes, in case you wonder why it's the only controller with no tests changed!


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
