### PR TITLE
AP-5083: Update CCMS home address payloads

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -143,10 +143,10 @@ class Applicant < ApplicationRecord
   def home_address_for_ccms
     return if no_fixed_residence?
 
-    if Setting.home_address?
-      same_correspondence_and_home_address ? address : home_address
-    else
-      address
-    end
+    home_address.presence || address
+  end
+
+  def correspondence_address_for_ccms
+    same_correspondence_and_home_address? ? home_address : address
   end
 end

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -197,7 +197,7 @@ module CCMS
     end
 
     def applicant_postcode(_options)
-      applicant.address.postcode
+      applicant.correspondence_address_for_ccms.postcode
     end
 
     def lead_proceeding_substantive_cost_limitation(_options)

--- a/app/services/ccms/requestors/case_add_requestor.rb
+++ b/app/services/ccms/requestors/case_add_requestor.rb
@@ -171,6 +171,7 @@ module CCMS
         xml.__send__(:"common:CoffName", applicant.correspondence_address_for_ccms.care_of_recipient) unless applicant.correspondence_address_for_ccms.care_of_recipient.nil?
         xml.__send__(:"common:AddressLine1", applicant.correspondence_address_for_ccms.address_line_one)
         xml.__send__(:"common:AddressLine2", applicant.correspondence_address_for_ccms.address_line_two)
+        xml.__send__(:"common:AddressLine3", applicant.correspondence_address_for_ccms.address_line_three) unless applicant.correspondence_address_for_ccms.address_line_three.nil?
         xml.__send__(:"common:City", applicant.correspondence_address_for_ccms.city)
         xml.__send__(:"common:County", applicant.correspondence_address_for_ccms.county)
         xml.__send__(:"common:Country", "GBR")

--- a/app/services/ccms/requestors/case_add_requestor.rb
+++ b/app/services/ccms/requestors/case_add_requestor.rb
@@ -168,12 +168,12 @@ module CCMS
       end
 
       def generate_correspondence_address(xml)
-        xml.__send__(:"common:AddressLine1", applicant.address.address_line_one)
-        xml.__send__(:"common:AddressLine2", applicant.address.address_line_two)
-        xml.__send__(:"common:City", applicant.address.city)
-        xml.__send__(:"common:County", applicant.address.county)
+        xml.__send__(:"common:AddressLine1", applicant.correspondence_address_for_ccms.address_line_one)
+        xml.__send__(:"common:AddressLine2", applicant.correspondence_address_for_ccms.address_line_two)
+        xml.__send__(:"common:City", applicant.correspondence_address_for_ccms.city)
+        xml.__send__(:"common:County", applicant.correspondence_address_for_ccms.county)
         xml.__send__(:"common:Country", "GBR")
-        xml.__send__(:"common:PostalCode", applicant.address.pretty_postcode)
+        xml.__send__(:"common:PostalCode", applicant.correspondence_address_for_ccms.pretty_postcode) if applicant.correspondence_address_for_ccms.postcode.present?
       end
 
       def generate_category_of_law(xml)

--- a/app/services/ccms/requestors/case_add_requestor.rb
+++ b/app/services/ccms/requestors/case_add_requestor.rb
@@ -168,6 +168,7 @@ module CCMS
       end
 
       def generate_correspondence_address(xml)
+        xml.__send__(:"common:CoffName", applicant.correspondence_address_for_ccms.care_of_recipient) unless applicant.correspondence_address_for_ccms.care_of_recipient.nil?
         xml.__send__(:"common:AddressLine1", applicant.correspondence_address_for_ccms.address_line_one)
         xml.__send__(:"common:AddressLine2", applicant.correspondence_address_for_ccms.address_line_two)
         xml.__send__(:"common:City", applicant.correspondence_address_for_ccms.city)

--- a/spec/factories/applicants.rb
+++ b/spec/factories/applicants.rb
@@ -11,7 +11,9 @@ FactoryBot.define do
     student_finance_amount { nil }
     changed_last_name { false }
 
-    trait :with_address do
+    trait :with_only_correspondence_address do
+      # TODO: delete this trait when Setting.home_address? is removed
+      # Colin, 21 Jun 2024
       addresses { build_list(:address, 1) }
     end
 

--- a/spec/factories/applicants.rb
+++ b/spec/factories/applicants.rb
@@ -15,8 +15,14 @@ FactoryBot.define do
       addresses { build_list(:address, 1) }
     end
 
+    trait :with_address do
+      same_correspondence_and_home_address { true }
+      addresses { build_list(:address, 1, :as_home_address) }
+    end
+
     trait :with_address_for_xml_fixture do
-      addresses { build_list(:address, 1, :with_address_for_xml_fixture) }
+      same_correspondence_and_home_address { true }
+      addresses { build_list(:address, 1, :as_home_address, :with_address_for_xml_fixture) }
     end
 
     trait :with_address_lookup do

--- a/spec/requests/providers/check_provider_answers_controller_spec.rb
+++ b/spec/requests/providers/check_provider_answers_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Providers::CheckProviderAnswersController do
     )
   end
 
-  let(:applicant) { create(:applicant, :with_address) }
+  let(:applicant) { create(:applicant, :with_only_correspondence_address) } # TODO: revert to :with_address when Setting.home_address? is deleted
   let(:application_id) { application.id }
   let(:parsed_html) { Nokogiri::HTML(response.body) }
   let(:proceeding_name) { application.lead_proceeding.name }

--- a/spec/requests/providers/correspondence_address/care_ofs_controller_spec.rb
+++ b/spec/requests/providers/correspondence_address/care_ofs_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Providers::CorrespondenceAddress::CareOfsController do
   let(:legal_aid_application) { create(:legal_aid_application, applicant:) }
-  let(:applicant) { create(:applicant, :with_address) }
+  let(:applicant) { create(:applicant, :with_only_correspondence_address) } # TODO: revert to :with_address when Setting.home_address? is deleted
   let(:provider) { legal_aid_application.provider }
   let(:care_of) { "" }
   let(:care_of_first_name) { "" }

--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -328,7 +328,7 @@ module CCMS
             it "is set to the expected, separate, home address" do
               expect(request_xml)
                 .to have_xml("#{address_xpath}/common:AddressLine1", "109 Correspondence Avenue")
-                      .and have_xml("#{address_xpath}/common:AddressLine2", correspondence_address.address_line_two)
+                .and have_xml("#{address_xpath}/common:AddressLine2", correspondence_address.address_line_two)
             end
           end
 
@@ -341,6 +341,49 @@ module CCMS
               expect(request_xml)
                 .to have_xml("#{address_xpath}/common:AddressLine1", "109 Correspondence Avenue")
                 .and have_xml("#{address_xpath}/common:AddressLine2", correspondence_address.address_line_two)
+            end
+          end
+        end
+
+        describe "care of address handling" do
+          let(:applicant) { create(:applicant, address:) }
+          let(:address) do
+            create(:address,
+                   care_of:,
+                   care_of_first_name:,
+                   care_of_last_name:,
+                   care_of_organisation_name:)
+          end
+          let(:care_of) { nil }
+          let(:care_of_first_name) { nil }
+          let(:care_of_last_name) { nil }
+          let(:care_of_organisation_name) { nil }
+          let(:address_xpath) { "//casebio:CaseDetails/casebio:ApplicationDetails/casebio:CorrespondenceAddress" }
+
+          context "when care of is not set" do
+            it "does not add the xml key" do
+              expect(request_xml).not_to match "common:CoFFName"
+            end
+          end
+
+          context "when care of is set to an individual" do
+            let(:care_of) { "person" }
+            let(:care_of_first_name) { "James" }
+            let(:care_of_last_name) { "Bond" }
+
+            it "records the care of name" do
+              expect(request_xml)
+                .to have_xml("#{address_xpath}/common:CoffName", "James Bond")
+            end
+          end
+
+          context "when care of is set to an organisation" do
+            let(:care_of) { "organisation" }
+            let(:care_of_organisation_name) { "International Exports" }
+
+            it "records the care of organisation name" do
+              expect(request_xml)
+                .to have_xml("#{address_xpath}/common:CoffName", "International Exports")
             end
           end
         end

--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -309,35 +309,38 @@ module CCMS
           let(:home_address) { create(:address, :as_home_address, address_line_one: "27 Home Street") }
           let(:address_xpath) { "//casebio:CaseDetails/casebio:ApplicationDetails/casebio:CorrespondenceAddress" }
 
-          context "when the home address flag is false" do
-            before { allow(Setting).to receive(:home_address?).and_return false }
+          context "when the provider has set the home address to the same as correspondence" do
+            let(:same_correspondence_and_home_address) { true }
+            let(:correspondence_address) { nil }
+            let(:addresses) { [home_address] }
 
+            it "is set to the correspondence address" do
+              expect(request_xml)
+                .to have_xml("#{address_xpath}/common:AddressLine1", "27 Home Street")
+                .and have_xml("#{address_xpath}/common:AddressLine2", home_address.address_line_two)
+            end
           end
 
-          context "when the home address flag is true" do
-            before { allow(Setting).to receive(:home_address?).and_return true }
+          context "when the provider has set a different home address" do
+            let(:same_correspondence_and_home_address) { false }
+            let(:addresses) { [home_address, correspondence_address] }
 
-            context "when the provider has set a different home address" do
-              let(:same_correspondence_and_home_address) { false }
-              let(:addresses) { [home_address, correspondence_address] }
-
-              it "is set to the expected, separate, home address" do
-                expect(request_xml)
-                  .to have_xml("#{address_xpath}/common:AddressLine1", "109 Correspondence Avenue")
-                  .and have_xml("#{address_xpath}/common:AddressLine2", correspondence_address.address_line_two)
-              end
+            it "is set to the expected, separate, home address" do
+              expect(request_xml)
+                .to have_xml("#{address_xpath}/common:AddressLine1", "109 Correspondence Avenue")
+                      .and have_xml("#{address_xpath}/common:AddressLine2", correspondence_address.address_line_two)
             end
+          end
 
-            context "when the provider has set the home address to the same as correspondence" do
-              let(:same_correspondence_and_home_address) { true }
-              let(:correspondence_address) { nil }
-              let(:addresses) { [home_address] }
+          context "when the record was created before the home_address flag was enabled" do
+            let(:same_correspondence_and_home_address) { nil }
+            let(:home_address) { nil }
+            let(:addresses) { [correspondence_address] }
 
-              it "is set to the correspondence address" do
-                expect(request_xml)
-                  .to have_xml("#{address_xpath}/common:AddressLine1", "27 Home Street")
-                  .and have_xml("#{address_xpath}/common:AddressLine2", home_address.address_line_two)
-              end
+            it "is set to the correspondence address" do
+              expect(request_xml)
+                .to have_xml("#{address_xpath}/common:AddressLine1", "109 Correspondence Avenue")
+                .and have_xml("#{address_xpath}/common:AddressLine2", correspondence_address.address_line_two)
             end
           end
         end

--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -387,6 +387,22 @@ module CCMS
             end
           end
         end
+
+        context "when optional address line three field is populated" do
+          let(:address) do
+            create(:address,
+                   address_line_one: "Corporation name",
+                   address_line_two: "109 Correspondence Avenue",
+                   address_line_three: "Placeholder City")
+          end
+          let(:address_xpath) { "//casebio:CaseDetails/casebio:ApplicationDetails/casebio:CorrespondenceAddress" }
+
+          it "is included in the payload" do
+            expect(request_xml).to have_xml("#{address_xpath}/common:AddressLine1", "Corporation name")
+                                     .and have_xml("#{address_xpath}/common:AddressLine2", "109 Correspondence Avenue")
+                                     .and have_xml("#{address_xpath}/common:AddressLine3", "Placeholder City")
+          end
+        end
       end
     end
   end

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_means_tested_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_means_tested_attributes_spec.rb
@@ -395,7 +395,7 @@ module CCMS
           it "adds applicant's POST_CODE attribute with value into means and merits assessment sections" do
             %i[global_means global_merits].each do |entity|
               block = XmlExtractor.call(xml, entity, "POST_CODE")
-              expect(block).to have_text_response legal_aid_application.applicant.address.postcode
+              expect(block).to have_text_response legal_aid_application.applicant.correspondence_address_for_ccms.postcode
             end
           end
 

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/passported_attributes_spec.rb
@@ -656,7 +656,7 @@ module CCMS
             it "inserts applicant's postcode as a string" do
               %i[global_means global_merits].each do |entity|
                 block = XmlExtractor.call(xml, entity, "POST_CODE")
-                expect(block).to have_text_response legal_aid_application.applicant.address.postcode
+                expect(block).to have_text_response legal_aid_application.applicant.correspondence_address_for_ccms.postcode
               end
             end
           end

--- a/spec/services/ccms/submitters/add_applicant_service_spec.rb
+++ b/spec/services/ccms/submitters/add_applicant_service_spec.rb
@@ -7,7 +7,7 @@ module CCMS
 
       let(:legal_aid_application) { create(:legal_aid_application, :with_applicant_and_address) }
       let(:applicant) { legal_aid_application.applicant }
-      let(:address) { applicant.address }
+      let(:address) { applicant.home_address_for_ccms }
       let(:submission) { create(:submission, :case_ref_obtained, legal_aid_application:) }
       let(:history) { SubmissionHistory.find_by(submission_id: submission.id) }
       let(:endpoint) { "https://ccmssoagateway.dev.legalservices.gov.uk/ccmssoa/soa-infra/services/default/ClientServices/ClientServices_ep" }

--- a/spec/services/flow/steps/provider_capital/applicant_bank_accounts_step_spec.rb
+++ b/spec/services/flow/steps/provider_capital/applicant_bank_accounts_step_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Flow::Steps::ProviderCapital::ApplicantBankAccountsStep, type: :request do
-  let(:application) { create(:legal_aid_application) }
+  let(:application) { create(:legal_aid_application, :with_applicant) }
 
   describe "#path" do
     subject { described_class.path.call(application) }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5083)

This PR updates the applicant model to update and add home_ and correspondence_address_for_ccms methods

These implement logic that should work for applications created before, during, or after the home_address flag is enabled. 
![CCMS address flows](https://github.com/ministryofjustice/laa-apply-for-legal-aid/assets/6757677/1184703f-4f01-4708-8592-b151695d66b9)

It updates CCMS tests to use, and expect, the new methods rather than just `applicant.address` or `applicant.home_address`
It also adds a temporary trait and uses it to make some tests pass

### Still to do:

- [x] Ensure the logic is updated for new home/correspondence mandatory changes
- [x] Ensure existing tests all pass
- [x] Add the care of line to addresses
- [x] Add the, optional, third address line to the payload

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
