### PR TITLE
ap-5105: fix error when clicking save as draft on Search Results page

### DIFF
--- a/app/controllers/providers/link_application/confirm_links_controller.rb
+++ b/app/controllers/providers/link_application/confirm_links_controller.rb
@@ -45,6 +45,8 @@ module Providers
 
       def form_params
         merge_with_model(linked_application) do
+          next {} unless params[:linked_application]
+
           params.require(:linked_application).permit(:confirm_link)
         end
       end

--- a/spec/requests/providers/link_application/confirm_links_controller_spec.rb
+++ b/spec/requests/providers/link_application/confirm_links_controller_spec.rb
@@ -112,22 +112,41 @@ RSpec.describe Providers::LinkApplication::ConfirmLinksController do
         end
 
         context "when form submitted with Save as draft button" do
-          let(:params) do
-            {
-              draft_button: "Save and come back later",
-              linked_application: {
-                confirm_link:,
-              },
-            }
+          context "when Yes is chosen" do
+            let(:params) do
+              {
+                draft_button: "Save and come back later",
+                linked_application: {
+                  confirm_link:,
+                },
+              }
+            end
+
+            it "redirects to the list of applications" do
+              patch_request
+              expect(response.body).to redirect_to providers_legal_aid_applications_path
+            end
+
+            it "sets the application as draft" do
+              expect { patch_request }.to change { legal_aid_application.reload.draft? }.from(false).to(true)
+            end
           end
 
-          it "redirects to the list of applications" do
-            patch_request
-            expect(response.body).to redirect_to providers_legal_aid_applications_path
-          end
+          context "when the application has not yet been linked" do
+            let(:params) do
+              {
+                draft_button: "Save and come back later",
+              }
+            end
 
-          it "sets the application as draft" do
-            expect { patch_request }.to change { legal_aid_application.reload.draft? }.from(false).to(true)
+            it "redirects to the list of applications" do
+              patch_request
+              expect(response.body).to redirect_to providers_legal_aid_applications_path
+            end
+
+            it "sets the application as draft" do
+              expect { patch_request }.to change { legal_aid_application.reload.draft? }.from(false).to(true)
+            end
           end
         end
       end


### PR DESCRIPTION
with no linked application



## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5105)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
