### PR TITLE
ap-5140: Fix error when provider has added SCA proceeding and uses de…

### DIFF
--- a/app/controllers/providers/limitations_controller.rb
+++ b/app/controllers/providers/limitations_controller.rb
@@ -22,7 +22,7 @@ module Providers
     end
 
     def form_needs_checking?
-      legal_aid_application.used_delegated_functions? || @legal_aid_application.substantive_cost_overridable?
+      (legal_aid_application.used_delegated_functions? && !legal_aid_application.special_children_act_proceedings?) || @legal_aid_application.substantive_cost_overridable?
     end
 
     def clear_limit_and_reason

--- a/spec/requests/providers/limitations_controller_spec.rb
+++ b/spec/requests/providers/limitations_controller_spec.rb
@@ -152,6 +152,20 @@ RSpec.describe Providers::LimitationsController do
           expect(response.body).to include("Emergency cost limit must be an amount of money, like 2,500")
         end
       end
+
+      context "with a Special Childrens Act application that has used delegated functions" do
+        subject(:patch_request) { patch providers_legal_aid_application_limitations_path(legal_aid_application) }
+
+        let(:legal_aid_application) { create(:legal_aid_application) }
+        let(:proceeding) { create(:proceeding, :pb003, used_delegated_functions: true, used_delegated_functions_on: Date.yesterday) }
+
+        before { legal_aid_application.proceedings << proceeding }
+
+        it "redirects to next page" do
+          patch_request
+          expect(response).to have_http_status(:redirect)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
…legated functions

In this instance there are no emergency cost certificate cost limits to override, however, the controller was expecting form parameters to be present.



## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5140)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
