### PR TITLE
Fix: broken page title

### DIFF
--- a/app/views/providers/proceedings_sca/heard_togethers/show.html.erb
+++ b/app/views/providers/proceedings_sca/heard_togethers/show.html.erb
@@ -11,7 +11,7 @@
                                             :value,
                                             :label,
                                             caption: { text: @current_proceeding.meaning, size: "xl" },
-                                            legend: { text: t(".page_title.#{@amount}", core_sca: @core_proceedings.first.meaning), size: "xl", tag: "h1" } do %>
+                                            legend: { text: t(".page_heading.#{@amount}", core_sca: @core_proceedings.first.meaning), size: "xl", tag: "h1" } do %>
                                               <% if @amount.eql?("multiple") %>
                                                 <p class="govuk-body">These are:</p>
                                                 <%= govuk_list @core_proceedings.pluck(:meaning), type: :bullet %>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1669,12 +1669,11 @@ en:
     proceedings_sca:
       heard_togethers:
         error: Select yes if this proceeding will be heard together with any special children act core proceedings
-        show:         
-          page_title:
+        show:
+          page_title: Will this proceeding be heard together with any special children act core proceedings?
+          page_heading:
             single: Will this proceeding be heard together with the '%{core_sca}' proceeding?
             multiple: Will this proceeding be heard together with any of the core proceedings?
-          heading: Will this proceeding be heard together with the '%{core_sca}' proceeding?
-    
       supervision_orders:
         error: Select yes if the application is to vary, discharge or extend a supervision order
         show:

--- a/spec/requests/providers/proceedings_sca/heard_togethers_controller_spec.rb
+++ b/spec/requests/providers/proceedings_sca/heard_togethers_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Providers::ProceedingsSCA::HeardTogethersController do
 
         it "returns http success" do
           expect(response).to have_http_status(:ok)
-          expect(unescaped_response_body).to include(I18n.t("providers.proceedings_sca.heard_togethers.show.page_title.single", core_sca:))
+          expect(unescaped_response_body).to include(I18n.t("providers.proceedings_sca.heard_togethers.show.page_heading.single", core_sca:))
         end
       end
 
@@ -34,7 +34,7 @@ RSpec.describe Providers::ProceedingsSCA::HeardTogethersController do
 
         it "returns http success" do
           expect(response).to have_http_status(:ok)
-          expect(response.body).to include(I18n.t("providers.proceedings_sca.heard_togethers.show.page_title.multiple"))
+          expect(response.body).to include(I18n.t("providers.proceedings_sca.heard_togethers.show.page_heading.multiple"))
         end
       end
     end


### PR DESCRIPTION
## What

During the many rebases of SCA questions the page title and headings got a bit jumbled and started to cause i18n warnings

This clarifies the page title and heading and ensures that warnings are removed and that the tab renders with the expected text

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
