### PR TITLE
ap-4752: Remove the do you want to use the default level of service or scope for the substantive application? question

### DIFF
--- a/app/controllers/providers/proceeding_loop/substantive_defaults_controller.rb
+++ b/app/controllers/providers/proceeding_loop/substantive_defaults_controller.rb
@@ -8,6 +8,8 @@ module Providers
       end
 
       def update
+        return go_forward if legal_aid_application.special_children_act_proceedings?
+
         @form = Proceedings::SubstantiveDefaultsForm.new(form_params)
         render :show unless save_continue_or_draft(@form)
       end

--- a/app/controllers/providers/proceeding_loop/substantive_defaults_controller.rb
+++ b/app/controllers/providers/proceeding_loop/substantive_defaults_controller.rb
@@ -8,8 +8,6 @@ module Providers
       end
 
       def update
-        return go_forward if legal_aid_application.special_children_act_proceedings?
-
         @form = Proceedings::SubstantiveDefaultsForm.new(form_params)
         render :show unless save_continue_or_draft(@form)
       end

--- a/app/forms/proceedings/substantive_defaults_form.rb
+++ b/app/forms/proceedings/substantive_defaults_form.rb
@@ -17,7 +17,7 @@ module Proceedings
                   :substantive_scope_limitation_code,
                   :additional_params
 
-    validates :accepted_substantive_defaults, presence: { unless: :draft? }
+    validates :accepted_substantive_defaults, presence: true, unless: proc { draft? || model.special_childrens_act? }
 
     def initialize(*args)
       super
@@ -32,13 +32,14 @@ module Proceedings
     end
 
     def save
+      return false unless valid?
+
       model.scope_limitations.where(scope_type: :substantive).destroy_all
-      case accepted_substantive_defaults&.to_s
-      when "false"
+      if accepted_substantive_defaults&.to_s == "false"
         attributes[:substantive_level_of_service] = nil
         attributes[:substantive_level_of_service_name] = nil
         attributes[:substantive_level_of_service_stage] = nil
-      when "true"
+      else
         model.scope_limitations.create!(scope_type: :substantive,
                                         code: substantive_scope_limitation_code,
                                         meaning: substantive_scope_limitation_meaning,

--- a/app/models/proceeding.rb
+++ b/app/models/proceeding.rb
@@ -60,4 +60,8 @@ class Proceeding < ApplicationRecord
   def proceeding_case_p_num
     "P_#{proceeding_case_id}"
   end
+
+  def special_childrens_act?
+    ccms_matter_code == "KPBLW"
+  end
 end

--- a/app/services/flow/steps/provider_proceeding_loop/substantive_defaults_step.rb
+++ b/app/services/flow/steps/provider_proceeding_loop/substantive_defaults_step.rb
@@ -8,7 +8,7 @@ module Flow
         end,
         forward: lambda do |application|
           proceeding = Proceeding.find(application.provider_step_params["id"])
-          if proceeding.accepted_substantive_defaults || application.special_children_act_proceedings?
+          if proceeding.accepted_substantive_defaults || proceeding.special_childrens_act?
             Flow::ProceedingLoop.next_step(application)
           else
             :substantive_level_of_service

--- a/app/services/flow/steps/provider_proceeding_loop/substantive_defaults_step.rb
+++ b/app/services/flow/steps/provider_proceeding_loop/substantive_defaults_step.rb
@@ -8,7 +8,11 @@ module Flow
         end,
         forward: lambda do |application|
           proceeding = Proceeding.find(application.provider_step_params["id"])
-          proceeding.accepted_substantive_defaults ? Flow::ProceedingLoop.next_step(application) : :substantive_level_of_service
+          if proceeding.accepted_substantive_defaults || application.special_children_act_proceedings?
+            Flow::ProceedingLoop.next_step(application)
+          else
+            :substantive_level_of_service
+          end
         end,
         carry_on_sub_flow: true,
         check_answers: :check_provider_answers,

--- a/app/views/providers/proceeding_loop/substantive_defaults/show.html.erb
+++ b/app/views/providers/proceeding_loop/substantive_defaults/show.html.erb
@@ -14,7 +14,7 @@
     <p><strong><%= t(".scope_header") %></strong> <%= form.object.substantive_scope_limitation_meaning %></p>
     <p><strong><%= t(".scope_description_header") %></strong> <%= form.object.substantive_scope_limitation_description %></p>
 
-    <% if !@legal_aid_application.special_children_act_proceedings? %>
+    <% if !@proceeding.special_childrens_act? %>
       <%= form.govuk_radio_buttons_fieldset :accepted_substantive_defaults,
                                             inline: false,
                                             legend: { size: "m", tag: "h2", text: t(".question") } do %>

--- a/app/views/providers/proceeding_loop/substantive_defaults/show.html.erb
+++ b/app/views/providers/proceeding_loop/substantive_defaults/show.html.erb
@@ -14,23 +14,25 @@
     <p><strong><%= t(".scope_header") %></strong> <%= form.object.substantive_scope_limitation_meaning %></p>
     <p><strong><%= t(".scope_description_header") %></strong> <%= form.object.substantive_scope_limitation_description %></p>
 
-    <%= form.govuk_radio_buttons_fieldset :accepted_substantive_defaults,
-                                          inline: false,
-                                          legend: { size: "m", tag: "h2", text: t(".question") } do %>
+    <% if !@legal_aid_application.special_children_act_proceedings? %>
+      <%= form.govuk_radio_buttons_fieldset :accepted_substantive_defaults,
+                                            inline: false,
+                                            legend: { size: "m", tag: "h2", text: t(".question") } do %>
 
-      <%= form.hidden_field :substantive_level_of_service %>
-      <%= form.hidden_field :substantive_level_of_service_name %>
-      <%= form.hidden_field :substantive_level_of_service_stage %>
-      <%= form.hidden_field :substantive_scope_limitation_meaning %>
-      <%= form.hidden_field :substantive_scope_limitation_description %>
-      <%= form.hidden_field :substantive_scope_limitation_code %>
+        <%= form.hidden_field :substantive_level_of_service %>
+        <%= form.hidden_field :substantive_level_of_service_name %>
+        <%= form.hidden_field :substantive_level_of_service_stage %>
+        <%= form.hidden_field :substantive_scope_limitation_meaning %>
+        <%= form.hidden_field :substantive_scope_limitation_description %>
+        <%= form.hidden_field :substantive_scope_limitation_code %>
 
-      <%= form.govuk_radio_button :accepted_substantive_defaults, true, label: { text: t("generic.yes") }, link_errors: true do %>
-        <% if form.object.additional_params.present? %>
-          <%= pp form.object.additional_params %>
+        <%= form.govuk_radio_button :accepted_substantive_defaults, true, label: { text: t("generic.yes") }, link_errors: true do %>
+          <% if form.object.additional_params.present? %>
+            <%= pp form.object.additional_params %>
+          <% end %>
         <% end %>
+        <%= form.govuk_radio_button :accepted_substantive_defaults, false, label: { text: t("generic.no") } %>
       <% end %>
-      <%= form.govuk_radio_button :accepted_substantive_defaults, false, label: { text: t("generic.no") } %>
     <% end %>
     <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>

--- a/spec/cassettes/Proceedings_SubstantiveDefaultsForm/_save/with_a_Special_Childrens_Act_proceeding/sets_the_default_values.yml
+++ b/spec/cassettes/Proceedings_SubstantiveDefaultsForm/_save/with_a_Special_Childrens_Act_proceeding/sets_the_default_values.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
+    body:
+      encoding: UTF-8
+      string: '{"proceeding_type_ccms_code":"PB003","delegated_functions_used":false,"client_involvement_type":"Z"}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v2.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Jul 2024 08:49:22 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '434'
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"67ea4b14e9caf68b80233b8b5943d573"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 2dedf4d5acea288573d30b398092156d
+      X-Runtime:
+      - '0.010167'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"PB003","delegated_functions_used":false,"client_involvement_type":"Z"},"default_level_of_service":{"level":3,"name":"Full
+        Representation","stage":8},"default_scope":{"code":"FM062","meaning":"Final
+        hearing","description":"Limited to all steps up to and including final hearing
+        and any action necessary to implement (but not enforce) the order.","additional_params":[]}}'
+  recorded_at: Wed, 03 Jul 2024 08:49:22 GMT
+recorded_with: VCR 6.2.0

--- a/spec/cassettes/Proceedings_SubstantiveDefaultsForm/_save/with_a_Special_Childrens_Act_proceeding/without_calling_the_subject/creates_a_scope_limitation_object.yml
+++ b/spec/cassettes/Proceedings_SubstantiveDefaultsForm/_save/with_a_Special_Childrens_Act_proceeding/without_calling_the_subject/creates_a_scope_limitation_object.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
+    body:
+      encoding: UTF-8
+      string: '{"proceeding_type_ccms_code":"PB003","delegated_functions_used":false,"client_involvement_type":"Z"}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v2.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Jul 2024 08:49:22 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '434'
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
+      Etag:
+      - W/"67ea4b14e9caf68b80233b8b5943d573"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - a9e3043c50cd0503929bccdcaba4a35f
+      X-Runtime:
+      - '0.007047'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"PB003","delegated_functions_used":false,"client_involvement_type":"Z"},"default_level_of_service":{"level":3,"name":"Full
+        Representation","stage":8},"default_scope":{"code":"FM062","meaning":"Final
+        hearing","description":"Limited to all steps up to and including final hearing
+        and any action necessary to implement (but not enforce) the order.","additional_params":[]}}'
+  recorded_at: Wed, 03 Jul 2024 08:49:22 GMT
+recorded_with: VCR 6.2.0

--- a/spec/forms/proceedings/substantive_defaults_form_spec.rb
+++ b/spec/forms/proceedings/substantive_defaults_form_spec.rb
@@ -107,5 +107,25 @@ RSpec.describe Proceedings::SubstantiveDefaultsForm, :vcr, type: :form do
         end
       end
     end
+
+    context "with a Special Childrens Act proceeding" do
+      let(:params) { {} }
+      let(:proceeding) { create(:proceeding, :pb003, :without_df_date, client_involvement_type_ccms_code: "A", no_scope_limitations: true) }
+
+      it "sets the default values" do
+        expect(proceeding.substantive_level_of_service).to eq 3
+        expect(proceeding.substantive_level_of_service_name).to eq "Full Representation"
+        expect(proceeding.substantive_level_of_service_stage).to eq 8
+      end
+
+      context "without calling the subject" do
+        let(:skip_subject) { true }
+
+        it "creates a scope_limitation object" do
+          expect { save_form }.to change(proceeding.scope_limitations, :count).by(1)
+          expect(proceeding.scope_limitations.find_by(scope_type: :substantive)).to have_attributes(code: "FM062", description: "Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order.")
+        end
+      end
+    end
   end
 end

--- a/spec/requests/providers/proceeding_loop/substantive_defaults_controller_spec.rb
+++ b/spec/requests/providers/proceeding_loop/substantive_defaults_controller_spec.rb
@@ -78,13 +78,24 @@ RSpec.describe "SubstantiveDefaultsController", :vcr do
           end
 
           it "redirects to next page" do
-            expect(response.body).to redirect_to(providers_legal_aid_application_limitations_path(application_id))
+            expect(response).to have_http_status(:redirect)
           end
         end
 
         context "when the provider does not accept the defaults" do
           it "redirects to next page" do
-            expect(response.body).to redirect_to(providers_legal_aid_application_substantive_level_of_service_path(application_id, proceeding_id))
+            expect(response).to have_http_status(:redirect)
+          end
+        end
+
+        context "when the application is a Special Childrens Act application" do
+          let(:application) { create(:legal_aid_application, :with_multiple_sca_proceedings) }
+          let(:params) do
+            {}
+          end
+
+          it "redirects to next page" do
+            expect(response).to have_http_status(:redirect)
           end
         end
 

--- a/spec/services/flow/steps/provider_proceeding_loop/substantive_defaults_step_spec.rb
+++ b/spec/services/flow/steps/provider_proceeding_loop/substantive_defaults_step_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe Flow::Steps::ProviderProceedingLoop::SubstantiveDefaultsStep, typ
       it { is_expected.to eq :limitations }
     end
 
+    context "when the application is a Special Childrens Act proceeding" do
+      let(:proceeding) { create(:proceeding, :pb003, legal_aid_application:, accepted_substantive_defaults: nil) }
+
+      it { is_expected.to eq :limitations }
+    end
+
     context "when accepted_substantive_defaults is false" do
       let(:accepted_substantive_defaults) { false }
 


### PR DESCRIPTION
Do not display the Do you want to use the default level of service or scope for the substantive application? question for SCA applications.



## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4572)

- Removed question from substantive_defaults view for SCA proceedings.
- Updated flow logic so that SCA proceedings should behave as if the user selected Yes to accept the substantive defaults
- Updated form logic so that SCA proceedings should behave as if the user selected Yes to accept the substantive defaults in terms of updating the default service level and scope limitations.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
