### PR TITLE
AP-5096: SCA means test interrupt

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -174,6 +174,10 @@ class LegalAidApplication < ApplicationRecord
     proceedings.any? { |proceeding| proceeding.ccms_matter_code.eql?("KSEC8") }
   end
 
+  def special_children_act_proceedings?
+    proceedings.any? { |proceeding| proceeding.ccms_matter_code.eql?("KPBLW") }
+  end
+
   def evidence_is_required?
     RequiredDocumentCategoryAnalyser.call(self)
     required_document_categories.any?
@@ -302,7 +306,7 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def non_means_tested?
-    applicant&.no_means_test_required?
+    applicant&.no_means_test_required? || special_children_act_proceedings?
   end
 
   def benefit_check_result_needs_updating?

--- a/app/views/providers/confirm_non_means_tested_applications/show.html.erb
+++ b/app/views/providers/confirm_non_means_tested_applications/show.html.erb
@@ -1,7 +1,9 @@
 <div class="interruption-panel">
   <%= page_template(page_title: t(".tab_title"), column_width: :full, template: :basic) do %>
     <h1 class="govuk-heading-m govuk-!-padding-bottom-4">
-      <% if @legal_aid_application.used_delegated_functions? %>
+      <% if @legal_aid_application.special_children_act_proceedings? %>
+        <%= t(".title.sca_proceeding") %>
+      <% elsif @legal_aid_application.used_delegated_functions? %>
         <%= t(".title.under_18_when_delegated_functions_used") %>
       <% else %>
         <%= t(".title.under_18_now") %>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -238,6 +238,7 @@ en:
           under_18_when_delegated_functions_used: |
             You do not need to do a means test as your client was under 18
             when you first used delegated functions on this case
+          sca_proceeding: You do not need to do a means test for special children act proceedings
         tab_title: No means test required
     check_client_details:
       show:

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -425,6 +425,13 @@ FactoryBot.define do
       end
     end
 
+    trait :with_multiple_sca_proceedings do
+      after(:create) do |application|
+        application.proceedings << create(:proceeding, :pb003)
+        application.proceedings << create(:proceeding, :pb059)
+      end
+    end
+
     trait :with_opponents_application_proceeding do
       after(:create) do |application|
         application.proceedings << create(:proceeding, :da001, :opponents_application)

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1443,7 +1443,7 @@ RSpec.describe LegalAidApplication do
     end
   end
 
-  describe "#special_children_act_proceedings??" do
+  describe "#special_children_act_proceedings?" do
     context "with special children act proceedings" do
       let(:laa) { create(:legal_aid_application, :with_multiple_sca_proceedings) }
 

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1443,6 +1443,25 @@ RSpec.describe LegalAidApplication do
     end
   end
 
+  describe "#special_children_act_proceedings??" do
+    context "with special children act proceedings" do
+      let(:laa) { create(:legal_aid_application, :with_multiple_sca_proceedings) }
+
+      it "returns true" do
+        expect(laa.special_children_act_proceedings?).to be true
+      end
+    end
+
+    context "without special children act proceedings" do
+      let(:laa) { create(:legal_aid_application) }
+
+      it "returns false" do
+        create(:proceeding, :da001, legal_aid_application: laa)
+        expect(laa.special_children_act_proceedings?).to be false
+      end
+    end
+  end
+
   describe "#online_current_accounts_balance" do
     let(:laa) { create(:legal_aid_application, :with_applicant) }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5096)

Add a means test interrupt page for SCA proceedings.

When the application is non-means tested, route to the interrupt page and then on to the merits task list page

Note: The merits task list page will be empty as we have not added those into LFA yet


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
