### PR TITLE
AP-5095: Add partner data to reports

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -66,17 +66,20 @@ module Admin
     def reports
       @reports ||= {
         csv_download: {
-          report_title: "Application Details report",
+          report_title: "Application Details report ",
+          report_link: { href: "https://dsdmoj.atlassian.net/wiki/x/JwBOKQE", text: "About this report (opens in new tab)", class: "govuk-link govuk-link--no-visited-state", rel: "noreferrer noopener", target: "_blank" },
           path: :admin_application_details_csv_path,
           path_text: "Download CSV",
         },
         provider_download: {
           report_title: "Provider email report",
+          report_link: nil,
           path: :admin_provider_emails_csv_path,
           path_text: "Download CSV",
         },
         user_feedback_download: {
           report_title: "User feedback report",
+          report_link: nil,
           path: :admin_user_feedbacks_csv_path,
           path_text: "Download CSV",
         },

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -13,6 +13,7 @@
           table.with_head do |head|
             head.with_row do |row|
               row.with_cell(text: "Report name")
+              row.with_cell(text: "Help link")
               row.with_cell(text: "Action")
             end
           end
@@ -21,6 +22,9 @@
             @reports.each_value do |report|
               body.with_row do |row|
                 row.with_cell(text: report[:report_title])
+                row.with_cell do
+                  report[:report_link].present? ? govuk_link_to(report[:report_link][:text], report[:report_link][:href], class: report[:report_link][:class], rel: report[:report_link][:rel], target: report[:report_link][:target]) : ""
+                end
                 row.with_cell do
                   govuk_link_to(report[:path_text], __send__(report[:path], format: :csv))
                 end

--- a/db/migrate/20240702132532_add_new_fields_to_application_digest.rb
+++ b/db/migrate/20240702132532_add_new_fields_to_application_digest.rb
@@ -1,0 +1,9 @@
+class AddNewFieldsToApplicationDigest < ActiveRecord::Migration[7.1]
+  def change
+    add_column :application_digests, :has_partner, :boolean
+    add_column :application_digests, :contrary_interest, :boolean
+    add_column :application_digests, :partner_dwp_challenge, :boolean
+    add_column :application_digests, :applicant_age, :integer
+    add_column :application_digests, :non_means_tested, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_27_104142) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_02_132532) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -168,6 +168,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_27_104142) do
     t.boolean "true_layer_path"
     t.boolean "bank_statements_path"
     t.boolean "true_layer_data"
+    t.boolean "has_partner"
+    t.boolean "contrary_interest"
+    t.boolean "partner_dwp_challenge"
+    t.integer "applicant_age"
+    t.boolean "non_means_tested"
     t.index ["legal_aid_application_id"], name: "index_application_digests_on_legal_aid_application_id", unique: true
   end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5095)

This PR adds the following columns to both the overnight digest generation and the Application report
- has_partner? 
- contrary_interest? 
- partner_dwp_challenge?
- applicant_age
- non_means_tested? 

As the data is getting more complex, it also adds a link to the reports page to allow a link to confluence to help users interpret the contained within the report

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
