### PR TITLE
Chore: Add csv gem to remove deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby file: ".ruby-version"
 
 gem "aasm", "~> 5.5.0"
 gem "active_model_serializers", "~> 0.10.14"
+gem "csv"
 gem "deep_cloneable", "~> 3.2.0"
 gem "discard", "~> 1.3"
 gem "geckoboard-ruby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,6 +181,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
+    csv (3.3.0)
     cucumber (9.2.0)
       builder (~> 3.2)
       cucumber-ci-environment (> 9, < 11)
@@ -768,6 +769,7 @@ DEPENDENCIES
   byebug
   capybara (>= 3.36.0, < 4.0)
   cssbundling-rails
+  csv
   cucumber
   cucumber-rails (>= 2.4.0)
   database_cleaner


### PR DESCRIPTION
## What

Since the last ruby update, each time rails starts, for testing, server, etc Their has been the following warning

> csv.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec.

Manually adding it to the gemfile should remove the warning and reduce the chance of the next ruby update failing

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
