### PR TITLE
Fix: Flickering test

### DIFF
--- a/spec/requests/citizens/check_answers_spec.rb
+++ b/spec/requests/citizens/check_answers_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "check your answers requests" do
 
     it "displays the name of the firm" do
       get_request
-      expect(response.body).to include(html_compare(firm.name))
+      expect(unescaped_response_body).to include(firm.name)
     end
 
     context "with firms with special characters in the name" do


### PR DESCRIPTION
## What

Faker would occaisionaly create a firm name with an apostrophe and this test would break.  
This commit ensures that this test matches the same pattern as that used in the explicit test for firm names with special characters

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
