### PR TITLE
AP-5026: Linking cases displayed on cya pages when linked cases is disabled

### DIFF
--- a/app/views/providers/check_provider_answers/_shared.html.erb
+++ b/app/views/providers/check_provider_answers/_shared.html.erb
@@ -98,36 +98,36 @@
     <% end %>
   <% end %>
 
-    <div class="govuk-grid-row" id="app-check-your-answers__proceedings">
-      <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-m"><%= t ".section_proceeding.heading" %></h2>
-      </div>
-      <div class="govuk-grid-column-one-third">
-        <%= unless @show_linked_proceedings || @read_only
-              govuk_link_to(
-                t("generic.change"), providers_legal_aid_application_has_other_proceedings_path(@legal_aid_application),
-                visually_hidden_suffix: t(".section_proceeding.heading"),
-                class: "govuk-link-right"
-              )
-            end %>
-      </div>
+  <div class="govuk-grid-row" id="app-check-your-answers__proceedings">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-m"><%= t ".section_proceeding.heading" %></h2>
     </div>
+    <div class="govuk-grid-column-one-third">
+      <%= unless @show_linked_proceedings || @read_only
+            govuk_link_to(
+              t("generic.change"), providers_legal_aid_application_has_other_proceedings_path(@legal_aid_application),
+              visually_hidden_suffix: t(".section_proceeding.heading"),
+              class: "govuk-link-right"
+            )
+          end %>
+    </div>
+  </div>
 
-    <%= govuk_summary_list(actions: false, classes: "govuk-!-margin-bottom-9") do |summary_list| %>
-      <%= @source_application.proceedings_by_name.each_with_index do |proceeding, i| %>
-        <%= summary_list.with_row(classes: "app-check-your-answers__#{proceeding.name}_proceeding") do |row| %>
-          <%= row.with_key(text: "#{t('.proceeding')} #{i + 1}", classes: "govuk-!-width-one-half") %>
-          <%= row.with_value { proceeding.meaning } %>
-        <% end %>
+  <%= govuk_summary_list(actions: false, classes: "govuk-!-margin-bottom-9") do |summary_list| %>
+    <%= @source_application.proceedings_by_name.each_with_index do |proceeding, i| %>
+      <%= summary_list.with_row(classes: "app-check-your-answers__#{proceeding.name}_proceeding") do |row| %>
+        <%= row.with_key(text: "#{t('.proceeding')} #{i + 1}", classes: "govuk-!-width-one-half") %>
+        <%= row.with_value { proceeding.meaning } %>
       <% end %>
     <% end %>
-    <% @source_application.proceedings.in_order_of_addition.each do |proceeding| %>
-      <%= render(
-            "shared/check_answers/proceeding_details",
-            proceeding:,
-            read_only: @read_only,
-          ) %>
-    <% end %>
+  <% end %>
+  <% @source_application.proceedings.in_order_of_addition.each do |proceeding| %>
+    <%= render(
+          "shared/check_answers/proceeding_details",
+          proceeding:,
+          read_only: @read_only,
+        ) %>
+  <% end %>
 
   <% if @source_application.used_delegated_functions? %>
     <div class="govuk-grid-row">

--- a/app/views/providers/check_provider_answers/_shared.html.erb
+++ b/app/views/providers/check_provider_answers/_shared.html.erb
@@ -17,85 +17,87 @@
         ) %>
   <% end %>
 
-  <div class="govuk-grid-row" id="app-check-your-answers__linking">
-    <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m"><%= t ".section_linking.heading" %></h2>
-    </div>
-  </div>
-  <%= govuk_summary_list(actions: !@read_only,
-                         classes: "govuk-!-margin-bottom-9",
-                         html_attributes: { id: "app-check-your-answers__linking_items" }) do |summary_list|
-        summary_list.with_row(classes: "app-check-your-answers__linking_question") do |row|
-          row.with_key(text: t(".section_linking.linked"), classes: "govuk-!-width-one-half")
-          row.with_value { safe_yes_or_no(@legal_aid_application&.lead_linked_application&.confirm_link?) }
-          unless @read_only
-            row.with_action(
-              text: t("generic.change"),
-              href: providers_legal_aid_application_link_application_make_link_path(@legal_aid_application),
-              visually_hidden_text: t(".section_linking.linked"),
-            )
-          end
-        end
-        if @legal_aid_application&.lead_linked_application&.confirm_link?
-          summary_list.with_row(classes: "app-check-your-answers__linking_case") do |row|
-            row.with_key(text: t(".section_linking.#{@legal_aid_application.lead_linked_application.link_type_code}"))
-            row.with_value(text: @legal_aid_application.lead_linked_application.lead_application.link_description)
-            unless @read_only
-              row.with_action(
-                text: t("generic.change"),
-                href: providers_legal_aid_application_link_application_find_link_application_path(@legal_aid_application),
-                visually_hidden_text: [t(".section_linking.aria_prefix"), t(".section_linking.#{@legal_aid_application.lead_linked_application.link_type_code}")].join(" "),
-              )
-            end
-          end
-        end
-      end %>
-
-  <% if all_linked_applications_details(@legal_aid_application).present? %>
-    <div class="govuk-grid-row" id="app-check-your-answers__other_links">
-      <div class="govuk-grid-column-full">
-        <h2 class="govuk-heading-m"><%= t ".other_links_section.#{@legal_aid_application.lead_linked_application.link_type_code}" %></h2>
-      </div>
-    </div>
-    <%= govuk_summary_list(actions: false, classes: "govuk-!-margin-bottom-9") do |summary_list|
-          all_linked_applications(@legal_aid_application).each do |application|
-            summary_list.with_row do |row|
-              row.with_key(text: application.applicant.full_name, classes: "govuk-!-width-one-half")
-              row.with_value { application.link_description }
-            end
-          end
-        end %>
-  <% end %>
-
-  <% if @legal_aid_application&.lead_linked_application&.confirm_link? %>
-    <div class="govuk-grid-row" id="app-check-your-answers__copying">
+  <% if Setting.linked_applications? %>
+    <div class="govuk-grid-row" id="app-check-your-answers__linking">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-m"><%= t ".section_copying.heading" %></h2>
-      </div>
-      <div class="govuk-grid-column-one-third">
-        <%= unless @read_only
-              govuk_link_to(
-                t("generic.change"), providers_legal_aid_application_link_application_copy_path(@legal_aid_application),
-                class: "govuk-link-right"
-              )
-            end %>
+        <h2 class="govuk-heading-m"><%= t ".section_linking.heading" %></h2>
       </div>
     </div>
     <%= govuk_summary_list(actions: !@read_only,
                            classes: "govuk-!-margin-bottom-9",
-                           html_attributes: { id: "app-check-your-answers__copying_items" }) do |summary_list|
-          summary_list.with_row(classes: "app-check-your-answers__copy_question") do |row|
-            row.with_key(text: t(".section_copying.question"), classes: "govuk-!-width-one-half")
-            row.with_value { safe_yes_or_no(@legal_aid_application.copy_case?) }
+                           html_attributes: { id: "app-check-your-answers__linking_items" }) do |summary_list|
+          summary_list.with_row(classes: "app-check-your-answers__linking_question") do |row|
+            row.with_key(text: t(".section_linking.linked"), classes: "govuk-!-width-one-half")
+            row.with_value { safe_yes_or_no(@legal_aid_application&.lead_linked_application&.confirm_link?) }
+            unless @read_only
+              row.with_action(
+                text: t("generic.change"),
+                href: providers_legal_aid_application_link_application_make_link_path(@legal_aid_application),
+                visually_hidden_text: t(".section_linking.linked"),
+              )
+            end
           end
-          if @legal_aid_application.copy_case?
-            summary_list.with_row(classes: "app-check-your-answers__copying_case") do |row|
-              row.with_key(text: t(".section_copying.copied"))
-              row.with_value(text: @source_application.link_description)
+          if @legal_aid_application&.lead_linked_application&.confirm_link?
+            summary_list.with_row(classes: "app-check-your-answers__linking_case") do |row|
+              row.with_key(text: t(".section_linking.#{@legal_aid_application.lead_linked_application.link_type_code}"))
+              row.with_value(text: @legal_aid_application.lead_linked_application.lead_application.link_description)
+              unless @read_only
+                row.with_action(
+                  text: t("generic.change"),
+                  href: providers_legal_aid_application_link_application_find_link_application_path(@legal_aid_application),
+                  visually_hidden_text: [t(".section_linking.aria_prefix"), t(".section_linking.#{@legal_aid_application.lead_linked_application.link_type_code}")].join(" "),
+                )
+              end
             end
           end
         end %>
+    <% if all_linked_applications_details(@legal_aid_application).present? %>
+      <div class="govuk-grid-row" id="app-check-your-answers__other_links">
+        <div class="govuk-grid-column-full">
+          <h2 class="govuk-heading-m"><%= t ".other_links_section.#{@legal_aid_application.lead_linked_application.link_type_code}" %></h2>
+        </div>
+      </div>
+      <%= govuk_summary_list(actions: false, classes: "govuk-!-margin-bottom-9") do |summary_list|
+            all_linked_applications(@legal_aid_application).each do |application|
+              summary_list.with_row do |row|
+                row.with_key(text: application.applicant.full_name, classes: "govuk-!-width-one-half")
+                row.with_value { application.link_description }
+              end
+            end
+          end %>
+    <% end %>
+
+    <% if @legal_aid_application&.lead_linked_application&.confirm_link? %>
+      <div class="govuk-grid-row" id="app-check-your-answers__copying">
+        <div class="govuk-grid-column-two-thirds">
+          <h2 class="govuk-heading-m"><%= t ".section_copying.heading" %></h2>
+        </div>
+        <div class="govuk-grid-column-one-third">
+          <%= unless @read_only
+                govuk_link_to(
+                  t("generic.change"), providers_legal_aid_application_link_application_copy_path(@legal_aid_application),
+                  class: "govuk-link-right"
+                )
+              end %>
+        </div>
+      </div>
+      <%= govuk_summary_list(actions: !@read_only,
+                             classes: "govuk-!-margin-bottom-9",
+                             html_attributes: { id: "app-check-your-answers__copying_items" }) do |summary_list|
+            summary_list.with_row(classes: "app-check-your-answers__copy_question") do |row|
+              row.with_key(text: t(".section_copying.question"), classes: "govuk-!-width-one-half")
+              row.with_value { safe_yes_or_no(@legal_aid_application.copy_case?) }
+            end
+            if @legal_aid_application.copy_case?
+              summary_list.with_row(classes: "app-check-your-answers__copying_case") do |row|
+                row.with_key(text: t(".section_copying.copied"))
+                row.with_value(text: @source_application.link_description)
+              end
+            end
+          end %>
+    <% end %>
   <% end %>
+
     <div class="govuk-grid-row" id="app-check-your-answers__proceedings">
       <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-heading-m"><%= t ".section_proceeding.heading" %></h2>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5026)

Add condition remove any linked application information when linked cases feature flag is disabled
Update indentation

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
