### PR TITLE
Chore: update proceeding loop spacing

### DIFF
--- a/app/views/providers/proceeding_loop/delegated_functions/show.html.erb
+++ b/app/views/providers/proceeding_loop/delegated_functions/show.html.erb
@@ -6,7 +6,7 @@
     ) do |form| %>
   <%= page_template page_title: @proceeding.meaning, template: :basic, form: do %>
     <span class="govuk-caption-xl"><%= position_in_array(@proceeding) %></span>
-    <h1 class="govuk-heading-xl govuk-!-margin-top-2"><%= page_title %></h1>
+    <h1 class="govuk-heading-xl"><%= page_title %></h1>
     <%= form.govuk_radio_buttons_fieldset(:used_delegated_functions,
                                           legend: { size: "m", tag: "h2", text: t(".question") }) do %>
       <%= form.govuk_radio_button :used_delegated_functions, true, label: { text: t("generic.yes") } do %>

--- a/app/views/providers/proceeding_loop/substantive_defaults/show.html.erb
+++ b/app/views/providers/proceeding_loop/substantive_defaults/show.html.erb
@@ -6,17 +6,13 @@
     ) do |form| %>
   <%= page_template template: :basic, form: do %>
     <span class="govuk-caption-xl"><%= position_in_array(@proceeding) %></span>
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-4"><%= @proceeding.meaning %></h1>
+    <h1 class="govuk-heading-xl"><%= @proceeding.meaning %></h1>
 
     <h2 class="govuk-heading-m"><%= t(".h2_header") %></h2>
-
-    <div class="govuk-!-padding-1"></div>
 
     <p><strong><%= t(".los_header") %></strong> <%= form.object.substantive_level_of_service_name %></p>
     <p><strong><%= t(".scope_header") %></strong> <%= form.object.substantive_scope_limitation_meaning %></p>
     <p><strong><%= t(".scope_description_header") %></strong> <%= form.object.substantive_scope_limitation_description %></p>
-
-    <div class="govuk-!-padding-2"></div>
 
     <%= form.govuk_radio_buttons_fieldset :accepted_substantive_defaults,
                                           inline: false,


### PR DESCRIPTION
## What

Remove custom spacing so default spacing is used on the `substantive_defaults` and `delegated_functions` pages
Agreed with designers

## Screenshots

<img width="1490" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-legal-aid/assets/13471320/c9954a32-18e0-4a44-a41e-e7a00ca746cb">

<img width="1479" alt="image" src="https://github.com/ministryofjustice/laa-apply-for-legal-aid/assets/13471320/6cf2e58e-e6fe-4880-a263-195e0acc8d3e">

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
