### PR TITLE
Fix: Flickery step test

### DIFF
--- a/spec/services/flow/steps/provider_capital/applicant_bank_accounts_step_spec.rb
+++ b/spec/services/flow/steps/provider_capital/applicant_bank_accounts_step_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Flow::Steps::ProviderCapital::ApplicantBankAccountsStep, type: :request do
-  let(:application) { create(:legal_aid_application) }
+  let(:application) { create(:legal_aid_application, :with_applicant) }
 
   describe "#path" do
     subject { described_class.path.call(application) }


### PR DESCRIPTION
## What

This test failed on a [circle ci](https://app.circleci.com/pipelines/github/ministryofjustice/laa-apply-for-legal-aid/28900/workflows/43c274e1-a637-45e0-9b98-50b96846fd80/jobs/151445) run and was reproducible locally.  

This issue seems to sometimes fail and sometimes only warn which is a bit weird, but this update definitely fixes a reproducible flicker


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
