### PR TITLE
AP-5045: Update SubmittedApplication view with link banner

### DIFF
--- a/app/controllers/providers/provider_base_controller.rb
+++ b/app/controllers/providers/provider_base_controller.rb
@@ -13,5 +13,13 @@ module Providers
       @legal_aid_application.cfe_result.version >= 4 &&
         @legal_aid_application.cfe_result.jobs?
     end
+
+    def link_banner_display
+      count = LinkedApplication.where(lead_application: @legal_aid_application).count
+      return if count.zero?
+      return I18n.t("providers.submitted_applications.show.link_banner_many", count:) if count > 1
+
+      I18n.t("providers.submitted_applications.show.link_banner_one")
+    end
   end
 end

--- a/app/controllers/providers/submitted_applications_controller.rb
+++ b/app/controllers/providers/submitted_applications_controller.rb
@@ -2,6 +2,7 @@ module Providers
   class SubmittedApplicationsController < ProviderBaseController
     authorize_with_policy_method :show_submitted_application?
     helper_method :display_employment_income?
+    helper_method :link_banner_display
 
     def show
       @source_application = LegalAidApplication.find(legal_aid_application.copy_case_id) if @legal_aid_application.copy_case?

--- a/app/views/providers/submitted_applications/show.html.erb
+++ b/app/views/providers/submitted_applications/show.html.erb
@@ -1,7 +1,7 @@
-<%= if @legal_aid_application.associated_linked_applications.any?
-      notification_banner_title = t("generic.important")
-      notification_banner_text = link_banner_display
-    end %>
+<% if @legal_aid_application.associated_linked_applications.any?
+     notification_banner_title = t("generic.important")
+     notification_banner_text = link_banner_display
+   end %>
 
 <%= page_template page_title: t(".heading"),
                   back_link: :none,

--- a/app/views/providers/submitted_applications/show.html.erb
+++ b/app/views/providers/submitted_applications/show.html.erb
@@ -1,4 +1,12 @@
-<%= page_template page_title: t(".heading"), back_link: :none do %>
+<%= if @legal_aid_application.associated_linked_applications.any?
+      notification_banner_title = t("generic.important")
+      notification_banner_text = link_banner_display
+    end %>
+
+<%= page_template page_title: t(".heading"),
+                  back_link: :none,
+                  notification_banner_title:,
+                  notification_banner_text: do %>
   <%= print_button t(".print_button") %>
 
   <%= render "shared/review_application/questions_and_answers" %>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1579,6 +1579,8 @@ en:
         back_home: Back to your applications
         heading: Application for civil legal aid certificate
         print_button: Print application
+        link_banner_one: This application has been linked with another one since you submitted it.
+        link_banner_many: This application has been linked with %{count} other ones since you submitted it.
     review_and_print_applications:
       show:
         heading: Review and print your application


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5045)

Update theSubmitted Application page to show a banner if _other_ applications have retrospectively selected it as a lead application

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
