### PR TITLE
Fix: Broken CYA with Home Address

### DIFF
--- a/app/controllers/providers/address_selections_base_controller.rb
+++ b/app/controllers/providers/address_selections_base_controller.rb
@@ -28,6 +28,10 @@ module Providers
 
   private
 
+    def no_state_change_required?
+      legal_aid_application.entering_applicant_details? || legal_aid_application.checking_applicant_details?
+    end
+
     def address_lookup
       @address_lookup ||= AddressLookupService.call(address.postcode)
     end

--- a/app/controllers/providers/correspondence_address/selections_controller.rb
+++ b/app/controllers/providers/correspondence_address/selections_controller.rb
@@ -5,10 +5,6 @@ module Providers
 
     private
 
-      def no_state_change_required?
-        legal_aid_application.entering_applicant_details? || legal_aid_application.checking_applicant_details?
-      end
-
       def address
         applicant.address || applicant.build_address(country_code: "GBR", country_name: "United Kingdom")
       end

--- a/app/controllers/providers/home_address/selections_controller.rb
+++ b/app/controllers/providers/home_address/selections_controller.rb
@@ -5,10 +5,6 @@ module Providers
 
     private
 
-      def no_state_change_required?
-        true
-      end
-
       def address
         applicant.home_address || applicant.build_address(country_code: "GBR", country_name: "United Kingdom")
       end


### PR DESCRIPTION
## What

When we changed the home address flow, we can now go straight to the home address controller.  This had a no_state_change_required? override that always by-passed the state change.  This meant that when we reached the CYA page the application state was in the initialised state and could not transition to the next state.

Reverting the home controller to match the correspondence controller allows either one to change the state and enable access to the CYA page.

As it is the same I have moved it into the AddressSelectionsBaseController

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
