### PR TITLE
AP-4622: Remove NINO hint text when there is SCA proceeding

### DIFF
--- a/app/views/providers/has_national_insurance_numbers/show.html.erb
+++ b/app/views/providers/has_national_insurance_numbers/show.html.erb
@@ -8,11 +8,8 @@
   <%= page_template page_title: t(".page_title"), template: :basic, form: do %>
 
     <%= form.govuk_radio_buttons_fieldset(:has_national_insurance_number,
-                                          legend: { text: page_title, size: "xl", tag: "h1" }) do %>
-
-      <p class="govuk-body govuk-!-margin-top-3 govuk-!-margin-bottom-6">
-        <%= t(".hint") %>
-      </p>
+                                          legend: { text: page_title, size: "xl", tag: "h1" },
+                                          hint: { text: Setting.special_childrens_act? ? nil : t(".hint") }) do %>
 
       <%= form.govuk_radio_button(
             :has_national_insurance_number,


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4622)

Remove NINO hint text when there is SCA proceeding
Move hint text into govuk fieldset component

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
