### PR TITLE
AP-5077: No back link on proceeding page after link change

### DIFF
--- a/app/views/providers/proceedings_types/index.html.erb
+++ b/app/views/providers/proceedings_types/index.html.erb
@@ -1,7 +1,13 @@
 <%= page_template(
       page_title: t(".heading_1"),
       show_errors_for: @legal_aid_application,
-      back_link: @legal_aid_application.proceedings.empty? && @legal_aid_application.checking_answers? ? :none : {},
+      back_link: if @legal_aid_application.proceedings.empty? &&
+                    @legal_aid_application.checking_answers? &&
+                    URI(url_for(:back)).path.eql?(URI(providers_legal_aid_application_has_other_proceedings_url).path)
+                   :none
+                 else
+                   {}
+                 end,
     ) %>
 
 <% error_message = @legal_aid_application.errors[:"proceeding-search-input"]&.to_sentence %>

--- a/features/providers/linked_applications/check_your_answers_link_and_copy.feature
+++ b/features/providers/linked_applications/check_your_answers_link_and_copy.feature
@@ -35,6 +35,7 @@ Scenario: If I change the linked from Family to No
   When I choose "No"
   And I click "Save and continue"
   Then I should be on a page showing "What does your client want legal aid for?"
+  And I should see 'Back'
 
   When I search for proceeding 'Non-molestation order'
   And proceeding suggestions has results


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5077)

Fix no back button on proceeding page after link change

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
