### PR TITLE
Fix: Flickery linked Application proceeding test

### DIFF
--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1867,7 +1867,8 @@ RSpec.describe LegalAidApplication do
       let(:legal_aid_application) { create(:legal_aid_application, :with_applicant, :with_proceedings, proceeding_count: 2) }
 
       it "returns the expected data" do
-        expect(link_description).to eql("#{legal_aid_application.applicant.full_name}, #{legal_aid_application.application_ref}, Inherent jurisdiction high court injunction, Non-molestation order")
+        expected = "#{legal_aid_application.applicant.full_name}, #{legal_aid_application.application_ref}, #{legal_aid_application.proceedings.map(&:meaning).join(', ')}"
+        expect(link_description).to eql(expected)
       end
     end
 


### PR DESCRIPTION
## What

This was caused by a race condition when setting up the proceedings, the test expected `A` -> `B`, 
but the setup sometimes created `B` a fraction of a second before `A`

To replicate the failure on main, duplicating the setup from the failing Circle job:
```shell
TEST_FILES=(spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_attributes_spec.rb
           spec/requests/providers/partners/bank_statements_controller_spec.rb
           spec/requests/pages_controller_spec.rb
           spec/models/legal_aid_application_spec.rb)

bundle exec rspec --seed 56013 --fail-fast -- ${TEST_FILES}
```

This changes the test to expect the text in the same order

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
