### PR TITLE
AP-5107: Update case link handling

### DIFF
--- a/app/controllers/providers/link_application/copies_controller.rb
+++ b/app/controllers/providers/link_application/copies_controller.rb
@@ -46,8 +46,8 @@ module Providers
       end
 
       def lead_application_reference
-        @lead_application ||= @legal_aid_application.lead_application
-        @lead_application_reference ||= @lead_application.application_ref
+        @target_application ||= @legal_aid_application.target_application
+        @lead_application_reference ||= @target_application.application_ref
       end
 
       def copy_case?

--- a/app/forms/providers/link_application/copy_form.rb
+++ b/app/forms/providers/link_application/copy_form.rb
@@ -8,7 +8,7 @@ module Providers
       validates :copy_case, presence: true, unless: :draft?
 
       def save
-        model.update!(copy_case_id: ActiveRecord::Type::Boolean.new.cast(copy_case) ? model.lead_application.id : nil)
+        model.update!(copy_case_id: ActiveRecord::Type::Boolean.new.cast(copy_case) ? model.target_application.id : nil)
         model.proceedings.destroy_all if copy_case
         super
       end

--- a/app/forms/providers/link_application/find_link_application_form.rb
+++ b/app/forms/providers/link_application/find_link_application_form.rb
@@ -34,7 +34,8 @@ module Providers
       end
 
       def save
-        attributes[:lead_application_id] = @found_application&.id
+        attributes[:target_application_id] = @found_application&.id
+        attributes[:lead_application_id] = @found_application&.lead_application&.id.presence || @found_application&.id
         super
       end
       alias_method :save!, :save

--- a/app/helpers/linked_applications_helper.rb
+++ b/app/helpers/linked_applications_helper.rb
@@ -9,6 +9,6 @@ private
 
   def all_linked_applications(legal_aid_application)
     all_linked_applications = LinkedApplication.where(associated_application_id: legal_aid_application.lead_application.id, link_type_code: legal_aid_application.lead_linked_application&.link_type_code).or(LinkedApplication.where(lead_application_id: legal_aid_application.lead_application.id, link_type_code: legal_aid_application.lead_linked_application&.link_type_code))
-    all_linked_applications.map(&:associated_application).concat(all_linked_applications.map(&:lead_application)).excluding(legal_aid_application, legal_aid_application.lead_application).reject(&:discarded?)
+    all_linked_applications.map(&:associated_application).concat(all_linked_applications.map(&:lead_application)).excluding(legal_aid_application, legal_aid_application.target_application).reject(&:discarded?).uniq
   end
 end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -60,6 +60,7 @@ class LegalAidApplication < ApplicationRecord
   has_one :partner, dependent: :destroy
   has_one :lead_linked_application, class_name: "LinkedApplication", foreign_key: "associated_application_id", dependent: :destroy
   has_one :lead_application, class_name: "LegalAidApplication", through: :lead_linked_application
+  has_one :target_application, class_name: "LegalAidApplication", through: :lead_linked_application
   has_many :associated_linked_applications, class_name: "LinkedApplication", foreign_key: "lead_application_id", dependent: :destroy
   has_many :associated_applications, class_name: "LegalAidApplication", through: :associated_linked_applications
 

--- a/app/models/linked_application.rb
+++ b/app/models/linked_application.rb
@@ -1,6 +1,7 @@
 class LinkedApplication < ApplicationRecord
   belongs_to :lead_application, class_name: "LegalAidApplication", optional: true
   belongs_to :associated_application, class_name: "LegalAidApplication"
+  belongs_to :target_application, class_name: "LegalAidApplication", optional: true
 
   validate :cannot_link_self
 

--- a/app/views/providers/link_application/confirm_links/show.html.erb
+++ b/app/views/providers/link_application/confirm_links/show.html.erb
@@ -20,15 +20,15 @@
         ) do |summary_list| %>
       <%= summary_list.with_row do |row| %>
         <%= row.with_key(text: t(".laa_reference"), classes: "govuk-!-width-one-half") %>
-        <%= row.with_value(text: @legal_aid_application.lead_application&.application_ref) %>
+        <%= row.with_value(text: @legal_aid_application.target_application&.application_ref) %>
       <% end %>
       <%= summary_list.with_row do |row| %>
         <%= row.with_key(text: t(".client"), classes: "govuk-!-width-one-half") %>
-        <%= row.with_value(text: @legal_aid_application.lead_application&.applicant&.full_name) %>
+        <%= row.with_value(text: @legal_aid_application.target_application&.applicant&.full_name) %>
       <% end %>
       <%= summary_list.with_row do |row| %>
         <%= row.with_key(text: t(".proceedings"), classes: "govuk-!-width-one-half") %>
-        <%= row.with_value(text: @legal_aid_application.lead_application&.proceedings&.map(&:meaning)&.join(", ")) %>
+        <%= row.with_value(text: @legal_aid_application.target_application&.proceedings&.map(&:meaning)&.join(", ")) %>
       <% end %>
     <% end %>
 

--- a/app/views/providers/link_application/copies/show.html.erb
+++ b/app/views/providers/link_application/copies/show.html.erb
@@ -14,15 +14,15 @@
     <%= govuk_summary_list(actions: false, classes: "govuk-summary-list--no-border") do |summary_list|
           summary_list.with_row do |row|
             row.with_key { t(".reference") }
-            row.with_value { @lead_application.application_ref }
+            row.with_value { @target_application.application_ref }
           end
           summary_list.with_row do |row|
             row.with_key { t(".client") }
-            row.with_value { @lead_application.applicant_full_name }
+            row.with_value { @target_application.applicant_full_name }
           end
           summary_list.with_row do |row|
             row.with_key { t(".proceedings") }
-            row.with_value { @lead_application.proceedings.map(&:meaning).join(",") }
+            row.with_value { @target_application.proceedings.map(&:meaning).join(",") }
           end
         end %>
 

--- a/app/views/shared/check_answers/_linking_and_copying.html.erb
+++ b/app/views/shared/check_answers/_linking_and_copying.html.erb
@@ -22,7 +22,7 @@
         if @legal_aid_application&.lead_linked_application&.confirm_link?
           summary_list.with_row(classes: "app-check-your-answers__linking_case") do |row|
             row.with_key(text: t(".section_linking.#{@legal_aid_application.lead_linked_application.link_type_code}"))
-            row.with_value(text: sanitize(@legal_aid_application.lead_linked_application.lead_application.link_description))
+            row.with_value(text: sanitize(@legal_aid_application.lead_linked_application.target_application.link_description))
             unless read_only
               row.with_action(
                 text: t("generic.change"),

--- a/db/migrate/20240627104142_add_target_application_to_linked_applications.rb
+++ b/db/migrate/20240627104142_add_target_application_to_linked_applications.rb
@@ -1,0 +1,7 @@
+class AddTargetApplicationToLinkedApplications < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :linked_applications, :target_application, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_25_094124) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_27_104142) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -664,9 +664,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_25_094124) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "confirm_link"
+    t.uuid "target_application_id"
     t.index ["associated_application_id"], name: "index_linked_applications_on_associated_application_id"
     t.index ["lead_application_id", "associated_application_id"], name: "index_linked_applications", unique: true
     t.index ["lead_application_id"], name: "index_linked_applications_on_lead_application_id"
+    t.index ["target_application_id"], name: "index_linked_applications_on_target_application_id"
   end
 
   create_table "malware_scan_results", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/features/step_definitions/linked_cases_steps.rb
+++ b/features/step_definitions/linked_cases_steps.rb
@@ -56,8 +56,8 @@ Given(/I have linked (and|not) copied the ['|"](.*?)['|"] application with a ['|
   else
     create(:proceeding, :da004, legal_aid_application: @legal_aid_application)
   end
-  # @legal_aid_application.update!(link_case: true)
   LinkedApplication.find_or_create_by!(lead_application:,
+                                       target_application: lead_application,
                                        confirm_link: true,
                                        associated_application: @legal_aid_application,
                                        link_type_code: type == "Family" ? "FC_LEAD" : "Legal")

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -626,6 +626,7 @@ FactoryBot.define do
         create(:linked_application,
                confirm_link: true,
                lead_application:,
+               target_application: lead_application,
                associated_application: application,
                link_type_code: "FC_LEAD")
         create(:linked_application,

--- a/spec/forms/providers/link_application/copy_form_spec.rb
+++ b/spec/forms/providers/link_application/copy_form_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe Providers::LinkApplication::CopyForm, type: :form do
   subject(:described_form) { described_class.new(params.merge(model: application)) }
 
   let(:lead_application) { create(:legal_aid_application) }
-  let(:link) { create(:linked_application, lead_application:, associated_application: application) }
-  let(:application) { create(:legal_aid_application, :with_applicant_and_address, lead_application:) }
+  let(:application) { create(:legal_aid_application, :with_applicant_and_address) }
+
+  before { create(:linked_application, lead_application:, target_application: lead_application, associated_application: application) }
 
   describe "#save" do
     context "when copy_case is not completed" do
@@ -54,7 +55,6 @@ RSpec.describe Providers::LinkApplication::CopyForm, type: :form do
         let(:application) do
           create(:legal_aid_application,
                  :with_applicant_and_address,
-                 lead_application:,
                  copy_case: true,
                  copy_case_id: SecureRandom.uuid)
         end

--- a/spec/helpers/linked_applications_helper_spec.rb
+++ b/spec/helpers/linked_applications_helper_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe LinkedApplicationsHelper do
 
     context "with a lead application linked to other applications" do
       before do
-        LinkedApplication.create!(lead_application_id: lead_application.id, associated_application_id: legal_aid_application.id, link_type_code: "FC_LEAD")
-        LinkedApplication.create!(lead_application_id: lead_application.id, associated_application_id: linked_application_one.id, link_type_code: "FC_LEAD")
-        LinkedApplication.create!(lead_application_id: lead_application.id, associated_application_id: linked_application_two.id, link_type_code: "LEGAL")
-        LinkedApplication.create!(lead_application_id: linked_application_three.id, associated_application_id: lead_application.id, link_type_code: "FC_LEAD")
-        LinkedApplication.create!(lead_application_id: lead_application.id, associated_application_id: linked_application_four.id, link_type_code: "FC_LEAD")
+        LinkedApplication.create!(lead_application_id: lead_application.id, target_application_id: lead_application.id, associated_application_id: legal_aid_application.id, link_type_code: "FC_LEAD")
+        LinkedApplication.create!(lead_application_id: lead_application.id, target_application_id: lead_application.id, associated_application_id: linked_application_one.id, link_type_code: "FC_LEAD")
+        LinkedApplication.create!(lead_application_id: lead_application.id, target_application_id: lead_application.id, associated_application_id: linked_application_two.id, link_type_code: "LEGAL")
+        LinkedApplication.create!(lead_application_id: lead_application.id, target_application_id: linked_application_one.id, associated_application_id: linked_application_three.id, link_type_code: "FC_LEAD")
+        LinkedApplication.create!(lead_application_id: lead_application.id, target_application_id: lead_application.id, associated_application_id: linked_application_four.id, link_type_code: "FC_LEAD")
       end
 
       it "returns details of all other applications linked to the lead application with the same link type that have not been discarded" do
@@ -31,7 +31,7 @@ RSpec.describe LinkedApplicationsHelper do
 
     context "with a lead application that is not linked to any other applications" do
       before do
-        LinkedApplication.create!(lead_application_id: lead_application.id, associated_application_id: legal_aid_application.id, link_type_code: "FC_LEAD")
+        LinkedApplication.create!(lead_application_id: lead_application.id, target_application_id: lead_application.id, associated_application_id: legal_aid_application.id, link_type_code: "FC_LEAD")
       end
 
       it "returns an empty string" do

--- a/spec/models/linked_application_spec.rb
+++ b/spec/models/linked_application_spec.rb
@@ -1,10 +1,17 @@
 require "rails_helper"
 
 RSpec.describe LinkedApplication do
-  subject(:linked_application) { build(:linked_application, lead_application: laa_lead, associated_application: laa_associated, link_type_code: link_type_text) }
+  subject(:linked_application) do
+    build(:linked_application,
+          lead_application: laa_lead,
+          associated_application: laa_associated,
+          target_application: laa_target,
+          link_type_code: link_type_text)
+  end
 
   let(:laa_lead) { build(:legal_aid_application) }
   let(:laa_associated) { build(:legal_aid_application) }
+  let(:laa_target) { build(:legal_aid_application) }
   let(:link_type_text) { "FC_LEAD" }
 
   describe "#lead_application" do
@@ -19,6 +26,13 @@ RSpec.describe LinkedApplication do
 
     it { expect(associated_application).to be_instance_of(LegalAidApplication) }
     it { expect(associated_application).to eq laa_associated }
+  end
+
+  describe "#target_application" do
+    subject(:target_application) { linked_application.target_application }
+
+    it { expect(target_application).to be_instance_of(LegalAidApplication) }
+    it { expect(target_application).to eq laa_target }
   end
 
   describe "#link_type_code" do

--- a/spec/requests/providers/link_application/copies_controller_spec.rb
+++ b/spec/requests/providers/link_application/copies_controller_spec.rb
@@ -2,9 +2,10 @@ require "rails_helper"
 
 RSpec.describe Providers::LinkApplication::CopiesController do
   let(:lead_application) { create(:legal_aid_application) }
-  let(:link) { create(:linked_application, lead_application:, associated_application: application) }
-  let(:legal_aid_application) { create(:legal_aid_application, :with_applicant, lead_application:) }
+  let(:legal_aid_application) { create(:legal_aid_application, :with_applicant) }
   let(:provider) { legal_aid_application.provider }
+
+  before { create(:linked_application, lead_application:, target_application: lead_application, associated_application: legal_aid_application) }
 
   describe "GET /providers/applications/:legal_aid_application_id/link_application/copy" do
     subject(:get_request) { get providers_legal_aid_application_link_application_copy_path(legal_aid_application) }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5107)

This PR extends the linked_application model to set a target_application as well as a lead_application.

This should allow us to display the link to data on the link search result page:
![image](https://github.com/ministryofjustice/laa-apply-for-legal-aid/assets/6757677/d5b67ac7-6a65-4024-9a4e-a7a2c920e60c)

As well as having a flattened lead_application structure:
![image](https://github.com/ministryofjustice/laa-apply-for-legal-aid/assets/6757677/03c0c0cc-0e4c-41df-8f79-915454be13f2)

So, when creating Application G, we could link to, and optionally copy data from, Application C. While setting Application A as the lead application as CCMS requires this

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
