### PR TITLE
Ap 4942 update merits routing copied cases

### DIFF
--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -1,7 +1,6 @@
 module TaskListHelper
   def task_list_includes?(legal_aid_application, task_name)
-    # TODO: Should legal_framework_merits_task_list be included in cloner service,
-    # or should we make the call to LFA here if required?
+    # TODO: AP-5023 Add legal_framework_merits_task_list be included to cloner service
     return LegalAidApplication.find(legal_aid_application.copy_case_id).legal_framework_merits_task_list&.serialized_data&.match?(/name: :#{task_name}\n\s+dependencies: \*\d+/) if legal_aid_application.copy_case?
 
     legal_aid_application.legal_framework_merits_task_list.serialized_data.match?(/name: :#{task_name}\n\s+dependencies: \*\d+/)

--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -1,5 +1,9 @@
 module TaskListHelper
   def task_list_includes?(legal_aid_application, task_name)
+    # TODO: Should legal_framework_merits_task_list be included in cloner service,
+    # or should we make the call to LFA here if required?
+    return LegalAidApplication.find(legal_aid_application.copy_case_id).legal_framework_merits_task_list&.serialized_data&.match?(/name: :#{task_name}\n\s+dependencies: \*\d+/) if legal_aid_application.copy_case?
+
     legal_aid_application.legal_framework_merits_task_list.serialized_data.match?(/name: :#{task_name}\n\s+dependencies: \*\d+/)
   end
 

--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -1,6 +1,6 @@
 module TaskListHelper
   def task_list_includes?(legal_aid_application, task_name)
-    # TODO: AP-5023 Add legal_framework_merits_task_list be included to cloner service
+    # TODO: AP-5023 Add legal_framework_merits_task_list to cloner service
     return LegalAidApplication.find(legal_aid_application.copy_case_id).legal_framework_merits_task_list&.serialized_data&.match?(/name: :#{task_name}\n\s+dependencies: \*\d+/) if legal_aid_application.copy_case?
 
     legal_aid_application.legal_framework_merits_task_list.serialized_data.match?(/name: :#{task_name}\n\s+dependencies: \*\d+/)

--- a/app/services/flow/flows/provider_capital.rb
+++ b/app/services/flow/flows/provider_capital.rb
@@ -121,14 +121,8 @@ module Flow
           path: ->(application) { urls.providers_legal_aid_application_check_capital_answers_path(application) },
           forward: :capital_income_assessment_results,
         },
-        capital_assessment_results: {
-          path: ->(application) { urls.providers_legal_aid_application_capital_assessment_result_path(application) },
-          forward: :merits_task_lists,
-        },
-        capital_income_assessment_results: {
-          path: ->(application) { urls.providers_legal_aid_application_capital_income_assessment_result_path(application) },
-          forward: :merits_task_lists,
-        },
+        capital_assessment_results: Steps::ProviderCapital::CapitalAssessmentResultsStep,
+        capital_income_assessment_results: Steps::ProviderCapital::CapitalIncomeAssessmentResultsStep,
         means_reports: {
           path: ->(application) { urls.providers_legal_aid_application_means_report_path(application) },
         },

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -76,10 +76,7 @@ module Flow
             end
           end,
         },
-        confirm_non_means_tested_applications: {
-          path: ->(application) { urls.providers_legal_aid_application_confirm_non_means_tested_applications_path(application) },
-          forward: :merits_task_lists,
-        },
+        confirm_non_means_tested_applications: Steps::ProviderStart::ConfirmNonMeansTestedApplicationStep,
         no_national_insurance_numbers: {
           path: ->(application) { urls.providers_legal_aid_application_no_national_insurance_number_path(application) },
           forward: lambda do |application|

--- a/app/services/flow/steps/provider_capital/capital_assessment_results_step.rb
+++ b/app/services/flow/steps/provider_capital/capital_assessment_results_step.rb
@@ -1,0 +1,10 @@
+module Flow
+  module Steps
+    module ProviderCapital
+      CapitalAssessmentResultsStep = Step.new(
+        path: ->(application) { Steps.urls.providers_legal_aid_application_capital_assessment_result_path(application) },
+        forward: ->(application) { application.copy_case? ? :check_merits_answers : :merits_task_lists },
+      )
+    end
+  end
+end

--- a/app/services/flow/steps/provider_capital/capital_income_assessment_results_step.rb
+++ b/app/services/flow/steps/provider_capital/capital_income_assessment_results_step.rb
@@ -1,0 +1,10 @@
+module Flow
+  module Steps
+    module ProviderCapital
+      CapitalIncomeAssessmentResultsStep = Step.new(
+        path: ->(application) { Steps.urls.providers_legal_aid_application_capital_income_assessment_result_path(application) },
+        forward: ->(application) { application.copy_case? ? :check_merits_answers : :merits_task_lists },
+      )
+    end
+  end
+end

--- a/app/services/flow/steps/provider_start/confirm_non_means_tested_application_step.rb
+++ b/app/services/flow/steps/provider_start/confirm_non_means_tested_application_step.rb
@@ -1,0 +1,10 @@
+module Flow
+  module Steps
+    module ProviderStart
+      ConfirmNonMeansTestedApplicationStep = Step.new(
+        path: ->(application) { Steps.urls.providers_legal_aid_application_confirm_non_means_tested_applications_path(application) },
+        forward: ->(application) { application.copy_case? ? :check_merits_answers : :merits_task_lists },
+      )
+    end
+  end
+end

--- a/db/migrate/20240514091845_rename_link_case_to_case_cloned_on_legal_aid_application.rb
+++ b/db/migrate/20240514091845_rename_link_case_to_case_cloned_on_legal_aid_application.rb
@@ -1,0 +1,7 @@
+class RenameLinkCaseToCaseClonedOnLegalAidApplication < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      rename_column :legal_aid_applications, :link_case, :case_cloned
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_10_114941) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_14_091845) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -612,7 +612,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_10_114941) do
     t.boolean "applicant_in_receipt_of_housing_benefit"
     t.boolean "copy_case"
     t.uuid "copy_case_id"
-    t.boolean "link_case"
+    t.boolean "case_cloned"
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
     t.index ["application_ref"], name: "index_legal_aid_applications_on_application_ref", unique: true
     t.index ["discarded_at"], name: "index_legal_aid_applications_on_discarded_at"

--- a/features/step_definitions/linked_cases_steps.rb
+++ b/features/step_definitions/linked_cases_steps.rb
@@ -56,7 +56,7 @@ Given(/I have linked (and|not) copied the ['|"](.*?)['|"] application with a ['|
   else
     create(:proceeding, :da004, legal_aid_application: @legal_aid_application)
   end
-  @legal_aid_application.update!(link_case: true)
+  # @legal_aid_application.update!(link_case: true)
   LinkedApplication.find_or_create_by!(lead_application:,
                                        confirm_link: true,
                                        associated_application: @legal_aid_application,

--- a/spec/helpers/task_list_helper_spec.rb
+++ b/spec/helpers/task_list_helper_spec.rb
@@ -7,20 +7,43 @@ RSpec.describe TaskListHelper do
     let(:legal_aid_application) { create(:legal_aid_application, :with_multiple_proceedings_inc_section8) }
     let(:task_name) { :opponent_name }
 
-    before do
-      create(:legal_framework_merits_task_list, :da001, legal_aid_application:)
+    context "when the application has not been copied" do
+      before do
+        create(:legal_framework_merits_task_list, :da001, legal_aid_application:)
+      end
+
+      context "when task name is included in list of required tasks from LFA" do
+        let(:task_name) { :opponent_name }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context "when task name is NOT included in list of required tasks from LFA" do
+        let(:task_name) { :why_matter_opposed }
+
+        it { is_expected.to be_falsey }
+      end
     end
 
-    context "when task name is included in list of required tasks from LFA" do
-      let(:task_name) { :opponent_name }
+    context "when the application has been copied" do
+      before do
+        create(:legal_framework_merits_task_list, :da001, legal_aid_application: source_application)
+      end
 
-      it { is_expected.to be_truthy }
-    end
+      let(:source_application) { create(:legal_aid_application, :with_multiple_proceedings_inc_section8) }
+      let(:legal_aid_application) { create(:legal_aid_application, copy_case: true, copy_case_id: source_application.id) }
 
-    context "when task name is NOT included in list of required tasks from LFA" do
-      let(:task_name) { :why_matter_opposed }
+      context "when task name is included in list of required tasks from LFA" do
+        let(:task_name) { :opponent_name }
 
-      it { is_expected.to be_falsey }
+        it { is_expected.to be_truthy }
+      end
+
+      context "when task name is NOT included in list of required tasks from LFA" do
+        let(:task_name) { :why_matter_opposed }
+
+        it { is_expected.to be_falsey }
+      end
     end
   end
 end

--- a/spec/requests/providers/capital_assessment_results_controller_spec.rb
+++ b/spec/requests/providers/capital_assessment_results_controller_spec.rb
@@ -273,8 +273,8 @@ RSpec.describe Providers::CapitalAssessmentResultsController do
       context "when continue button is pressed" do
         let(:submit_button) { { continue_button: "Continue" } }
 
-        it "redirects to the merits task list" do
-          expect(patch_request).to redirect_to(providers_legal_aid_application_merits_task_list_path)
+        it "redirects to the next page" do
+          expect(response).to have_http_status(:redirect)
         end
       end
 

--- a/spec/requests/providers/capital_income_assessment_results_controller_spec.rb
+++ b/spec/requests/providers/capital_income_assessment_results_controller_spec.rb
@@ -503,8 +503,8 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
       context "when the continue button is pressed" do
         let(:submit_button) { { continue_button: "Continue" } }
 
-        it "redirects to the merits task list" do
-          expect(patch_request).to redirect_to(providers_legal_aid_application_merits_task_list_path)
+        it "redirects to the next page" do
+          expect(response).to have_http_status(:redirect)
         end
       end
 

--- a/spec/requests/providers/confirm_non_means_tested_applications_controller_spec.rb
+++ b/spec/requests/providers/confirm_non_means_tested_applications_controller_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Providers::ConfirmNonMeansTestedApplicationsController do
 
       it "updates application statre and redirects to the merits task list", :aggregate_failures do
         expect { request }.to change { application.reload.state }.from("applicant_details_checked").to("provider_entering_merits")
-        expect(response).to redirect_to(providers_legal_aid_application_merits_task_list_path(application))
+        expect(response).to have_http_status(:redirect)
       end
     end
 

--- a/spec/requests/providers/confirm_non_means_tested_applications_controller_spec.rb
+++ b/spec/requests/providers/confirm_non_means_tested_applications_controller_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Providers::ConfirmNonMeansTestedApplicationsController do
           .to("no_assessment")
       end
 
-      it "updates application statre and redirects to the merits task list", :aggregate_failures do
+      it "updates application statre and redirects to the next page", :aggregate_failures do
         expect { request }.to change { application.reload.state }.from("applicant_details_checked").to("provider_entering_merits")
         expect(response).to have_http_status(:redirect)
       end

--- a/spec/services/flow/steps/provider_capital/capital_assessment_results_step_spec.rb
+++ b/spec/services/flow/steps/provider_capital/capital_assessment_results_step_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::ProviderCapital::CapitalAssessmentResultsStep, type: :request do
+  let(:legal_aid_application) { create(:legal_aid_application, copy_case:) }
+  let(:copy_case) { true }
+
+  describe "#path" do
+    subject { described_class.path.call(legal_aid_application) }
+
+    it { is_expected.to eq providers_legal_aid_application_capital_assessment_result_path(legal_aid_application) }
+  end
+
+  describe "#forward" do
+    subject { described_class.forward.call(legal_aid_application) }
+
+    context "when the application has been copied from another application" do
+      it { is_expected.to eq :check_merits_answers }
+    end
+
+    context "when no vehicles remain on the application" do
+      let(:copy_case) { false }
+
+      it { is_expected.to eq :merits_task_lists }
+    end
+  end
+end

--- a/spec/services/flow/steps/provider_capital/capital_assessment_results_step_spec.rb
+++ b/spec/services/flow/steps/provider_capital/capital_assessment_results_step_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Flow::Steps::ProviderCapital::CapitalAssessmentResultsStep, type:
       it { is_expected.to eq :check_merits_answers }
     end
 
-    context "when no vehicles remain on the application" do
+    context "when the application has not been copied from another application" do
       let(:copy_case) { false }
 
       it { is_expected.to eq :merits_task_lists }

--- a/spec/services/flow/steps/provider_capital/capital_income_assessment_results_step_spec.rb
+++ b/spec/services/flow/steps/provider_capital/capital_income_assessment_results_step_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::ProviderCapital::CapitalIncomeAssessmentResultsStep, type: :request do
+  let(:legal_aid_application) { create(:legal_aid_application, copy_case:) }
+  let(:copy_case) { true }
+
+  describe "#path" do
+    subject { described_class.path.call(legal_aid_application) }
+
+    it { is_expected.to eq providers_legal_aid_application_capital_income_assessment_result_path(legal_aid_application) }
+  end
+
+  describe "#forward" do
+    subject { described_class.forward.call(legal_aid_application) }
+
+    context "when the application has been copied from another application" do
+      it { is_expected.to eq :check_merits_answers }
+    end
+
+    context "when no vehicles remain on the application" do
+      let(:copy_case) { false }
+
+      it { is_expected.to eq :merits_task_lists }
+    end
+  end
+end

--- a/spec/services/flow/steps/provider_capital/capital_income_assessment_results_step_spec.rb
+++ b/spec/services/flow/steps/provider_capital/capital_income_assessment_results_step_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Flow::Steps::ProviderCapital::CapitalIncomeAssessmentResultsStep,
       it { is_expected.to eq :check_merits_answers }
     end
 
-    context "when no vehicles remain on the application" do
+    context "when the application has not been copied from another application" do
       let(:copy_case) { false }
 
       it { is_expected.to eq :merits_task_lists }

--- a/spec/services/flow/steps/provider_start/confirm_non_means_tested_application_step_spec.rb
+++ b/spec/services/flow/steps/provider_start/confirm_non_means_tested_application_step_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Flow::Steps::ProviderStart::ConfirmNonMeansTestedApplicationStep,
       it { is_expected.to eq :check_merits_answers }
     end
 
-    context "when no vehicles remain on the application" do
+    context "when the application has not been copied from another application" do
       let(:copy_case) { false }
 
       it { is_expected.to eq :merits_task_lists }

--- a/spec/services/flow/steps/provider_start/confirm_non_means_tested_application_step_spec.rb
+++ b/spec/services/flow/steps/provider_start/confirm_non_means_tested_application_step_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::ProviderStart::ConfirmNonMeansTestedApplicationStep, type: :request do
+  let(:legal_aid_application) { create(:legal_aid_application, copy_case:) }
+  let(:copy_case) { true }
+
+  describe "#path" do
+    subject { described_class.path.call(legal_aid_application) }
+
+    it { is_expected.to eq providers_legal_aid_application_confirm_non_means_tested_applications_path(legal_aid_application) }
+  end
+
+  describe "#forward" do
+    subject { described_class.forward.call(legal_aid_application) }
+
+    context "when the application has been copied from another application" do
+      it { is_expected.to eq :check_merits_answers }
+    end
+
+    context "when no vehicles remain on the application" do
+      let(:copy_case) { false }
+
+      it { is_expected.to eq :merits_task_lists }
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4942)

- Updated routing in 3 places to bypass merits task list for copied cases and go directly to the merits cya page.
- This reflects routing for passported, means-tested and non-means tested applications.
- The TaskListHelper which is used by the opponent_details partial on the merits cya page relies on legal_aid_application.legal_framework_merits_task_list however this is currently nil for copied cases. A workaround has been introduced on this ticket to obtain it from the copied application. However, a ticket has been created AP-5023 to add legal_framework_merits_task_list to the cloner service.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
