### PR TITLE
AP-5075: update link case confirm page

### DIFF
--- a/app/forms/providers/link_application/make_link_form.rb
+++ b/app/forms/providers/link_application/make_link_form.rb
@@ -8,7 +8,7 @@ module Providers
       validates :link_type_code, presence: true, unless: :draft?
 
       def save
-        model.update!(confirm_link: false) if link_type_code != "true"
+        model.update!(confirm_link: link_type_code == "false" ? false : nil)
         super
       end
       alias_method :save!, :save

--- a/app/services/flow/steps/linked_applications/confirm_link_step.rb
+++ b/app/services/flow/steps/linked_applications/confirm_link_step.rb
@@ -6,7 +6,7 @@ module Flow
         forward: lambda do |application|
           link = application&.lead_linked_application
           return :link_application_copies if link.confirm_link && link.link_type_code == "FC_LEAD"
-          return :link_application_make_links if link.confirm_link.nil?
+          return :link_application_find_link_applications if link.confirm_link.nil?
 
           application.proceedings.any? ? :has_other_proceedings : :proceedings_types
         end,

--- a/spec/forms/providers/link_application/make_link_form_spec.rb
+++ b/spec/forms/providers/link_application/make_link_form_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe Providers::LinkApplication::MakeLinkForm, type: :form do
       let(:link_type_code) { "FC_LEAD" }
 
       it "sets the link_type_code" do
-        expect(legal_aid_application.lead_linked_application.link_type_code).to eq "FC_LEAD"
+        expect(legal_aid_application.lead_linked_application).to have_attributes(link_type_code: "FC_LEAD",
+                                                                                 confirm_link: nil)
       end
     end
 
@@ -29,7 +30,8 @@ RSpec.describe Providers::LinkApplication::MakeLinkForm, type: :form do
       let(:link_type_code) { "LEGAL" }
 
       it "sets the link_type_code" do
-        expect(legal_aid_application.lead_linked_application.link_type_code).to eq "LEGAL"
+        expect(legal_aid_application.lead_linked_application).to have_attributes(link_type_code: "LEGAL",
+                                                                                 confirm_link: nil)
       end
     end
 
@@ -37,7 +39,8 @@ RSpec.describe Providers::LinkApplication::MakeLinkForm, type: :form do
       let(:link_type_code) { "false" }
 
       it "sets the link_type_code" do
-        expect(legal_aid_application.lead_linked_application.link_type_code).to eq "false"
+        expect(legal_aid_application.lead_linked_application).to have_attributes(link_type_code: "false",
+                                                                                 confirm_link: false)
       end
     end
 

--- a/spec/services/flow/steps/linked_applications/confirm_link_step_spec.rb
+++ b/spec/services/flow/steps/linked_applications/confirm_link_step_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Flow::Steps::LinkedApplications::ConfirmLinkStep, type: :request 
     context "when the provider confirms they want to link to a different application" do
       let(:confirm_link) { nil }
 
-      it { is_expected.to be :link_application_make_links }
+      it { is_expected.to be :link_application_find_link_applications }
     end
   end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5075)

Update the link case flow, ensure when then link_case_confirm page is reached that the `No` option is no pre-selected
When a use clicks on the `No, I want to link to a different case` option they are taken to the search page, not the link_type page

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
