### PR TITLE
ap-4621: add check for special_children_act_proceedings? to substanti…

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -402,7 +402,7 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def substantive_cost_overridable?
-    substantive_cost_limitation.present? && default_substantive_cost_limitation < MAX_SUBSTANTIVE_COST_LIMIT
+    substantive_cost_limitation.present? && default_substantive_cost_limitation < MAX_SUBSTANTIVE_COST_LIMIT && !special_children_act_proceedings?
   end
 
   def substantive_cost_limitation

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -401,6 +401,10 @@ class LegalAidApplication < ApplicationRecord
     default_substantive_cost_limitation
   end
 
+  def display_emergency_certificate?
+    used_delegated_functions? && !special_children_act_proceedings?
+  end
+
   def substantive_cost_overridable?
     substantive_cost_limitation.present? && default_substantive_cost_limitation < MAX_SUBSTANTIVE_COST_LIMIT && !special_children_act_proceedings?
   end

--- a/app/views/providers/limitations/show.html.erb
+++ b/app/views/providers/limitations/show.html.erb
@@ -12,7 +12,7 @@
                collection: @legal_aid_application.proceedings.in_order_of_addition, as: :proceeding,
                locals: { translation_path: "providers.limitations.show" } %>
 
-    <% if @legal_aid_application.used_delegated_functions? %>
+    <% if @legal_aid_application.display_emergency_certificate? %>
       <h2 class="govuk-heading-l"><%= t(".cost_heading") %></h2>
       <h3 class="govuk-heading-m"><%= t(".emergency_certificate") %></h3>
 

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1908,6 +1908,30 @@ RSpec.describe LegalAidApplication do
     end
   end
 
+  describe "#substantive_cost_overridable?" do
+    subject { legal_aid_application.substantive_cost_overridable? }
+
+    let(:legal_aid_application) { create(:legal_aid_application) }
+
+    context "when the substantive_cost_limitation for the proceeding(s) is 25000 or more" do
+      before { create(:proceeding, :da001, legal_aid_application:, substantive_cost_limitation: 25_000) }
+
+      it { is_expected.to be false }
+    end
+
+    context "when the substantive_cost_limitation for the proceeding(s) is less than 25000" do
+      before { create(:proceeding, :da001, legal_aid_application:, substantive_cost_limitation: 24_999) }
+
+      it { is_expected.to be true }
+    end
+
+    context "when there are special childrens act proceedings" do
+      before { create(:proceeding, :pb003, legal_aid_application:, substantive_cost_limitation: 24_999) }
+
+      it { is_expected.to be false }
+    end
+  end
+
 private
 
   def uploaded_evidence_output

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1932,6 +1932,28 @@ RSpec.describe LegalAidApplication do
     end
   end
 
+  describe "#display_emergency_certificate?" do
+    subject { legal_aid_application.display_emergency_certificate? }
+
+    let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings, :with_delegated_functions_on_proceedings, explicit_proceedings: %i[da001], df_options: { DA001: [Time.zone.today, Time.zone.today] }) }
+
+    context "when the provider has used delegated functions" do
+      it { is_expected.to be true }
+    end
+
+    context "when the provider has not used delegated functions" do
+      let(:legal_aid_application) { create(:legal_aid_application) }
+
+      it { is_expected.to be false }
+    end
+
+    context "when there are special childrens act proceedings" do
+      before { legal_aid_application.proceedings << create(:proceeding, :pb003) }
+
+      it { is_expected.to be false }
+    end
+  end
+
 private
 
   def uploaded_evidence_output


### PR DESCRIPTION
…ve_cost_overridable?



## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4621)

Added a check that there are not special children act proceedings to substantive_cost_overridable? method.
Added a check to not display emergency certificate if there are special children act proceedings (see ticket for discussion).

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
