### PR TITLE
AP-5061: Update CCMS partner handling

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -77,7 +77,7 @@ class LegalAidApplication < ApplicationRecord
   validate :validate_document_categories
 
   delegate :bank_transactions, :under_18?, :under_16_blocked?, to: :applicant, allow_nil: true
-  delegate :full_name, :has_partner, :has_partner?, to: :applicant, prefix: true, allow_nil: true
+  delegate :full_name, :has_partner, :has_partner?, :has_partner_with_no_contrary_interest?, to: :applicant, prefix: true, allow_nil: true
   delegate :shared_benefit_with_applicant, :shared_benefit_with_applicant?, to: :partner, allow_nil: true
   delegate :case_ccms_reference, to: :ccms_submission, allow_nil: true
   delegate :applicant_enter_means!,

--- a/config/ccms/attribute_block_configs/base.yml
+++ b/config/ccms/attribute_block_configs/base.yml
@@ -1332,24 +1332,24 @@ global_means:
     response_type: boolean
     user_defined: false
   GB_INPUT_B_5WP1_3A:
-    value: '#applicant_has_partner?'
+    value: '#applicant_has_partner_with_no_contrary_interest?'
     br100_meaning: 'Client: The client has a partner?'
     response_type: boolean
     user_defined: true
   GB_INPUT_T_5WP1_5A:
-    generate_block?: '#applicant_has_partner?'
+    generate_block?: '#applicant_has_partner_with_no_contrary_interest?'
     value: '#partner_first_name'
     br100_meaning: 'Client: The client has a partner?'
     response_type: text
     user_defined: true
   GB_INPUT_T_5WP1_6A:
-    generate_block?: '#applicant_has_partner?'
+    generate_block?: '#applicant_has_partner_with_no_contrary_interest?'
     value: '#partner_last_name'
     br100_meaning: 'Client: The client has a partner?'
     response_type: text
     user_defined: true
   GB_INPUT_D_5WP1_8A:
-    generate_block?: '#applicant_has_partner?'
+    generate_block?: '#applicant_has_partner_with_no_contrary_interest?'
     value: '#partner_date_of_birth'
     br100_meaning: 'Client: The client has a partner?'
     response_type: date

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
@@ -1767,6 +1767,40 @@ module CCMS
             end
           end
 
+          context "when the applicant has a partner with a contrary interest" do
+            before do
+              legal_aid_application.applicant.update(has_partner: true, partner_has_contrary_interest: true)
+            end
+
+            describe "GB_INPUT_B_5WP1_3A - Client: The client has a partner?" do
+              it "returns false" do
+                block = XmlExtractor.call(xml, :global_means, "GB_INPUT_B_5WP1_3A")
+                expect(block).to have_boolean_response false
+              end
+            end
+
+            describe "GB_INPUT_T_5WP1_5A - Partner: First name" do
+              it "is not returned" do
+                block = XmlExtractor.call(xml, :global_means, "GB_INPUT_T_5WP1_5A")
+                expect(block).not_to be_present, "Expected block for attribute GB_INPUT_T_5WP1_5A not to be generated, but was \n #{block}"
+              end
+            end
+
+            describe "GB_INPUT_T_5WP1_6A - Partner: Surname" do
+              it "is not returned" do
+                block = XmlExtractor.call(xml, :global_means, "GB_INPUT_T_5WP1_6A")
+                expect(block).not_to be_present, "Expected block for attribute GB_INPUT_T_5WP1_6A not to be generated, but was \n #{block}"
+              end
+            end
+
+            describe "GB_INPUT_T_5WP1_8A - Partner: DOB" do
+              it "is not returned" do
+                block = XmlExtractor.call(xml, :global_means, "GB_INPUT_T_5WP1_8A")
+                expect(block).not_to be_present, "Expected block for attribute GB_INPUT_T_5WP1_8A not to be generated, but was \n #{block}"
+              end
+            end
+          end
+
           context "when the applicant does not have a partner" do
             describe "GB_INPUT_B_5WP1_3A - Client: The client has a partner?" do
               it "returns false" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5061)

It was set up to add partner details if applicant_has_partner was true but if the partner has a contrary interest we do not save values

This changes the CCMS builders to only add them if applicant_has_partner_with_no_contrary_interest is true as then the partner values should exist

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
