### PR TITLE
Ap 4991 update linked applications helper for discarded applications

### DIFF
--- a/app/helpers/linked_applications_helper.rb
+++ b/app/helpers/linked_applications_helper.rb
@@ -12,10 +12,10 @@ private
   end
 
   def all_associated_linked_applications(legal_aid_application)
-    LinkedApplication.where(lead_application_id: legal_aid_application.lead_application.id, link_type_code: legal_aid_application.lead_linked_application.link_type_code).map(&:associated_application)
+    LinkedApplication.where(lead_application_id: legal_aid_application.lead_application.id, link_type_code: legal_aid_application.lead_linked_application.link_type_code).map(&:associated_application).reject(&:discarded?)
   end
 
   def all_lead_linked_applications(legal_aid_application)
-    LinkedApplication.where(associated_application_id: legal_aid_application.lead_application.id, link_type_code: legal_aid_application.lead_linked_application.link_type_code).map(&:lead_application)
+    LinkedApplication.where(associated_application_id: legal_aid_application.lead_application.id, link_type_code: legal_aid_application.lead_linked_application.link_type_code).map(&:lead_application).reject(&:discarded?)
   end
 end

--- a/app/helpers/linked_applications_helper.rb
+++ b/app/helpers/linked_applications_helper.rb
@@ -8,14 +8,7 @@ module LinkedApplicationsHelper
 private
 
   def all_linked_applications(legal_aid_application)
-    all_associated_linked_applications(legal_aid_application).concat(all_lead_linked_applications(legal_aid_application)).excluding(legal_aid_application)
-  end
-
-  def all_associated_linked_applications(legal_aid_application)
-    LinkedApplication.where(lead_application_id: legal_aid_application.lead_application.id, link_type_code: legal_aid_application.lead_linked_application.link_type_code).map(&:associated_application).reject(&:discarded?)
-  end
-
-  def all_lead_linked_applications(legal_aid_application)
-    LinkedApplication.where(associated_application_id: legal_aid_application.lead_application.id, link_type_code: legal_aid_application.lead_linked_application.link_type_code).map(&:lead_application).reject(&:discarded?)
+    all_linked_applications = LinkedApplication.where(associated_application_id: legal_aid_application.lead_application.id, link_type_code: legal_aid_application.lead_linked_application&.link_type_code).or(LinkedApplication.where(lead_application_id: legal_aid_application.lead_application.id, link_type_code: legal_aid_application.lead_linked_application&.link_type_code))
+    all_linked_applications.map(&:associated_application).concat(all_linked_applications.map(&:lead_application)).excluding(legal_aid_application, legal_aid_application.lead_application).reject(&:discarded?)
   end
 end

--- a/app/views/providers/link_application/confirm_links/show.html.erb
+++ b/app/views/providers/link_application/confirm_links/show.html.erb
@@ -32,7 +32,7 @@
       <% end %>
     <% end %>
 
-    <% if all_linked_applications_details(@legal_aid_application) %>
+    <% if all_linked_applications_details(@legal_aid_application).present? %>
       <%= govuk_details(summary_text: t(".all_linked_applications", link_type: @legal_aid_application.lead_linked_application&.link_type_description&.downcase)) do %>
         <%= all_linked_applications_details(@legal_aid_application) %>
       <% end %>

--- a/spec/helpers/linked_applications_helper_spec.rb
+++ b/spec/helpers/linked_applications_helper_spec.rb
@@ -9,9 +9,11 @@ RSpec.describe LinkedApplicationsHelper do
     let(:linked_application_one) { create(:legal_aid_application, application_ref: "L-INK-001", applicant: applicant_one) }
     let(:linked_application_two) { create(:legal_aid_application, application_ref: "L-INK-002", applicant: applicant_two) }
     let(:linked_application_three) { create(:legal_aid_application, application_ref: "L-INK-003", applicant: applicant_three) }
+    let(:linked_application_four) { create(:legal_aid_application, application_ref: "L-INK-004", applicant: applicant_four, discarded_at: Date.current) }
     let(:applicant_one) { create(:applicant, last_name: "applicant-one", first_name: "linked") }
     let(:applicant_two) { create(:applicant, last_name: "applicant-two", first_name: "linked") }
     let(:applicant_three) { create(:applicant, last_name: "applicant-three", first_name: "linked") }
+    let(:applicant_four) { create(:applicant, last_name: "applicant-four", first_name: "linked") }
 
     context "with a lead application" do
       before do
@@ -19,9 +21,10 @@ RSpec.describe LinkedApplicationsHelper do
         LinkedApplication.create!(lead_application_id: lead_application.id, associated_application_id: linked_application_one.id, link_type_code: "FC_LEAD")
         LinkedApplication.create!(lead_application_id: lead_application.id, associated_application_id: linked_application_two.id, link_type_code: "LEGAL")
         LinkedApplication.create!(lead_application_id: linked_application_three.id, associated_application_id: lead_application.id, link_type_code: "FC_LEAD")
+        LinkedApplication.create!(lead_application_id: lead_application.id, associated_application_id: linked_application_four.id, link_type_code: "FC_LEAD")
       end
 
-      it "returns details of all other applications linked to the lead application with the same link type" do
+      it "returns details of all other applications linked to the lead application with the same link type that have not been discarded" do
         expect(details).to eq "L-INK-001, linked applicant-one<br>L-INK-003, linked applicant-three"
       end
     end

--- a/spec/helpers/linked_applications_helper_spec.rb
+++ b/spec/helpers/linked_applications_helper_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe LinkedApplicationsHelper do
     let(:applicant_three) { create(:applicant, last_name: "applicant-three", first_name: "linked") }
     let(:applicant_four) { create(:applicant, last_name: "applicant-four", first_name: "linked") }
 
-    context "with a lead application" do
+    context "with a lead application linked to other applications" do
       before do
         LinkedApplication.create!(lead_application_id: lead_application.id, associated_application_id: legal_aid_application.id, link_type_code: "FC_LEAD")
         LinkedApplication.create!(lead_application_id: lead_application.id, associated_application_id: linked_application_one.id, link_type_code: "FC_LEAD")
@@ -26,6 +26,16 @@ RSpec.describe LinkedApplicationsHelper do
 
       it "returns details of all other applications linked to the lead application with the same link type that have not been discarded" do
         expect(details).to eq "L-INK-001, linked applicant-one<br>L-INK-003, linked applicant-three"
+      end
+    end
+
+    context "with a lead application that is not linked to any other applications" do
+      before do
+        LinkedApplication.create!(lead_application_id: lead_application.id, associated_application_id: legal_aid_application.id, link_type_code: "FC_LEAD")
+      end
+
+      it "returns an empty string" do
+        expect(details).to eq ""
       end
     end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4991)

- Updated linked_applications_helper to ensure discarded/soft-deleted applications are not displayed.
- Updated linked_applications_helper to retrieve all_linked_applications using a single db query
- Fixed bug so that the "All applications with a family link to this one" detail panel is not displayed if all_linked_applications_details returns empty string

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
