### PR TITLE
AP-5038: Add where_to_send_correspondence page

### DIFF
--- a/app/controllers/providers/correspondence_address/choices_controller.rb
+++ b/app/controllers/providers/correspondence_address/choices_controller.rb
@@ -1,0 +1,31 @@
+module Providers
+  module CorrespondenceAddress
+    class ChoicesController < ProviderBaseController
+      prefix_step_with :correspondence_address
+
+      def show
+        @form = Addresses::ChoiceForm.new(model: applicant)
+      end
+
+      def update
+        @form = Addresses::ChoiceForm.new(form_params)
+
+        render :show unless save_continue_or_draft(@form)
+      end
+
+    private
+
+      def applicant
+        legal_aid_application.applicant
+      end
+
+      def form_params
+        merge_with_model(applicant) do
+          next {} unless params[:applicant]
+
+          params.require(:applicant).permit(:correspondence_address_choice)
+        end
+      end
+    end
+  end
+end

--- a/app/forms/addresses/choice_form.rb
+++ b/app/forms/addresses/choice_form.rb
@@ -1,0 +1,10 @@
+module Addresses
+  class ChoiceForm < BaseForm
+    form_for Applicant
+
+    attr_accessor :correspondence_address_choice
+
+    validates :correspondence_address_choice, presence: true, unless: :draft?
+    validates :correspondence_address_choice, inclusion: { in: %w[home residence office] }, allow_blank: true, unless: :draft?
+  end
+end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -8,6 +8,12 @@ class Applicant < ApplicationRecord
 
   NINO_REGEXP = /\A[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}\z/
 
+  enum correspondence_address_choice: {
+    home: "home".freeze,
+    residence: "residence".freeze,
+    office: "office".freeze,
+  }
+
   has_one :legal_aid_application, dependent: :destroy
   has_many :addresses, dependent: :destroy
   has_one :address, -> { where(location: "correspondence").order(created_at: :desc) }, inverse_of: :applicant, dependent: :destroy

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -6,6 +6,7 @@ module Flow
         delete: Steps::DeleteStep,
         applicants: Steps::ProviderStart::ApplicantsStep,
         applicant_details: Steps::ProviderStart::ApplicantDetailsStep,
+        correspondence_address_choices: Steps::Addresses::CorrespondenceAddressChoicesStep,
         correspondence_address_lookups: Steps::Addresses::CorrespondenceAddressLookupsStep,
         correspondence_address_selections: Steps::Addresses::CorrespondenceAddressSelectionsStep,
         correspondence_address_manuals: Steps::Addresses::CorrespondenceAddressManualsStep,

--- a/app/services/flow/steps/addresses/correspondence_address_choices_step.rb
+++ b/app/services/flow/steps/addresses/correspondence_address_choices_step.rb
@@ -1,0 +1,18 @@
+module Flow
+  module Steps
+    module Addresses
+      CorrespondenceAddressChoicesStep = Step.new(
+        path: ->(application) { Steps.urls.providers_legal_aid_application_correspondence_address_choice_path(application) },
+        forward: lambda do |application|
+          {
+            home: :home_address_lookups,
+            residence: :correspondence_address_lookups,
+            office: :correspondence_address_manuals,
+          }[application&.applicant&.correspondence_address_choice&.to_sym]
+        end,
+        check_answers: :check_provider_answers,
+        carry_on_sub_flow: true,
+      )
+    end
+  end
+end

--- a/app/services/flow/steps/provider_start/applicant_details_step.rb
+++ b/app/services/flow/steps/provider_start/applicant_details_step.rb
@@ -6,6 +6,8 @@ module Flow
         forward: lambda do |application|
           if application.overriding_dwp_result?
             :has_national_insurance_numbers
+          elsif Setting.home_address?
+            :correspondence_address_choices
           else
             :correspondence_address_lookups
           end

--- a/app/services/flow/steps/provider_start/applicants_step.rb
+++ b/app/services/flow/steps/provider_start/applicants_step.rb
@@ -3,7 +3,7 @@ module Flow
     module ProviderStart
       ApplicantsStep = Step.new(
         path: ->(_) { Steps.urls.new_providers_applicant_path },
-        forward: :correspondence_address_lookups,
+        forward: ->(_) { Setting.home_address? ? :correspondence_address_choices : :correspondence_address_lookups },
       )
     end
   end

--- a/app/views/providers/check_provider_answers/_shared.html.erb
+++ b/app/views/providers/check_provider_answers/_shared.html.erb
@@ -2,7 +2,7 @@
 
   <%= render(
         "shared/check_answers/client_details",
-        attributes: %i[first_name last_name last_name_at_birth changed_last_name date_of_birth national_insurance_number employment_status address home_address],
+        attributes: %i[first_name last_name last_name_at_birth changed_last_name date_of_birth national_insurance_number employment_status correspondence_choice address home_address],
         applicant: @applicant,
         address: @address,
         read_only: @read_only,

--- a/app/views/providers/correspondence_address/choices/show.html.erb
+++ b/app/views/providers/correspondence_address/choices/show.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(
+      model: @form,
+      scope: :applicant,
+      url: providers_legal_aid_application_correspondence_address_choice_path(@legal_aid_application),
+      method: :patch,
+      local: true,
+    ) do |form| %>
+
+  <%= page_template(
+        page_title: t(".heading"),
+        template: :basic,
+        form:,
+      ) do %>
+
+    <%= form.govuk_radio_buttons_fieldset(:correspondence_address_choice, legend: { size: "xl", text: t(".heading"), tag: "h1" }) do %>
+      <div class="govuk-body"><%= t(".text") %></div>
+      <%= form.govuk_radio_button :correspondence_address_choice, :home, label: { text: t(".options.home") }, link_errors: true %>
+      <%= form.govuk_radio_button :correspondence_address_choice, :residence, label: { text: t(".options.residential") }, link_errors: false %>
+      <%= form.govuk_radio_button :correspondence_address_choice, :office, label: { text: t(".options.office") }, hint: { text: t(".options.office_hint") }, link_errors: false %>
+    <% end %>
+
+    <%= next_action_buttons(
+          form:,
+          show_draft: true,
+        ) %>
+  <% end %>
+<% end %>

--- a/app/views/shared/check_answers/_client_details.html.erb
+++ b/app/views/shared/check_answers/_client_details.html.erb
@@ -75,6 +75,18 @@
     <% end %>
   <% end %>
 
+  <% if Setting.home_address? && :correspondence_choice.in?(attributes) %>
+    <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__correspondence_address_choice" }) do |row| %>
+      <%= row.with_key(text: t(".correspondence_address_choice"), classes: "govuk-!-width-one-half") %>
+      <%= row.with_value(text: t(".correspondence_choice.#{applicant.correspondence_address_choice}")) %>
+      <%= row.with_action(
+            text: t("generic.change"),
+            href: providers_legal_aid_application_correspondence_address_choice_path,
+            visually_hidden_text: "#{t('.aria_prefix')} #{t('.address')}",
+          ) %>
+    <% end %>
+  <% end %>
+
   <% if :address.in?(attributes) %>
     <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__address" }) do |row| %>
       <%= row.with_key(text: t(".address"), classes: "govuk-!-width-one-half") %>

--- a/app/views/shared/review_application/_questions_and_answers.html.erb
+++ b/app/views/shared/review_application/_questions_and_answers.html.erb
@@ -24,7 +24,7 @@
     <h2 class="govuk-heading-l"><%= t(".client_details_heading") %></h2>
     <%= render(
           "shared/check_answers/client_details",
-          attributes: %i[first_name last_name last_name_at_birth changed_last_name date_of_birth national_insurance_number email address],
+          attributes: %i[first_name last_name last_name_at_birth changed_last_name date_of_birth national_insurance_number email correspondence_choice address home_address],
           applicant: @legal_aid_application.applicant,
           address: @legal_aid_application.applicant.address,
           read_only: true,

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -141,6 +141,9 @@ en:
               blank: Select yes if your client gets any benefits
             same_correspondence_and_home_address:
               blank: Select yes if this is your client's home address
+            correspondence_address_choice:
+              blank: Select where we should send your client's correspondence
+              inclusion: Select where we should send your client's correspondence
             student_finance:
               inclusion: Select yes if your client receives student finance
             student_finance_amount:
@@ -526,7 +529,7 @@ en:
               invalid: Enter a valid application reference to search for
               not_found: The application reference entered cannot be found
             search_laa_reference:
-              blank: Enter the LAA reference of the application you want to link to. 
+              blank: Enter the LAA reference of the application you want to link to.
               invalid: We could not find an application with the LAA reference of %{value}
               not_submitted: We found the case but it's NOT Been SUBMITTED - OH NO!
             link_type_code:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -189,7 +189,16 @@ en:
         they_always_need: They always need to be on.
         find_out_more_link: Find out more about cookies on GOV.UK
         save_changes_btn: Save changes
-
+    correspondence_address:
+      choices:
+        show:
+          heading: Where should we send your client’s correspondence?
+          text: We do not send correspondence to non-UK addresses.
+          options:
+            home: My client’s UK home address
+            residential: Another UK residential address
+            office: A UK office address
+            office_hint: For example, a provider’s office
     confirm_dwp_non_passported_applications:
       show:
         tab_title: DWP records show that your client does not get a passporting benefit – Apply for Legal Aid - GOV.UK

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -381,6 +381,11 @@ en:
         upper_limit_label: Capital upper limit
         total: Total capital assessed
       client_details:
+        correspondence_address_choice: Where to send client's mail
+        correspondence_choice:
+          home: My client’s UK home address
+          residential: Another UK residential address
+          office: A UK office address
         address: Correspondence address
         home_address: Home address
         aria_prefix: client's

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,6 +165,7 @@ Rails.application.routes.draw do
       end
       get :search, on: :collection
       namespace :correspondence_address do
+        resource :choice, only: %i[show update], path: "where_to_send_correspondence"
         resource :lookup, only: %i[show update], path: "find_correspondence_address"
         resource :manual, only: %i[show update], path: "enter_correspondence_address"
         resource :selection, only: %i[show update], path: "correspondence_address_results"

--- a/db/migrate/20240531070655_add_correspondence_address_choice_to_applicant.rb
+++ b/db/migrate/20240531070655_add_correspondence_address_choice_to_applicant.rb
@@ -1,0 +1,5 @@
+class AddCorrespondenceAddressChoiceToApplicant < ActiveRecord::Migration[7.1]
+  def change
+    add_column :applicants, :correspondence_address_choice, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_17_110634) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_31_070655) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -133,6 +133,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_17_110634) do
     t.boolean "changed_last_name"
     t.boolean "same_correspondence_and_home_address"
     t.boolean "no_fixed_residence"
+    t.string "correspondence_address_choice"
     t.index ["confirmation_token"], name: "index_applicants_on_confirmation_token", unique: true
     t.index ["email"], name: "index_applicants_on_email"
     t.index ["unlock_token"], name: "index_applicants_on_unlock_token", unique: true

--- a/features/providers/linked_applications/back_button.feature
+++ b/features/providers/linked_applications/back_button.feature
@@ -19,6 +19,10 @@ Scenario: Complete flow reversion with back button
   And I choose 'No'
   And I enter the date of birth '01-01-1999'
   And I click 'Save and continue'
+  Then I should be on a page with title "Where should we send your client’s correspondence?"
+
+  When I choose 'Another UK residential address'
+  And I click 'Save and continue'
   Then I am on the postcode entry page
 
   When I enter a postcode 'SW1H 9EA'

--- a/spec/forms/addresses/choice_form_spec.rb
+++ b/spec/forms/addresses/choice_form_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Addresses::ChoiceForm, type: :form do
+  subject(:form) { described_class.new(form_params.merge(model: applicant)) }
+
+  let(:correspondence_address_choice) { "home" }
+  let(:applicant) { create(:applicant) }
+  let(:form_params) do
+    {
+      correspondence_address_choice:,
+    }
+  end
+
+  describe "validations" do
+    it "is valid with all the required attributes" do
+      expect(form).to be_valid
+    end
+
+    context "when correspondence_address_choice is blank" do
+      let(:correspondence_address_choice) { "" }
+
+      it "contains a presence error on the correspondence_address_choice" do
+        expect(form).not_to be_valid
+        expect(form.errors[:correspondence_address_choice]).to contain_exactly("Select where we should send your client's correspondence")
+      end
+    end
+
+    context "when correspondence_address_choice is maliciously wrong" do
+      let(:correspondence_address_choice) { "wrong" }
+
+      it "contains a presence error on the correspondence_address_choice" do
+        expect(form).not_to be_valid
+        expect(form.errors[:correspondence_address_choice]).to contain_exactly("Select where we should send your client's correspondence")
+      end
+    end
+  end
+end

--- a/spec/requests/providers/correspondence_address/choices_controller_spec.rb
+++ b/spec/requests/providers/correspondence_address/choices_controller_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+RSpec.describe Providers::CorrespondenceAddress::ChoicesController do
+  let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
+  let(:applicant) { legal_aid_application.applicant }
+  let(:provider) { legal_aid_application.provider }
+
+  describe "GET /providers/applications/:legal_aid_application_id/where_to_send_correspondence" do
+    subject(:get_request) { get providers_legal_aid_application_correspondence_address_choice_path(legal_aid_application) }
+
+    context "when the provider is not authenticated" do
+      before { get_request }
+
+      it_behaves_like "a provider not authenticated"
+    end
+
+    context "when the provider is authenticated" do
+      before do
+        login_as provider
+        get_request
+      end
+
+      it "shows the correspondence address choice page" do
+        expect(response).to be_successful
+        expect(unescaped_response_body).to include("Where should we send your client’s correspondence?")
+      end
+    end
+  end
+
+  describe "PATCH/providers/applications/:legal_aid_application_id/where_to_send_correspondence" do
+    subject(:patch_request) { patch providers_legal_aid_application_correspondence_address_choice_path(legal_aid_application), params: }
+
+    let(:correspondence_address_choice) { "home" }
+    let(:submit_button) { {} }
+    let(:params) do
+      {
+        applicant: {
+          correspondence_address_choice:,
+        },
+      }.merge(submit_button)
+    end
+
+    context "when the provider is not authenticated" do
+      before { patch_request }
+
+      it_behaves_like "a provider not authenticated"
+    end
+
+    context "when the provider is authenticated" do
+      before do
+        login_as provider
+      end
+
+      context "with an invalid choice" do
+        let(:correspondence_address_choice) { "invalid-choice" }
+
+        it "re-renders the form with the validation errors" do
+          patch_request
+          expect(response).to have_http_status(:ok)
+          expect(unescaped_response_body).to include("There is a problem")
+          expect(unescaped_response_body).to include("Select where we should send your client's correspondence")
+        end
+      end
+
+      context "with a valid choice" do
+        it "saves the choice" do
+          patch_request
+          expect(applicant.reload.correspondence_address_choice).to eq("home")
+        end
+
+        it "redirects to the next page" do
+          patch_request
+          expect(response).to have_http_status(:redirect)
+        end
+      end
+
+      context "with form submitted using Save as draft button" do
+        let(:submit_button) { { draft_button: "Save as draft" } }
+
+        it "redirects provider to provider's applications page" do
+          patch_request
+          expect(response).to redirect_to(providers_legal_aid_applications_path)
+        end
+
+        it "sets the application as draft" do
+          expect { patch_request }.to change { legal_aid_application.reload.draft? }.from(false).to(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/flow/steps/addresses/correspondence_address_choices_step_spec.rb
+++ b/spec/services/flow/steps/addresses/correspondence_address_choices_step_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::Addresses::CorrespondenceAddressChoicesStep, type: :request do
+  let(:legal_aid_application) { build_stubbed(:legal_aid_application) }
+  let(:applicant) { build_stubbed(:applicant, legal_aid_application:) }
+
+  describe "#path" do
+    subject { described_class.path.call(legal_aid_application) }
+
+    it { is_expected.to eq providers_legal_aid_application_correspondence_address_choice_path(legal_aid_application) }
+  end
+
+  describe "#forward" do
+    subject { described_class.forward.call(legal_aid_application) }
+
+    before { allow(applicant).to receive(:correspondence_address_choice).and_return(correspondence_address_choice) }
+
+    context "when the provider has chosen home" do
+      let(:correspondence_address_choice) { "home" }
+
+      it { is_expected.to eq :home_address_lookups }
+    end
+
+    context "when the provider has chosen residence" do
+      let(:correspondence_address_choice) { "residence" }
+
+      it { is_expected.to eq :correspondence_address_lookups }
+    end
+
+    context "when the provider has chosen office" do
+      let(:correspondence_address_choice) { "office" }
+
+      it { is_expected.to eq :correspondence_address_manuals }
+    end
+  end
+
+  describe "#check_answers" do
+    subject { described_class.check_answers }
+
+    it { is_expected.to eq :check_provider_answers }
+  end
+
+  describe "#carry_on_sub_flow" do
+    subject { described_class.carry_on_sub_flow }
+
+    it { is_expected.to be true }
+  end
+end

--- a/spec/services/flow/steps/provider_start/applicant_details_step_spec.rb
+++ b/spec/services/flow/steps/provider_start/applicant_details_step_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe Flow::Steps::ProviderStart::ApplicantDetailsStep, type: :request 
 
       it { is_expected.to eq :has_national_insurance_numbers }
     end
+
+    context "when the home_address feature flag is enabled" do
+      before { allow(Setting).to receive(:home_address?).and_return(true) }
+
+      it { is_expected.to eq :correspondence_address_choices }
+    end
   end
 
   describe "#check_answers" do

--- a/spec/services/flow/steps/provider_start/applicants_step_spec.rb
+++ b/spec/services/flow/steps/provider_start/applicants_step_spec.rb
@@ -10,7 +10,17 @@ RSpec.describe Flow::Steps::ProviderStart::ApplicantsStep, type: :request do
   end
 
   describe "#forward" do
-    subject { described_class.forward }
+    subject { described_class.forward.call(nil) }
+
+    before { allow(Setting).to receive(:home_address?).and_return(home_address_setting) }
+
+    let(:home_address_setting) { false }
+
+    context "when the home_address feature flag is enabled" do
+      let(:home_address_setting) { true }
+
+      it { is_expected.to eq :correspondence_address_choices }
+    end
 
     it { is_expected.to eq :correspondence_address_lookups }
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5038)

This PR adds the new correspondence choice page for the updated home address flow.  
It updates the existing flow when the flag is enabled to route to the new page and move onto to the next pages as defined in the figma file

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
