### PR TITLE
AP-4990: Bug: Hide change links for proceedings when read_only

### DIFF
--- a/app/views/providers/check_provider_answers/_shared.html.erb
+++ b/app/views/providers/check_provider_answers/_shared.html.erb
@@ -22,11 +22,13 @@
         <h2 class="govuk-heading-m"><%= t ".section_proceeding.heading" %></h2>
       </div>
       <div class="govuk-grid-column-one-third">
-        <%= govuk_link_to(
-              t("generic.change"), providers_legal_aid_application_has_other_proceedings_path(@legal_aid_application),
-              visually_hidden_suffix: t(".section_proceeding.heading"),
-              class: "govuk-link-right"
-            ) %>
+        <%= unless @read_only
+              govuk_link_to(
+                t("generic.change"), providers_legal_aid_application_has_other_proceedings_path(@legal_aid_application),
+                visually_hidden_suffix: t(".section_proceeding.heading"),
+                class: "govuk-link-right"
+              )
+            end %>
       </div>
     </div>
     <%= render(

--- a/app/views/shared/check_answers/_proceeding_details.html.erb
+++ b/app/views/shared/check_answers/_proceeding_details.html.erb
@@ -4,12 +4,14 @@
     <h2 class="govuk-heading-m"><%= proceeding.meaning %> <%= t(".description") %></h2>
   </div>
   <div class="govuk-grid-column-one-quarter">
-    <%= govuk_link_to(
-          t("generic.change"),
-          providers_legal_aid_application_client_involvement_type_path(@legal_aid_application, proceeding),
-          visually_hidden_suffix: "#{proceeding.meaning} #{t('.description')}",
-          class: "govuk-link-right",
-        ) %>
+    <%= unless @read_only
+          govuk_link_to(
+            t("generic.change"),
+            providers_legal_aid_application_client_involvement_type_path(@legal_aid_application, proceeding),
+            visually_hidden_suffix: "#{proceeding.meaning} #{t('.description')}",
+            class: "govuk-link-right",
+          )
+        end %>
   </div>
 </div>
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4990)

The check provider answers view is re-used when the provider is waiting for the client to provide true-layer details.

A read_only flag is set and all other sections of the Check Providers Answers page check for the presence of the read_only flag and hide the change links.

The proceedings and proceeding details did not, this PR adds the check to prevent providers changing something and breaking the flow and subsequent page views.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
