### PR TITLE
CHORE: Update super_diff gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -703,7 +703,7 @@ GEM
     stringio (3.1.0)
     strong_migrations (1.8.0)
       activerecord (>= 5.2)
-    super_diff (0.12.0)
+    super_diff (0.12.1)
       attr_extras (>= 6.2.4)
       diff-lcs
       patience_diff


### PR DESCRIPTION

## What

v12.0.0 was pulled from rubygems over the weekend, after we updated Friday, and replaced with 12.0.1
>[!Warning]
> 
> This release has been yanked, as it included changes that weren't properly
> logged in the changelog. This release wasn't ideal as it contained some
> leftover print statements, anyway.

This causes all subsequent deploys to fail as 12.0.1 is not available for the docker build process on CircleCI


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
