### PR TITLE
ap-5094-attept-to-fix-vehicle-details-error

### DIFF
--- a/app/forms/vehicles/details_form.rb
+++ b/app/forms/vehicles/details_form.rb
@@ -45,6 +45,13 @@ module Vehicles
     end
     alias_method :save!, :save
 
+    def save_as_draft
+      @draft = true
+      save!
+      legal_aid_application.provider_step_params["id"] = model.id
+      legal_aid_application.save!
+    end
+
     def self.radio_options
       translation_root = "providers.means.vehicle_details.show.owner.options"
       SINGLE_VALUE_ATTRIBUTES.map { |option| RadioOption.new(option, I18n.t("#{translation_root}.#{option}")) }
@@ -62,6 +69,10 @@ module Vehicles
 
     def has_partner?
       model.legal_aid_application.applicant.has_partner_with_no_contrary_interest?
+    end
+
+    def legal_aid_application
+      @legal_aid_application ||= model.legal_aid_application
     end
   end
 end

--- a/app/services/flow/steps/provider_capital/vehicle_details_step.rb
+++ b/app/services/flow/steps/provider_capital/vehicle_details_step.rb
@@ -2,7 +2,14 @@ module Flow
   module Steps
     module ProviderCapital
       VehicleDetailsStep = Step.new(
-        path: ->(application) { Steps.urls.new_providers_legal_aid_application_means_vehicle_detail_path(application) },
+        path: lambda do |application|
+          if application.provider_step_params["id"]
+            vehicle = application.vehicles.find(application.provider_step_params["id"])
+            Steps.urls.providers_legal_aid_application_means_vehicle_detail_path(application, vehicle)
+          else
+            Steps.urls.new_providers_legal_aid_application_means_vehicle_detail_path(application)
+          end
+        end,
         forward: :add_other_vehicles,
         check_answers: ->(application) { application.checking_non_passported_means? ? :check_capital_answers : :check_passported_answers },
       )

--- a/spec/forms/vehicles/details_form_spec.rb
+++ b/spec/forms/vehicles/details_form_spec.rb
@@ -92,4 +92,59 @@ RSpec.describe Vehicles::DetailsForm, :vcr, type: :form do
       end
     end
   end
+
+  describe "#save_as_draft" do
+    subject(:save_form_as_draft) { vehicle_details_form.save_as_draft }
+
+    let(:estimated_value) { "£5000.00" }
+    let(:more_than_three_years_old) { "false" }
+    let(:owner) { "client" }
+    let(:payments_remain) { "true" }
+    let(:payment_remaining) { 1000 }
+    let(:used_regularly) { "true" }
+
+    context "when the parameters are all valid" do
+      before do
+        model.legal_aid_application.provider_step_params = {}
+        save_form_as_draft
+      end
+
+      it "updates the vehicle" do
+        expect(model.reload).to have_attributes(
+          estimated_value: 5000,
+          more_than_three_years_old: false,
+          owner: "client",
+          payment_remaining: 1000,
+          used_regularly: true,
+        )
+      end
+
+      it "updates the legal_aid_application provider_step_params with the id of the vehicle" do
+        expect(model.legal_aid_application.provider_step_params["id"]).to eq model.id
+      end
+    end
+
+    context "when the payments_remain is false and payment_remaining is set" do
+      let(:payments_remain) { "false" }
+
+      before do
+        model.legal_aid_application.provider_step_params = {}
+        save_form_as_draft
+      end
+
+      it "updates the vehicle and blanks the remaining payments" do
+        expect(model.reload).to have_attributes(
+          estimated_value: 5000,
+          more_than_three_years_old: false,
+          owner: "client",
+          payment_remaining: 0,
+          used_regularly: true,
+        )
+      end
+
+      it "updates the legal_aid_application provider_step_params with the id of the vehicle" do
+        expect(model.legal_aid_application.provider_step_params["id"]).to eq model.id
+      end
+    end
+  end
 end

--- a/spec/services/flow/steps/provider_capital/vehicle_details_step_spec.rb
+++ b/spec/services/flow/steps/provider_capital/vehicle_details_step_spec.rb
@@ -1,12 +1,22 @@
 require "rails_helper"
 
 RSpec.describe Flow::Steps::ProviderCapital::VehicleDetailsStep, type: :request do
-  let(:legal_aid_application) { build_stubbed(:legal_aid_application) }
+  let(:legal_aid_application) { create(:legal_aid_application, provider_step_params:) }
+  let(:provider_step_params) { {} }
 
   describe "#path" do
     subject { described_class.path.call(legal_aid_application) }
 
     it { is_expected.to eq new_providers_legal_aid_application_means_vehicle_detail_path(legal_aid_application) }
+
+    context "when the user has previously clicked save as draft on the vehicle details page" do
+      before { legal_aid_application.vehicles << vehicle }
+
+      let(:vehicle) { create(:vehicle) }
+      let(:provider_step_params) { { id: vehicle.id } }
+
+      it { is_expected.to eq providers_legal_aid_application_means_vehicle_detail_path(legal_aid_application, vehicle) }
+    end
   end
 
   describe "#forward" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5094)

See ticket for steps to recreate
This pr attempts to prevent the application from creating a second vehicle (wrongly) when the user has clicked save_as_draft on the vehicle details page and returns to the application.

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
