### PR TITLE
Fix unprocessable-entity

### DIFF
--- a/app/controllers/providers/proceedings_sca/heard_togethers_controller.rb
+++ b/app/controllers/providers/proceedings_sca/heard_togethers_controller.rb
@@ -23,7 +23,7 @@ module Providers
           return go_forward(form.heard_together?)
         end
 
-        render :show, status: :unprocessable_entity
+        render :show, status: :unprocessable_content
       end
 
     private

--- a/spec/requests/providers/proceedings_sca/heard_togethers_controller_spec.rb
+++ b/spec/requests/providers/proceedings_sca/heard_togethers_controller_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Providers::ProceedingsSCA::HeardTogethersController do
         let(:heard_together) { "" }
 
         it "renders the same page with an error message" do
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to include("Select yes if this proceeding will be heard together with any special children act core proceedings").twice
         end
       end


### PR DESCRIPTION

## What

Rack gem update renamed the unprocessable_* status from entity to content while this was being developed

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
