### PR TITLE
AP-5076: Remove copy info from CYA when legal link

### DIFF
--- a/app/forms/providers/link_application/make_link_form.rb
+++ b/app/forms/providers/link_application/make_link_form.rb
@@ -9,6 +9,9 @@ module Providers
 
       def save
         model.update!(confirm_link: link_type_code == "false" ? false : nil)
+        if link_type_code.eql?("LEGAL")
+          model.associated_application.update!(copy_case: nil, copy_case_id: nil)
+        end
         super
       end
       alias_method :save!, :save

--- a/app/views/shared/check_answers/_linking_and_copying.html.erb
+++ b/app/views/shared/check_answers/_linking_and_copying.html.erb
@@ -49,7 +49,7 @@
         end %>
   <% end %>
 
-  <% if @legal_aid_application&.lead_linked_application&.confirm_link? %>
+  <% if @legal_aid_application&.lead_linked_application&.confirm_link? && @legal_aid_application&.lead_linked_application&.link_type_code.eql?("FC_LEAD") %>
     <div class="govuk-grid-row" id="app-check-your-answers__copying">
       <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-heading-m"><%= t ".section_copying.heading" %></h2>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5076)

- Copy case info removed from CYA page when legal link is selected
- When family link is chosen and case is copied, but then link is changed to legal link, copying information is removed

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
