### PR TITLE
Chore: Update docker scan action

### DIFF
--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -1,8 +1,9 @@
 name: Scan docker image
 
 on:
+  workflow_dispatch:
   schedule:
-    - cron:  '45 5 * * *'
+    - cron:  '15 6 * * *'
 
 jobs:
   scan-docker-image:


### PR DESCRIPTION
## What

The scan job was running at the same time as the base-docker-image job so, if a new build is scheduled that fixes a security incident, the fixes won't be picked up until the following day.

It now runs 30 minutes after the base-docker-image job so that it should be testing the newest build each day

This also adds a workflow dispatch trigger so we can run manually if needed, like today!

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
