### PR TITLE
AP-4992: Update linking case back button handling

### DIFF
--- a/app/controllers/providers/link_application/confirm_links_controller.rb
+++ b/app/controllers/providers/link_application/confirm_links_controller.rb
@@ -4,7 +4,7 @@ module Providers
       prefix_step_with :link_application
 
       def show
-        @form = Providers::LinkApplication::ConfirmLinkForm.new(model: legal_aid_application)
+        @form = Providers::LinkApplication::ConfirmLinkForm.new(model: linked_application)
       end
 
       def update
@@ -18,7 +18,7 @@ module Providers
 
         if @form.valid?
           @form.save!
-          flash[:hash] = success_hash if @form.link_case == "true"
+          flash[:hash] = success_hash if @form.confirm_link == "true"
           return go_forward
         end
 
@@ -39,11 +39,13 @@ module Providers
         @heading_text ||= legal_aid_application.lead_linked_application&.link_type_code == "FC_LEAD" ? t("providers.link_application.confirm_links.show.success_family") : t("providers.link_application.confirm_links.show.success_legal", application_ref: legal_aid_application.lead_application&.application_ref)
       end
 
-      def form_params
-        merge_with_model(legal_aid_application) do
-          next {} unless params[:legal_aid_application]
+      def linked_application
+        legal_aid_application.lead_linked_application
+      end
 
-          params.require(:legal_aid_application).permit(:link_case)
+      def form_params
+        merge_with_model(linked_application) do
+          params.require(:linked_application).permit(:confirm_link)
         end
       end
     end

--- a/app/forms/providers/link_application/confirm_link_form.rb
+++ b/app/forms/providers/link_application/confirm_link_form.rb
@@ -1,20 +1,15 @@
 module Providers
   module LinkApplication
     class ConfirmLinkForm < BaseForm
-      form_for LegalAidApplication
+      form_for LinkedApplication
 
-      attr_accessor :link_case
+      attr_accessor :confirm_link
 
-      validates :link_case, presence: true, unless: :draft?
+      validates :confirm_link, presence: true, unless: :draft?
 
       def save
-        if link_case == "No"
-          model.update!(link_case: nil)
-          return
-        elsif link_case == "false"
-          model.lead_linked_application&.destroy!
-        end
         super
+        model.update!(confirm_link: nil) if confirm_link == "No"
       end
       alias_method :save!, :save
     end

--- a/app/forms/providers/link_application/make_link_form.rb
+++ b/app/forms/providers/link_application/make_link_form.rb
@@ -8,11 +8,7 @@ module Providers
       validates :link_type_code, presence: true, unless: :draft?
 
       def save
-        if link_type_code == "false"
-          model.associated_application.update!(link_case: false)
-          model.destroy!
-          return
-        end
+        model.update!(confirm_link: false) if link_type_code != "true"
         super
       end
       alias_method :save!, :save

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -16,10 +16,7 @@ module Flow
         home_address_manuals: Steps::Addresses::HomeAddressManualsStep,
         non_uk_home_addresses: Steps::Addresses::NonUkHomeAddressesStep,
         link_application_make_links: Steps::LinkedApplications::MakeLinkStep,
-        link_application_find_link_applications: {
-          path: ->(application) { urls.providers_legal_aid_application_link_application_find_link_application_path(application) },
-          forward: :link_application_confirm_links,
-        },
+        link_application_find_link_applications: Steps::LinkedApplications::FindLinkStep,
         link_application_confirm_links: Steps::LinkedApplications::ConfirmLinkStep,
         link_application_copies: Steps::LinkedApplications::CopyStep,
         about_financial_means: {

--- a/app/services/flow/steps/linked_applications/confirm_link_step.rb
+++ b/app/services/flow/steps/linked_applications/confirm_link_step.rb
@@ -4,18 +4,11 @@ module Flow
       ConfirmLinkStep = Step.new(
         path: ->(application) { Steps.urls.providers_legal_aid_application_link_application_confirm_link_path(application) },
         forward: lambda do |application|
-          case application.link_case
-          when true
-            if application.lead_linked_application&.link_type_code == "FC_LEAD"
-              :link_application_copies
-            else
-              application.proceedings.any? ? :has_other_proceedings : :proceedings_types
-            end
-          when false
-            application.proceedings.any? ? :has_other_proceedings : :proceedings_types
-          else
-            :link_application_make_links
-          end
+          link = application&.lead_linked_application
+          return :link_application_copies if link.confirm_link && link.link_type_code == "FC_LEAD"
+          return :link_application_make_links if link.confirm_link.nil?
+
+          application.proceedings.any? ? :has_other_proceedings : :proceedings_types
         end,
         check_answers: :check_provider_answers,
         carry_on_sub_flow: ->(application) { application.lead_linked_application&.link_type_code == "FC_LEAD" },

--- a/app/services/flow/steps/linked_applications/find_link_step.rb
+++ b/app/services/flow/steps/linked_applications/find_link_step.rb
@@ -1,0 +1,10 @@
+module Flow
+  module Steps
+    module LinkedApplications
+      FindLinkStep = Step.new(
+        path: ->(application) { Steps.urls.providers_legal_aid_application_link_application_find_link_application_path(application) },
+        forward: :link_application_confirm_links,
+      )
+    end
+  end
+end

--- a/app/services/flow/steps/linked_applications/make_link_step.rb
+++ b/app/services/flow/steps/linked_applications/make_link_step.rb
@@ -4,7 +4,7 @@ module Flow
       MakeLinkStep = Step.new(
         path: ->(application) { Steps.urls.providers_legal_aid_application_link_application_make_link_path(application) },
         forward: lambda do |application|
-          if application.lead_linked_application&.persisted?
+          if application.lead_linked_application&.link_type_code.in?(%w[FC_LEAD LEGAL])
             :link_application_find_link_applications
           else
             application.proceedings.any? ? :has_other_proceedings : :proceedings_types

--- a/app/views/providers/check_provider_answers/_shared.html.erb
+++ b/app/views/providers/check_provider_answers/_shared.html.erb
@@ -27,7 +27,7 @@
                          html_attributes: { id: "app-check-your-answers__linking_items" }) do |summary_list|
         summary_list.with_row(classes: "app-check-your-answers__linking_question") do |row|
           row.with_key(text: t(".section_linking.linked"), classes: "govuk-!-width-one-half")
-          row.with_value { safe_yes_or_no(@legal_aid_application.link_case?) }
+          row.with_value { safe_yes_or_no(@legal_aid_application&.lead_linked_application&.confirm_link?) }
           unless @read_only
             row.with_action(
               text: t("generic.change"),
@@ -36,7 +36,7 @@
             )
           end
         end
-        if @legal_aid_application.link_case?
+        if @legal_aid_application&.lead_linked_application&.confirm_link?
           summary_list.with_row(classes: "app-check-your-answers__linking_case") do |row|
             row.with_key(text: t(".section_linking.#{@legal_aid_application.lead_linked_application.link_type_code}"))
             row.with_value(text: @legal_aid_application.lead_linked_application.lead_application.link_description)
@@ -67,7 +67,7 @@
         end %>
   <% end %>
 
-  <% if @legal_aid_application.link_case? %>
+  <% if @legal_aid_application&.lead_linked_application&.confirm_link? %>
     <div class="govuk-grid-row" id="app-check-your-answers__copying">
       <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-heading-m"><%= t ".section_copying.heading" %></h2>

--- a/app/views/providers/link_application/confirm_links/show.html.erb
+++ b/app/views/providers/link_application/confirm_links/show.html.erb
@@ -38,10 +38,10 @@
       <% end %>
     <% end %>
 
-    <%= form.govuk_radio_buttons_fieldset(:link_case, legend: { tag: "h2", size: "l", text: t(".link_case") }) do %>
-      <%= form.govuk_radio_button :link_case, true, label: { text: t("generic.yes") }, link_errors: true %>
-      <%= form.govuk_radio_button :link_case, "No", label: { text: t(".options.no_link_to_different_case") } %>
-      <%= form.govuk_radio_button :link_case, false, label: { text: t(".options.no_carry_on_without_linking") } %>
+    <%= form.govuk_radio_buttons_fieldset(:confirm_link, legend: { tag: "h2", size: "l", text: t(".link_case") }) do %>
+      <%= form.govuk_radio_button :confirm_link, true, label: { text: t("generic.yes") }, link_errors: true %>
+      <%= form.govuk_radio_button :confirm_link, "No", label: { text: t(".options.no_link_to_different_case") } %>
+      <%= form.govuk_radio_button :confirm_link, false, label: { text: t(".options.no_carry_on_without_linking") } %>
 
     <% end %>
 

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -519,8 +519,6 @@ en:
               date_not_in_range: "The date you used delegated functions cannot be before %{months}"
             client_declaration_confirmed:
               accepted: Confirm this information is correct and that you'll get a signed declaration
-            link_case:
-              blank: Select if you want to link to the application
         linked_application:
           attributes:
             search_ref:
@@ -533,6 +531,8 @@ en:
               not_submitted: We found the case but it's NOT Been SUBMITTED - OH NO!
             link_type_code:
               blank: Select if you want to link this application with another one
+            confirm_link:
+              blank: Select if you want to link to the application
         other_assets_declaration:
           attributes:
             valuable_items_value:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -418,7 +418,7 @@ en:
       find_link_applications:
         show:
           heading: What is the LAA reference of the application you want to link to?
-          hint: For example, 'A-BCD-E1F'.
+          hint: For example, 'L-AB1-CD2'.
           missing: "We could not find an application with the LAA reference of %{application_ref}."
           not_submitted:
             heading: "Submit %{application_ref} if you want to link to it."

--- a/db/migrate/20240510114941_add_confirm_link_to_linked_application.rb
+++ b/db/migrate/20240510114941_add_confirm_link_to_linked_application.rb
@@ -1,0 +1,5 @@
+class AddConfirmLinkToLinkedApplication < ActiveRecord::Migration[7.1]
+  def change
+    add_column :linked_applications, :confirm_link, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_15_074736) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_10_114941) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -657,6 +657,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_15_074736) do
     t.string "link_type_code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "confirm_link"
     t.index ["associated_application_id"], name: "index_linked_applications_on_associated_application_id"
     t.index ["lead_application_id", "associated_application_id"], name: "index_linked_applications", unique: true
     t.index ["lead_application_id"], name: "index_linked_applications_on_lead_application_id"

--- a/features/cassettes/Linking_cases_back_button_use/Complete_flow_reversion_with_back_button.yml
+++ b/features/cassettes/Linking_cases_back_button_use/Complete_flow_reversion_with_back_button.yml
@@ -1,0 +1,308 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.os.uk/search/places/v1/postcode?key=<ORDNANCE_SURVEY_API_KEY>&lr=EN&postcode=SW1H9EA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.9.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Mon, 13 May 2024 10:54:46 GMT
+      content-type:
+      - application/json;charset=UTF-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      vary:
+      - Origin,Accept-Encoding,key
+      omse-category:
+      - premium
+      omse-transaction-count:
+      - '60'
+      omse-premium-count:
+      - '0'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: "{\r\n  \"header\" : {\r\n    \"uri\" : \"https://api.os.uk/search/places/v1/postcode?lr=EN&postcode=SW1H9EA\",\r\n
+        \   \"query\" : \"postcode=SW1H9EA\",\r\n    \"offset\" : 0,\r\n    \"totalresults\"
+        : 5,\r\n    \"format\" : \"JSON\",\r\n    \"dataset\" : \"DPA\",\r\n    \"lr\"
+        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"109\",\r\n    \"lastupdate\"
+        : \"2024-05-10\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
+        : [ {\r\n    \"DPA\" : {\r\n      \"UPRN\" : \"100023337883\",\r\n      \"UDPRN\"
+        : \"23749699\",\r\n      \"ADDRESS\" : \"SUPER FIRM LTD, 84, PETTY FRANCE,
+        LONDON, SW1H 9EA\",\r\n      \"ORGANISATION_NAME\" : \"SUPER FIRM LTD\",\r\n
+        \     \"BUILDING_NUMBER\" : \"84\",\r\n      \"THOROUGHFARE_NAME\" : \"PETTY
+        FRANCE\",\r\n      \"POST_TOWN\" : \"LONDON\",\r\n      \"POSTCODE\" : \"SW1H
+        9EA\",\r\n      \"RPC\" : \"2\",\r\n      \"X_COORDINATE\" : 529526.39,\r\n
+        \     \"Y_COORDINATE\" : 179490.43,\r\n      \"STATUS\" : \"APPROVED\",\r\n
+        \     \"LOGICAL_STATUS_CODE\" : \"1\",\r\n      \"CLASSIFICATION_CODE\" :
+        \"CR07\",\r\n      \"CLASSIFICATION_CODE_DESCRIPTION\" : \"Restaurant / Cafeteria\",\r\n
+        \     \"LOCAL_CUSTODIAN_CODE\" : 5990,\r\n      \"LOCAL_CUSTODIAN_CODE_DESCRIPTION\"
+        : \"CITY OF WESTMINSTER\",\r\n      \"COUNTRY_CODE\" : \"E\",\r\n      \"COUNTRY_CODE_DESCRIPTION\"
+        : \"This record is within England\",\r\n      \"POSTAL_ADDRESS_CODE\" : \"D\",\r\n
+        \     \"POSTAL_ADDRESS_CODE_DESCRIPTION\" : \"A record which is linked to
+        PAF\",\r\n      \"BLPU_STATE_CODE\" : \"2\",\r\n      \"BLPU_STATE_CODE_DESCRIPTION\"
+        : \"In use\",\r\n      \"TOPOGRAPHY_LAYER_TOID\" : \"osgb1000042216527\",\r\n
+        \     \"WARD_CODE\" : \"E05013806\",\r\n      \"LAST_UPDATE_DATE\" : \"10/02/2016\",\r\n
+        \     \"ENTRY_DATE\" : \"19/03/2001\",\r\n      \"BLPU_STATE_DATE\" : \"19/03/2001\",\r\n
+        \     \"LANGUAGE\" : \"EN\",\r\n      \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\"
+        : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\" : \"1B\"\r\n    }\r\n  },
+        {\r\n    \"DPA\" : {\r\n      \"UPRN\" : \"10033650067\",\r\n      \"UDPRN\"
+        : \"56825040\",\r\n      \"ADDRESS\" : \"BRITISH TRANSPORT POLICE, 98, PETTY
+        FRANCE, LONDON, SW1H 9EA\",\r\n      \"ORGANISATION_NAME\" : \"BRITISH TRANSPORT
+        POLICE\",\r\n      \"BUILDING_NUMBER\" : \"98\",\r\n      \"THOROUGHFARE_NAME\"
+        : \"PETTY FRANCE\",\r\n      \"POST_TOWN\" : \"LONDON\",\r\n      \"POSTCODE\"
+        : \"SW1H 9EA\",\r\n      \"RPC\" : \"2\",\r\n      \"X_COORDINATE\" : 529558.47,\r\n
+        \     \"Y_COORDINATE\" : 179482.17,\r\n      \"STATUS\" : \"APPROVED\",\r\n
+        \     \"LOGICAL_STATUS_CODE\" : \"1\",\r\n      \"CLASSIFICATION_CODE\" :
+        \"CO01\",\r\n      \"CLASSIFICATION_CODE_DESCRIPTION\" : \"Office / Work Studio\",\r\n
+        \     \"LOCAL_CUSTODIAN_CODE\" : 5990,\r\n      \"LOCAL_CUSTODIAN_CODE_DESCRIPTION\"
+        : \"CITY OF WESTMINSTER\",\r\n      \"COUNTRY_CODE\" : \"E\",\r\n      \"COUNTRY_CODE_DESCRIPTION\"
+        : \"This record is within England\",\r\n      \"POSTAL_ADDRESS_CODE\" : \"D\",\r\n
+        \     \"POSTAL_ADDRESS_CODE_DESCRIPTION\" : \"A record which is linked to
+        PAF\",\r\n      \"BLPU_STATE_CODE\" : \"2\",\r\n      \"BLPU_STATE_CODE_DESCRIPTION\"
+        : \"In use\",\r\n      \"TOPOGRAPHY_LAYER_TOID\" : \"osgb1000042217066\",\r\n
+        \     \"WARD_CODE\" : \"E05013806\",\r\n      \"PARENT_UPRN\" : \"100023337884\",\r\n
+        \     \"LAST_UPDATE_DATE\" : \"14/02/2022\",\r\n      \"ENTRY_DATE\" : \"19/03/2021\",\r\n
+        \     \"BLPU_STATE_DATE\" : \"19/03/2021\",\r\n      \"LANGUAGE\" : \"EN\",\r\n
+        \     \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\" : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\"
+        : \"1Q\"\r\n    }\r\n  }, {\r\n    \"DPA\" : {\r\n      \"UPRN\" : \"100023337884\",\r\n
+        \     \"UDPRN\" : \"23749702\",\r\n      \"ADDRESS\" : \"TRANSPORT FOR LONDON,
+        98, PETTY FRANCE, LONDON, SW1H 9EA\",\r\n      \"ORGANISATION_NAME\" : \"TRANSPORT
+        FOR LONDON\",\r\n      \"BUILDING_NUMBER\" : \"98\",\r\n      \"THOROUGHFARE_NAME\"
+        : \"PETTY FRANCE\",\r\n      \"POST_TOWN\" : \"LONDON\",\r\n      \"POSTCODE\"
+        : \"SW1H 9EA\",\r\n      \"RPC\" : \"1\",\r\n      \"X_COORDINATE\" : 529558.47,\r\n
+        \     \"Y_COORDINATE\" : 179482.17,\r\n      \"STATUS\" : \"APPROVED\",\r\n
+        \     \"LOGICAL_STATUS_CODE\" : \"1\",\r\n      \"CLASSIFICATION_CODE\" :
+        \"PP\",\r\n      \"CLASSIFICATION_CODE_DESCRIPTION\" : \"Property Shell\",\r\n
+        \     \"LOCAL_CUSTODIAN_CODE\" : 5990,\r\n      \"LOCAL_CUSTODIAN_CODE_DESCRIPTION\"
+        : \"CITY OF WESTMINSTER\",\r\n      \"COUNTRY_CODE\" : \"E\",\r\n      \"COUNTRY_CODE_DESCRIPTION\"
+        : \"This record is within England\",\r\n      \"POSTAL_ADDRESS_CODE\" : \"D\",\r\n
+        \     \"POSTAL_ADDRESS_CODE_DESCRIPTION\" : \"A record which is linked to
+        PAF\",\r\n      \"BLPU_STATE_CODE\" : \"2\",\r\n      \"BLPU_STATE_CODE_DESCRIPTION\"
+        : \"In use\",\r\n      \"TOPOGRAPHY_LAYER_TOID\" : \"osgb1000042217066\",\r\n
+        \     \"WARD_CODE\" : \"E05013806\",\r\n      \"LAST_UPDATE_DATE\" : \"30/03/2021\",\r\n
+        \     \"ENTRY_DATE\" : \"19/03/2001\",\r\n      \"BLPU_STATE_DATE\" : \"19/03/2001\",\r\n
+        \     \"LANGUAGE\" : \"EN\",\r\n      \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\"
+        : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\" : \"1F\"\r\n    }\r\n  },
+        {\r\n    \"DPA\" : {\r\n      \"UPRN\" : \"100023337882\",\r\n      \"UDPRN\"
+        : \"23749700\",\r\n      \"ADDRESS\" : \"100, PETTY FRANCE, LONDON, SW1H 9EA\",\r\n
+        \     \"BUILDING_NUMBER\" : \"100\",\r\n      \"THOROUGHFARE_NAME\" : \"PETTY
+        FRANCE\",\r\n      \"POST_TOWN\" : \"LONDON\",\r\n      \"POSTCODE\" : \"SW1H
+        9EA\",\r\n      \"RPC\" : \"2\",\r\n      \"X_COORDINATE\" : 529619.99,\r\n
+        \     \"Y_COORDINATE\" : 179499.2,\r\n      \"STATUS\" : \"APPROVED\",\r\n
+        \     \"LOGICAL_STATUS_CODE\" : \"1\",\r\n      \"CLASSIFICATION_CODE\" :
+        \"CT08\",\r\n      \"CLASSIFICATION_CODE_DESCRIPTION\" : \"Station / Interchange
+        / Terminal / Halt\",\r\n      \"LOCAL_CUSTODIAN_CODE\" : 5990,\r\n      \"LOCAL_CUSTODIAN_CODE_DESCRIPTION\"
+        : \"CITY OF WESTMINSTER\",\r\n      \"COUNTRY_CODE\" : \"E\",\r\n      \"COUNTRY_CODE_DESCRIPTION\"
+        : \"This record is within England\",\r\n      \"POSTAL_ADDRESS_CODE\" : \"D\",\r\n
+        \     \"POSTAL_ADDRESS_CODE_DESCRIPTION\" : \"A record which is linked to
+        PAF\",\r\n      \"BLPU_STATE_CODE\" : \"2\",\r\n      \"BLPU_STATE_CODE_DESCRIPTION\"
+        : \"In use\",\r\n      \"TOPOGRAPHY_LAYER_TOID\" : \"osgb1000042216526\",\r\n
+        \     \"WARD_CODE\" : \"E05013806\",\r\n      \"LAST_UPDATE_DATE\" : \"24/08/2021\",\r\n
+        \     \"ENTRY_DATE\" : \"19/03/2001\",\r\n      \"BLPU_STATE_DATE\" : \"19/03/2001\",\r\n
+        \     \"LANGUAGE\" : \"EN\",\r\n      \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\"
+        : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\" : \"1A\"\r\n    }\r\n  },
+        {\r\n    \"DPA\" : {\r\n      \"UPRN\" : \"10033648845\",\r\n      \"UDPRN\"
+        : \"54770395\",\r\n      \"ADDRESS\" : \"C P S, 102, PETTY FRANCE, LONDON,
+        SW1H 9EA\",\r\n      \"ORGANISATION_NAME\" : \"C P S\",\r\n      \"BUILDING_NUMBER\"
+        : \"102\",\r\n      \"THOROUGHFARE_NAME\" : \"PETTY FRANCE\",\r\n      \"POST_TOWN\"
+        : \"LONDON\",\r\n      \"POSTCODE\" : \"SW1H 9EA\",\r\n      \"RPC\" : \"2\",\r\n
+        \     \"X_COORDINATE\" : 529576.0,\r\n      \"Y_COORDINATE\" : 179549.0,\r\n
+        \     \"STATUS\" : \"APPROVED\",\r\n      \"LOGICAL_STATUS_CODE\" : \"1\",\r\n
+        \     \"CLASSIFICATION_CODE\" : \"CO01\",\r\n      \"CLASSIFICATION_CODE_DESCRIPTION\"
+        : \"Office / Work Studio\",\r\n      \"LOCAL_CUSTODIAN_CODE\" : 5990,\r\n
+        \     \"LOCAL_CUSTODIAN_CODE_DESCRIPTION\" : \"CITY OF WESTMINSTER\",\r\n
+        \     \"COUNTRY_CODE\" : \"E\",\r\n      \"COUNTRY_CODE_DESCRIPTION\" : \"This
+        record is within England\",\r\n      \"POSTAL_ADDRESS_CODE\" : \"D\",\r\n
+        \     \"POSTAL_ADDRESS_CODE_DESCRIPTION\" : \"A record which is linked to
+        PAF\",\r\n      \"BLPU_STATE_CODE\" : \"2\",\r\n      \"BLPU_STATE_CODE_DESCRIPTION\"
+        : \"In use\",\r\n      \"TOPOGRAPHY_LAYER_TOID\" : \"osgb1000001796535716\",\r\n
+        \     \"WARD_CODE\" : \"E05013806\",\r\n      \"PARENT_UPRN\" : \"10033604583\",\r\n
+        \     \"LAST_UPDATE_DATE\" : \"06/07/2020\",\r\n      \"ENTRY_DATE\" : \"15/06/2020\",\r\n
+        \     \"BLPU_STATE_DATE\" : \"15/06/2020\",\r\n      \"LANGUAGE\" : \"EN\",\r\n
+        \     \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\" : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\"
+        : \"1N\"\r\n    }\r\n  } ]\r\n}"
+  recorded_at: Mon, 13 May 2024 10:54:46 GMT
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v2.9.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Mon, 13 May 2024 10:54:53 GMT
+      content-type:
+      - application/json; charset=utf-8
+      content-length:
+      - '12573'
+      connection:
+      - keep-alive
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      x-permitted-cross-domain-policies:
+      - none
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      vary:
+      - Accept, Origin
+      etag:
+      - W/"dd6907b8448bc8458adb599124824756"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 4953e9dec17813a04eb4dcc84aa37b5a
+      x-runtime:
+      - '0.065844'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '[{"ccms_code":"DA001","meaning":"Inherent jurisdiction high court injunction","description":"to
+        be represented on an application for an injunction, order or declaration under
+        the inherent jurisdiction of the court.","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
+        abuse"},{"ccms_code":"SE095","meaning":"Enforcement order 11J-S8","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE015A","meaning":"Vary CAO contact-Appeal","description":"to
+        be represented on an application to vary/discharge a child arrangements order-who
+        the child(ren) spend time with. Appeals only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
+        be represented on an application for a non-molestation order.","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
+        abuse"},{"ccms_code":"SE014E","meaning":"CAO residence-Enforcement","description":"to
+        be represented on an application for a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE004A","meaning":"Specific Issue Order-Appeal-S8","description":"to
+        be represented on an application for a specific issue order.  Appeals only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
+        abuse"},{"ccms_code":"SE014A","meaning":"CAO residence-Appeal","description":"to
+        be represented on an application for a child arrangements order –where the
+        child(ren) will live. Appeals only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE013E","meaning":"CAO contact-Enforcement","description":"to
+        be represented on an application for a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE095A","meaning":"Enforcement order-Appeal-S8","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Appeals only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE097A","meaning":"Revocation enforcement-Appeal-S8","description":"to
+        be represented on an application for the revocation of an enforcement order
+        under section 11J and Schedule A1 Children Act 1989.  Appeals only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE099E","meaning":"Amd enforcement-breach-S8","description":"to
+        be represented on an application, following breach, for an amendment to an
+        enforcement order or for a further enforcement order under section 11J and
+        Schedule A1 Children Act 1989.  Enforcement only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE004E","meaning":"Specific Issue Order-Enforcement-S8","description":"to
+        be represented on an application for a specific issue order.  Enforcement
+        only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"DA020","meaning":"FGM Protection Order","description":"To
+        be represented on an application for a Female Genital Mutilation Protection
+        Order under the Female Genital Mutilation Act.","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
+        abuse"},{"ccms_code":"SE101E","meaning":"Compensation-Enforcement-S8","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE016","meaning":"Vary CAO residence","description":"to
+        be represented on an application to vary or discharge a child arrangements
+        order –where the child(ren) will live.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE016E","meaning":"Vary CAO residence-Enforcement","description":"to
+        be represented on an application to vary or discharge a child arrangements
+        order –where the child(ren) will live. Enforcement only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE004","meaning":"Specific Issue Order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE097","meaning":"Revocation enforcement-S8","description":"to
+        be represented on an application for the revocation of an enforcement order
+        under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE013A","meaning":"CAO contact-Appeal","description":"to
+        be represented on an application for a child arrangements order-who the child(ren)
+        spend time with. Appeals only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE007A","meaning":"Vary/Discharge Prohib Steps
+        Order-Appeal-S8","description":"to be represented on an application to vary
+        or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE100E","meaning":"Breach enforcement-S8","description":"to
+        be represented on an application, following breach, for an amendment to an
+        enforcement order or for a further enforcement order under section 11J and
+        Schedule A1 Children Act 1989.  Enforcement only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE015","meaning":"Vary CAO contact","description":"to
+        be represented on an application to vary/discharge a child arrangements order-who
+        the child(ren) spend time with.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE008","meaning":"Vary/Discharge Specific Issues
+        Ord-S8","description":"to be represented on an application to vary or discharge
+        a specific issue order.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
+        abuse"},{"ccms_code":"SE003E","meaning":"Prohibited Steps Order-Enforcement-S8","description":"to
+        be represented on an application for a prohibited steps order.  Enforcement
+        only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE015E","meaning":"Vary CAO contact-Enforcement","description":"to
+        be represented on an application to vary/discharge a child arrangements order-who
+        the child(ren) spend time with. Enforcement only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE007","meaning":"Vary/Discharge Prohib Steps
+        Order-S8","description":"to be represented on an application to vary or discharge
+        a prohibited steps order.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE007E","meaning":"Vary/Discharge Prohib Steps
+        Order-Enforcement-S8","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE013","meaning":"Child arrangements order (contact)","description":"to
+        be represented on an application for a child arrangements order-who the child(ren)
+        spend time with.","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE008A","meaning":"Vary/Discharge Specific Issues
+        Ord-Appeal-S8","description":"to be represented on an application to vary
+        or discharge a specific issue order.  Appeals only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE101A","meaning":"Compensation-Appeal-S8","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"DA006","meaning":"Extend, variation or discharge
+        - Part IV","description":"to be represented on an application to extend, vary
+        or discharge an order under Part IV Family Law Act 1996","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
+        abuse"},{"ccms_code":"SE003A","meaning":"Prohibited Steps Order-Appeal-S8","description":"to
+        be represented on an application for a prohibited steps order.  Appeals only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE014","meaning":"Child arrangements order (residence)","description":"to
+        be represented on an application for a child arrangements order –where the
+        child(ren) will live","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE008E","meaning":"Vary/Discharge Specific Issues
+        Ord-Enforcement-S8","description":"to be represented on an application to
+        vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"DA002","meaning":"Variation or discharge under
+        section 5 protection from harassment act 1997","description":"to be represented
+        on an application to vary or discharge an order under section 5 Protection
+        from Harassment Act 1997 where the parties are associated persons (as defined
+        by Part IV Family Law Act 1996).","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
+        abuse"},{"ccms_code":"SE096E","meaning":"Enforcement order+c’tal-S8","description":"to
+        be represented on an application for committal and for an enforcement order
+        under section 11J Children Act 1989. Enforcement only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"SE016A","meaning":"Vary CAO residence-Appeal","description":"to
+        be represented on an application to vary or discharge a child arrangements
+        order –where the child(ren) will live. Appeals only.","full_s8_only":true,"ccms_category_law":"Family","ccms_matter_code":"KSEC8","ccms_matter":"Children
+        - section 8"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
+        be represented on an application for a forced marriage protection order","full_s8_only":false,"ccms_category_law":"Family","ccms_matter_code":"MINJN","ccms_matter":"Domestic
+        abuse"}]'
+  recorded_at: Mon, 13 May 2024 10:54:53 GMT
+recorded_with: VCR 6.2.0

--- a/features/providers/linked_applications/back_button.feature
+++ b/features/providers/linked_applications/back_button.feature
@@ -1,0 +1,70 @@
+Feature: Linking cases back button use
+@javascript @vcr
+Scenario: Complete flow reversion with back button
+  Given I have created and submitted an application with the application reference 'L-123-456'
+  And the feature flag for linked_applications is enabled
+  And the feature flag for home_address is enabled
+
+  When I visit the application service
+  And I click link "Sign in"
+  And I choose 'London'
+  And I click 'Save and continue'
+  And I click link "Make a new application"
+  Then I should be on the 'providers/declaration' page showing 'Declaration'
+
+  When I click 'Agree and continue'
+  Then I should be on the Applicant page
+
+  And I enter name 'Test', 'User'
+  And I choose 'No'
+  And I enter the date of birth '01-01-1999'
+  And I click 'Save and continue'
+  Then I am on the postcode entry page
+
+  When I enter a postcode 'SW1H 9EA'
+  And I click find address
+  And I choose an address 'Transport For London, 98 Petty France, London, SW1H 9EA'
+  And I click 'Use this address'
+  Then I should be on a page with title "Is this also your client's home address?"
+
+  When I choose "Yes"
+  And I click "Save and continue"
+  Then I should be on a page with title "Do you want to link this application with another one?"
+
+  When I choose "Yes, I want to make a family link"
+  And I click "Save and continue"
+  Then I should be on a page with title "What is the LAA reference of the application you want to link to?"
+
+  When I search for laa reference 'L-123-456'
+  And I click "Search"
+  Then I should be on a page with title "Search result"
+  And I should see "Is this the application you want to link to?"
+
+  When I choose "Yes"
+  And I click "Save and continue"
+  Then I should be on a page with title "Do you want to copy the proceedings and merits from L-123-456 to this one?"
+  And I should see "You've made a family link"
+
+  When I choose "Yes, the information will be the same"
+  And I click "Save and continue"
+  Then I should be on a page with title "Does your client have a National Insurance number?"
+
+  When I click link "Back"
+  Then I should be on a page with title "Do you want to copy the proceedings and merits from L-123-456 to this one?"
+  And I should not see "You've made a family link"
+
+  When I click link "Back"
+  Then I should be on a page with title "Search result"
+  And I should see "Is this the application you want to link to?"
+  And I should see "L-123-456"
+
+  When I click link "Back"
+  Then I should be on a page with title "What is the LAA reference of the application you want to link to?"
+  And I should not see "L-123-456"
+
+  When I click link "Back"
+  Then I should be on a page with title "Do you want to link this application with another one?"
+
+  When I choose "No"
+  And I click "Save and continue"
+  Then I should be on a page showing "What does your client want legal aid for?"

--- a/features/step_definitions/linked_cases_steps.rb
+++ b/features/step_definitions/linked_cases_steps.rb
@@ -10,6 +10,9 @@ Given("I have created and submitted an application with the application referenc
     application_ref:,
   )
   @provider = @legal_aid_application.provider
+  firm = @provider.firm
+  @provider.offices << create(:office, firm:, code: "London")
+  @provider.offices << create(:office, firm:, code: "Manchester")
   login_as @provider
 end
 
@@ -55,13 +58,14 @@ Given(/I have linked (and|not) copied the ['|"](.*?)['|"] application with a ['|
   end
   @legal_aid_application.update!(link_case: true)
   LinkedApplication.find_or_create_by!(lead_application:,
+                                       confirm_link: true,
                                        associated_application: @legal_aid_application,
                                        link_type_code: type == "Family" ? "FC_LEAD" : "Legal")
 end
 
 When("I have neither linked or copied an application") do
-  @legal_aid_application.update!(link_case: false,
-                                 copy_case: false)
+  LinkedApplication.find_or_create_by!(associated_application: @legal_aid_application,
+                                       link_type_code: "false")
   @legal_aid_application.proceedings.destroy_all
   create(:proceeding, :da004, legal_aid_application: @legal_aid_application)
 end

--- a/spec/forms/providers/link_application/confirm_link_form_spec.rb
+++ b/spec/forms/providers/link_application/confirm_link_form_spec.rb
@@ -3,12 +3,12 @@ require "rails_helper"
 RSpec.describe Providers::LinkApplication::ConfirmLinkForm, type: :form do
   subject(:instance) { described_class.new(params) }
 
-  before { LinkedApplication.create!(lead_application_id: lead_application.id, associated_application_id: legal_aid_application.id, link_type_code: "FC_LEAD") }
+  let(:linked_application) { LinkedApplication.create!(lead_application_id: lead_application.id, associated_application_id: legal_aid_application.id, link_type_code: "FC_LEAD") }
 
   let(:params) do
     {
-      link_case:,
-      model: legal_aid_application,
+      confirm_link:,
+      model: linked_application,
     }
   end
   let(:legal_aid_application) { create(:legal_aid_application) }
@@ -19,11 +19,27 @@ RSpec.describe Providers::LinkApplication::ConfirmLinkForm, type: :form do
 
     before { call_save }
 
-    context "with link_case true" do
-      let(:link_case) { "true" }
+    context "with confirm_link true" do
+      let(:confirm_link) { "true" }
 
       it "sets link_case to true" do
-        expect(legal_aid_application.reload.link_case).to be true
+        expect(linked_application.confirm_link).to be true
+      end
+    end
+
+    context "with confirm_link false" do
+      let(:confirm_link) { "false" }
+
+      it "sets confirm_link to false" do
+        expect(linked_application.confirm_link).to be false
+      end
+    end
+
+    context "with confirm_link No" do
+      let(:confirm_link) { "No" }
+
+      it "sets confirm_link to nil" do
+        expect(linked_application.confirm_link).to be_nil
       end
 
       it "does not not destroy the linked application" do
@@ -31,32 +47,8 @@ RSpec.describe Providers::LinkApplication::ConfirmLinkForm, type: :form do
       end
     end
 
-    context "with link_case false" do
-      let(:link_case) { "false" }
-
-      it "sets link_case to true" do
-        expect(legal_aid_application.reload.link_case).to be false
-      end
-
-      it "destroys the linked application" do
-        expect(legal_aid_application.reload.lead_application).to be_nil
-      end
-    end
-
-    context "with link_case No" do
-      let(:link_case) { "No" }
-
-      it "sets link_case to nil" do
-        expect(legal_aid_application.reload.link_case).to be_nil
-      end
-
-      it "does not not destroy the linked application" do
-        expect(legal_aid_application.reload.lead_application).to eq lead_application
-      end
-    end
-
-    context "with link type nil" do
-      let(:link_case) { "" }
+    context "with confirm_link nil" do
+      let(:confirm_link) { "" }
 
       it "is invalid" do
         expect(instance).not_to be_valid
@@ -74,55 +66,39 @@ RSpec.describe Providers::LinkApplication::ConfirmLinkForm, type: :form do
 
     before { save_as_draft }
 
-    context "with link_case true" do
-      let(:link_case) { "true" }
+    context "with confirm_link true" do
+      let(:confirm_link) { "true" }
 
-      it "sets link_case to true" do
-        expect(legal_aid_application.reload.link_case).to be true
-      end
-
-      it "does not not destroy the linked application" do
-        expect(legal_aid_application.reload.lead_application).to eq lead_application
+      it "sets confirm_link to true" do
+        expect(linked_application.confirm_link).to be true
       end
     end
 
-    context "with link_case false" do
-      let(:link_case) { "false" }
+    context "with confirm_link false" do
+      let(:confirm_link) { "false" }
 
-      it "sets link_case to true" do
-        expect(legal_aid_application.reload.link_case).to be false
-      end
-
-      it "destroys the linked application" do
-        expect(legal_aid_application.reload.lead_application).to be_nil
+      it "sets confirm_link to true" do
+        expect(linked_application.confirm_link).to be false
       end
     end
 
-    context "with link_case No" do
-      let(:link_case) { "No" }
+    context "with confirm_link No" do
+      let(:confirm_link) { "No" }
 
-      it "sets link_case to nil" do
-        expect(legal_aid_application.reload.link_case).to be_nil
-      end
-
-      it "does not not destroy the linked application" do
-        expect(legal_aid_application.reload.lead_application).to eq lead_application
+      it "sets confirm_link to nil" do
+        expect(linked_application.confirm_link).to be_nil
       end
     end
 
-    context "with link type nil" do
-      let(:link_case) { "" }
+    context "with confirm_link nil" do
+      let(:confirm_link) { "" }
 
       it "is valid" do
         expect(instance).to be_valid
       end
 
-      it "does not update link_case" do
-        expect(legal_aid_application.reload.link_case).to be_nil
-      end
-
-      it "does not not destroy the linked application" do
-        expect(legal_aid_application.reload.lead_application).to eq lead_application
+      it "does not confirm_link" do
+        expect(linked_application.confirm_link).to be_nil
       end
     end
   end

--- a/spec/forms/providers/link_application/make_link_form_spec.rb
+++ b/spec/forms/providers/link_application/make_link_form_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Providers::LinkApplication::MakeLinkForm, type: :form do
     context "with family link type chosen" do
       let(:link_type_code) { "FC_LEAD" }
 
-      it "sets the lead_linked_appliction" do
+      it "sets the link_type_code" do
         expect(legal_aid_application.lead_linked_application.link_type_code).to eq "FC_LEAD"
       end
     end
@@ -28,7 +28,7 @@ RSpec.describe Providers::LinkApplication::MakeLinkForm, type: :form do
     context "with legal link type chosen" do
       let(:link_type_code) { "LEGAL" }
 
-      it "sets the lead_linked_appliction" do
+      it "sets the link_type_code" do
         expect(legal_aid_application.lead_linked_application.link_type_code).to eq "LEGAL"
       end
     end
@@ -36,12 +36,8 @@ RSpec.describe Providers::LinkApplication::MakeLinkForm, type: :form do
     context "with link type no chosen" do
       let(:link_type_code) { "false" }
 
-      it "does not create a linked application" do
-        expect(legal_aid_application.lead_linked_application).to be_nil
-      end
-
-      it "ensures the link_case boolean is false" do
-        expect(legal_aid_application.reload.link_case).to be false
+      it "sets the link_type_code" do
+        expect(legal_aid_application.lead_linked_application.link_type_code).to eq "false"
       end
     end
 
@@ -55,6 +51,15 @@ RSpec.describe Providers::LinkApplication::MakeLinkForm, type: :form do
       it "adds custom blank error message" do
         error_messages = instance.errors.messages.values.flatten
         expect(error_messages).to include("Select if you want to link this application with another one")
+      end
+    end
+
+    context "when the answer is changed from yes to no" do
+      let(:linked_application) { build(:linked_application, associated_application_id: legal_aid_application.id, link_type_code: "FC_LEAD") }
+      let(:link_type_code) { "false" }
+
+      it "resets the linked_application model" do
+        expect(linked_application.confirm_link).to be false
       end
     end
   end

--- a/spec/requests/providers/link_application/find_link_applications_controller_spec.rb
+++ b/spec/requests/providers/link_application/find_link_applications_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Providers::LinkApplication::FindLinkApplicationsController do
 
         it "redirects to the next page" do
           patch_request
-          expect(response).to redirect_to(providers_legal_aid_application_link_application_confirm_link_path)
+          expect(response).to have_http_status(:redirect)
 
           expect(flash).to be_empty
         end

--- a/spec/requests/providers/link_application/make_links_controller_spec.rb
+++ b/spec/requests/providers/link_application/make_links_controller_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe Providers::LinkApplication::MakeLinksController do
             expect(response).to have_http_status(:redirect)
           end
 
-          it "does not create a new lead linked application" do
-            expect { patch_request }.not_to change(LinkedApplication, :count)
+          it "creates a new lead linked application" do
+            expect { patch_request }.to change(LinkedApplication, :count).by(1)
           end
         end
 

--- a/spec/services/flow/steps/linked_applications/confirm_link_step_spec.rb
+++ b/spec/services/flow/steps/linked_applications/confirm_link_step_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Flow::Steps::LinkedApplications::ConfirmLinkStep, type: :request do
-  let(:legal_aid_application) { create(:legal_aid_application, link_case:) }
+  let(:legal_aid_application) { create(:legal_aid_application) }
   let(:lead_application) { create(:legal_aid_application) }
   let(:link_case) { true }
   let(:link_type_code) { "FC_LEAD" }
@@ -15,9 +15,16 @@ RSpec.describe Flow::Steps::LinkedApplications::ConfirmLinkStep, type: :request 
   describe "#forward" do
     subject { described_class.forward.call(legal_aid_application) }
 
-    before { LinkedApplication.create!(lead_application_id: lead_application.id, associated_application_id: legal_aid_application.id, link_type_code:) }
+    before do
+      LinkedApplication.create!(lead_application_id: lead_application.id,
+                                associated_application_id: legal_aid_application.id,
+                                link_type_code:,
+                                confirm_link:)
+    end
 
     context "when the provider confirms they wish to link the application" do
+      let(:confirm_link) { true }
+
       context "when the link type is family" do
         it { is_expected.to be :link_application_copies }
       end
@@ -30,13 +37,13 @@ RSpec.describe Flow::Steps::LinkedApplications::ConfirmLinkStep, type: :request 
     end
 
     context "when the provider confirms they do not want to link to an application" do
-      let(:link_case) { false }
+      let(:confirm_link) { false }
 
       it { is_expected.to be :proceedings_types }
     end
 
     context "when the provider confirms they want to link to a different application" do
-      let(:link_case) { nil }
+      let(:confirm_link) { nil }
 
       it { is_expected.to be :link_application_make_links }
     end

--- a/spec/services/flow/steps/linked_applications/find_link_step_spec.rb
+++ b/spec/services/flow/steps/linked_applications/find_link_step_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::LinkedApplications::FindLinkStep, type: :request do
+  let(:legal_aid_application) { create(:legal_aid_application) }
+
+  describe "#path" do
+    subject { described_class.path.call(legal_aid_application) }
+
+    it { is_expected.to eq providers_legal_aid_application_link_application_find_link_application_path(legal_aid_application) }
+  end
+
+  describe "#forward" do
+    subject { described_class.forward }
+
+    it { is_expected.to eq :link_application_confirm_links }
+  end
+end

--- a/spec/services/flow/steps/linked_applications/make_link_step_spec.rb
+++ b/spec/services/flow/steps/linked_applications/make_link_step_spec.rb
@@ -13,9 +13,33 @@ RSpec.describe Flow::Steps::LinkedApplications::MakeLinkStep, type: :request do
     subject { described_class.forward.call(legal_aid_application) }
 
     context "when the application has a linked_application" do
-      before { create(:linked_application, associated_application: legal_aid_application) }
+      before { create(:linked_application, associated_application: legal_aid_application, link_type_code:) }
 
-      it { is_expected.to eq :link_application_find_link_applications }
+      context "when it's a family link" do
+        let(:link_type_code) { "FC_LEAD" }
+
+        it { is_expected.to eq :link_application_find_link_applications }
+      end
+
+      context "when it's a Legal link" do
+        let(:link_type_code) { "LEGAL" }
+
+        it { is_expected.to eq :link_application_find_link_applications }
+      end
+
+      context "when it is not linked" do
+        let(:link_type_code) { "false" }
+
+        context "when the application has proceedings" do
+          let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings) }
+
+          it { is_expected.to eq :has_other_proceedings }
+        end
+
+        context "when the application has no proceedings" do
+          it { is_expected.to eq :proceedings_types }
+        end
+      end
     end
 
     context "when the application does not have a linked_application" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4992)

This PR updates the views, forms and flow for each of the linking cases pages and updated to allow the use of back buttons, it also updates the CYA page to use the new values 

>[!NOTE]
A future PR will have to delete the linked_application if user has picked no


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
