### PR TITLE
Chore: SCA interrupt page

### DIFF
--- a/app/controllers/providers/proceedings_sca/interrupts_controller.rb
+++ b/app/controllers/providers/proceedings_sca/interrupts_controller.rb
@@ -1,0 +1,23 @@
+module Providers
+  module ProceedingsSCA
+    class InterruptsController < ProviderBaseController
+      def show
+        type
+      end
+
+    private
+
+      def type
+        @type ||= type_param
+      end
+
+      def type_param
+        I18n.t("title_html", scope: "providers.proceedings_sca.interrupts.show.#{params.require(:type)}").match(/^translation missing/i).present?
+        params.require(:type)
+      rescue ActionController::ParameterMissing, I18n::MissingTranslationData
+        # TODO: Placeholder to allow fallback while developing
+        "default"
+      end
+    end
+  end
+end

--- a/app/views/providers/proceedings_sca/interrupts/show.html.erb
+++ b/app/views/providers/proceedings_sca/interrupts/show.html.erb
@@ -1,0 +1,14 @@
+<div class="interruption-panel">
+  <%= page_template(page_title: t(".#{@type}.title_html"), column_width: "full", template: :basic) do %>
+    <%= page_heading(size: "l") %>
+
+    <div class="maximize-text-width">
+      <p class="govuk-body"><%= t(".options") %></p>
+      <%= govuk_list t(".#{@type}.option_bullets"), type: :bullet %>
+    </div>
+
+    <div class='govuk-button-group'>
+      <%= govuk_button_link_to t(".applications"), providers_legal_aid_applications_path, class: "white-button", role: "button" %>
+    </div>
+  <% end %>
+</div>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -21,4 +21,5 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "DWP"
   inflect.acronym "MIS"
   inflect.acronym "HMRC"
+  inflect.acronym "SCA"
 end

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1664,6 +1664,22 @@ en:
         page_title: Enter your client's email address
         label: Email address
         hint: We'll use this to send your client a link to the service.
+    proceedings_sca:
+      interrupts:
+        show:
+          options: "You can (choose one of the following):"
+          applications: Select a different proceeding or matter type
+          default:
+            title_html: You cannot choose a special children act proceeding if it has not been issued
+            option_bullets:
+              - select a different proceeding or matter type
+              - go back and change your answer
+              - use legal help
+          supervision:
+            title_html: For special children act, a supervision order cannot be varied, discharged or extended
+            option_bullets:
+              - select a different proceeding or matter type
+              - go back and change your answer
     proceeding_loop:
       single_proceeding: Proceeding 1
       multi_proceeding: Proceeding %{position} of %{total}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -269,6 +269,12 @@ Rails.application.routes.draw do
       scope module: :interrupt do
         resource :block, only: %i[show], path: "voided-application"
       end
+
+      scope module: :proceedings_sca do
+        # resource :interrupts, only: %i[show]
+        get "/interrupt/:type", to: "interrupts#show", as: "sca_interrupt"
+      end
+
       scope module: :proceeding_loop do
         resources :delegated_functions, only: %i[show update]
         resources :confirm_delegated_functions_date, only: %i[show update]

--- a/spec/requests/providers/proceedings_sca/interrupts_controller_spec.rb
+++ b/spec/requests/providers/proceedings_sca/interrupts_controller_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe Providers::ProceedingsSCA::InterruptsController do
+  let(:legal_aid_application) { create(:legal_aid_application) }
+  let(:provider) { legal_aid_application.provider }
+
+  describe "GET /providers/applications/:id/interrupt/:type" do
+    subject(:get_request) { get providers_legal_aid_application_sca_interrupt_path(legal_aid_application, display) }
+
+    let(:display) { "supervision" }
+
+    context "when the provider is not authenticated" do
+      before { get_request }
+
+      it_behaves_like "a provider not authenticated"
+    end
+
+    context "when the provider is authenticated" do
+      before do
+        login_as provider
+        get_request
+      end
+
+      it "returns http success" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "shows text for a supervision order and a button to select a different proceeding" do
+        expect(response.body).to include("For special children act, a supervision order cannot be varied, discharged or extended")
+        expect(response.body).to include("Select a different proceeding or matter type")
+      end
+
+      context "when passed an unknown type" do
+        let(:display) { "jedi" }
+
+        it "shows default text and a button to select a different proceeding" do
+          expect(response.body).to include("You cannot choose a special children act proceeding if it has not been issued")
+          expect(response.body).to include("Select a different proceeding or matter type")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION

## What

Implement an SCA interrupt page as we need a standard page we can use for each question

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
