### PR TITLE
AP-5141: Change partner file name lengths

### DIFF
--- a/app/controllers/providers/partners/bank_statements_controller.rb
+++ b/app/controllers/providers/partners/bank_statements_controller.rb
@@ -30,7 +30,7 @@ module Providers
       end
 
       def attachments
-        legal_aid_application.attachments.partner_bank_statement_evidence
+        legal_aid_application.attachments.part_bank_state_evidence
       end
 
       def url

--- a/app/controllers/v1/partners/bank_statements_controller.rb
+++ b/app/controllers/v1/partners/bank_statements_controller.rb
@@ -3,7 +3,7 @@ module V1
     class BankStatementsController < BaseBankStatementsController
       def initialize
         super
-        @attachment_type = "partner_bank_statement_evidence"
+        @attachment_type = "part_bank_state_evidence"
         @attachment_type_capture = /^#{@attachment_type}_(\d+)$/
       end
 
@@ -11,8 +11,8 @@ module V1
 
       # can be shared with v1 bank statement controller
       def sequenced_attachment_name
-        if legal_aid_application.attachments.partner_bank_statement_evidence.any?
-          most_recent_name = legal_aid_application.attachments.partner_bank_statement_evidence.order(:attachment_name).last.attachment_name
+        if legal_aid_application.attachments.part_bank_state_evidence.any?
+          most_recent_name = legal_aid_application.attachments.part_bank_state_evidence.order(:attachment_name).last.attachment_name
           increment_name(most_recent_name)
         else
           attachment_type

--- a/app/forms/providers/partners/bank_statement_form.rb
+++ b/app/forms/providers/partners/bank_statement_form.rb
@@ -3,20 +3,20 @@ module Providers
     class BankStatementForm < BaseBankStatementForm
       def initialize(bank_statement_form_params)
         super
-        @attachment_type = "partner_bank_statement_evidence"
+        @attachment_type = "part_bank_state_evidence"
         @attachment_type_capture = /^#{@attachment_type}_(\d+)$/
       end
 
     private
 
       def any_bank_statements_or_draft?
-        legal_aid_application.attachments.partner_bank_statement_evidence.any? || draft?
+        legal_aid_application.attachments.part_bank_state_evidence.any? || draft?
       end
 
       # can be shared with v1 bank statement controller
       def sequenced_attachment_name
-        if legal_aid_application.attachments.partner_bank_statement_evidence.any?
-          most_recent_name = legal_aid_application.attachments.partner_bank_statement_evidence.order(:created_at, :attachment_name).last.attachment_name
+        if legal_aid_application.attachments.part_bank_state_evidence.any?
+          most_recent_name = legal_aid_application.attachments.part_bank_state_evidence.order(:created_at, :attachment_name).last.attachment_name
           increment_name(most_recent_name)
         else
           attachment_type

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -539,7 +539,7 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def uploading_bank_statements?
-    client_not_given_consent_to_open_banking? || attachments.bank_statement_evidence.exists? || attachments.partner_bank_statement_evidence.exists?
+    client_not_given_consent_to_open_banking? || attachments.bank_statement_evidence.exists? || attachments.part_bank_state_evidence.exists?
   end
 
   def client_uploading_bank_statements?
@@ -547,7 +547,7 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def partner_uploading_bank_statements?
-    attachments&.partner_bank_statement_evidence&.exists?
+    attachments&.part_bank_state_evidence&.exists?
   end
 
   def has_transaction_type?(transaction_type)

--- a/app/services/ccms/requestors/document_id_requestor.rb
+++ b/app/services/ccms/requestors/document_id_requestor.rb
@@ -33,9 +33,17 @@ module CCMS
 
       def document_type(xml)
         case @document_type
-        in "bank_transaction_report" | "bank_statement_evidence_pdf"
+        when "bank_statement_evidence_pdf", "part_bank_state_evidence_pdf", "bank_transaction_report"
           xml.__send__(:"casebio:DocumentType", "BSTMT")
-        in "gateway_evidence_pdf"
+        when "client_employment_evidence_pdf", "part_employ_evidence_pdf", "employment_evidence_pdf"
+          xml.__send__(:"casebio:DocumentType", "PAYSLIP")
+        when "court_order_pdf", "court_application_or_order_pdf", "court_application_pdf"
+          xml.__send__(:"casebio:DocumentType", "COURT_ORD")
+        when "expert_report_pdf", "gateway_evidence_pdf"
+          xml.__send__(:"casebio:DocumentType", "EX_RPT")
+        when "benefit_evidence_pdf"
+          xml.__send__(:"casebio:DocumentType", "BEN_LTR")
+        when "statement_of_case_pdf"
           xml.__send__(:"casebio:DocumentType", "STATE")
         else
           xml.__send__(:"casebio:DocumentType", "ADMIN1")

--- a/app/services/ccms/requestors/document_upload_requestor.rb
+++ b/app/services/ccms/requestors/document_upload_requestor.rb
@@ -45,10 +45,22 @@ module CCMS
         when "bank_transaction_report"
           xml.__send__(:"casebio:DocumentType", "BSTMT")
           xml.__send__(:"casebio:FileExtension", "csv")
-        when "bank_statement_evidence_pdf"
+        when "bank_statement_evidence_pdf", "part_bank_state_evidence_pdf"
           xml.__send__(:"casebio:DocumentType", "BSTMT")
           xml.__send__(:"casebio:FileExtension", "pdf")
-        when "gateway_evidence_pdf"
+        when "client_employment_evidence_pdf", "part_employ_evidence_pdf", "employment_evidence_pdf"
+          xml.__send__(:"casebio:DocumentType", "PAYSLIP")
+          xml.__send__(:"casebio:FileExtension", "pdf")
+        when "court_order_pdf", "court_application_or_order_pdf", "court_application_pdf"
+          xml.__send__(:"casebio:DocumentType", "COURT_ORD")
+          xml.__send__(:"casebio:FileExtension", "pdf")
+        when "expert_report_pdf", "gateway_evidence_pdf"
+          xml.__send__(:"casebio:DocumentType", "EX_RPT")
+          xml.__send__(:"casebio:FileExtension", "pdf")
+        when "benefit_evidence_pdf"
+          xml.__send__(:"casebio:DocumentType", "BEN_LTR")
+          xml.__send__(:"casebio:FileExtension", "pdf")
+        when "statement_of_case_pdf"
           xml.__send__(:"casebio:DocumentType", "STATE")
           xml.__send__(:"casebio:FileExtension", "pdf")
         else

--- a/app/services/required_document_category_analyser.rb
+++ b/app/services/required_document_category_analyser.rb
@@ -12,7 +12,7 @@ class RequiredDocumentCategoryAnalyser
     required_document_categories << "benefit_evidence" if @application.dwp_override&.has_evidence_of_benefit?
     required_document_categories << "gateway_evidence" if @application.section_8_proceedings?
     required_document_categories << "client_employment_evidence" if @application.employment_evidence_required?
-    required_document_categories << "partner_employment_evidence" if @application&.partner&.employment_evidence_required?
+    required_document_categories << "part_employ_evidence" if @application&.partner&.employment_evidence_required?
     required_document_categories << "court_application_or_order" if has_opponents_application? && !has_listed_final_hearing?
     if has_listed_final_hearing? && !has_opponents_application?
       required_document_categories << "court_order"

--- a/app/validators/document_category_validator.rb
+++ b/app/validators/document_category_validator.rb
@@ -4,14 +4,15 @@
 # - to validate the name field on the DocumentCategory model
 #
 class DocumentCategoryValidator < ActiveModel::Validator
+  # these names should not exceed 30 characters
   VALID_DOCUMENT_TYPES = %w[
     bank_transaction_report
     benefit_evidence
     benefit_evidence_pdf
     client_employment_evidence
     client_employment_evidence_pdf
-    partner_employment_evidence
-    partner_employment_evidence_pdf
+    part_employ_evidence
+    part_employ_evidence_pdf
     gateway_evidence
     gateway_evidence_pdf
     means_report
@@ -28,8 +29,8 @@ class DocumentCategoryValidator < ActiveModel::Validator
     expert_report_pdf
     court_application_or_order
     court_application_or_order_pdf
-    partner_bank_statement_evidence
-    partner_bank_statement_evidence_pdf
+    part_bank_state_evidence
+    part_bank_state_evidence_pdf
   ].freeze
 
   def validate(record)

--- a/app/views/providers/capital_income_assessment_results/_result_details.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_result_details.html.erb
@@ -19,7 +19,7 @@
       <%= render("outgoings", individual: "Client") %>
 
       <% if @legal_aid_application.applicant.has_partner_with_no_contrary_interest? %>
-        <%= render("bank_statements", bank_statements: @legal_aid_application.attachments.partner_bank_statement_evidence, individual: "Partner", read_only: true) %>
+        <%= render("bank_statements", bank_statements: @legal_aid_application.attachments.part_bank_state_evidence, individual: "Partner", read_only: true) %>
 
         <% if @cfe_result.partner_jobs? %>
           <%= render("employment_income", individual: "Partner") %>

--- a/app/views/providers/means/check_income_answers/_partner_income_assessment.html.erb
+++ b/app/views/providers/means/check_income_answers/_partner_income_assessment.html.erb
@@ -1,7 +1,7 @@
 <section class="partner">
   <h2 class="govuk-heading-l govuk-!-margin-bottom-8"><%= t(".income-heading") %></h2>
 
-  <%= render("shared/check_answers/bank_statements", bank_statements: @legal_aid_application.attachments.partner_bank_statement_evidence, read_only: false, partner: true) %>
+  <%= render("shared/check_answers/bank_statements", bank_statements: @legal_aid_application.attachments.part_bank_state_evidence, read_only: false, partner: true) %>
 
   <% if @legal_aid_application.partner.hmrc_employment_income? %>
     <% if @legal_aid_application.partner.has_multiple_employments? %>

--- a/app/views/providers/means_reports/_with_cfe_result_details.html.erb
+++ b/app/views/providers/means_reports/_with_cfe_result_details.html.erb
@@ -114,7 +114,7 @@
           <%= row.with_key(text: t(".partner_bank_statement_question"), classes: "govuk-!-width-one-half") %>
           <%= row.with_value do %>
             <ul class="govuk-list">
-              <% attachments_with_size(@legal_aid_application.attachments.partner_bank_statement_evidence).each do |answer| %>
+              <% attachments_with_size(@legal_aid_application.attachments.part_bank_state_evidence).each do |answer| %>
                 <li><%= answer %></li>
               <% end %>
             </ul>

--- a/app/views/providers/partners/bank_statements/show.html.erb
+++ b/app/views/providers/partners/bank_statements/show.html.erb
@@ -5,4 +5,4 @@
            warning: t(".warning"),
            url: providers_legal_aid_application_partners_bank_statements_path,
            data_url: v1_partners_bank_statements_path,
-           attachments: @form.legal_aid_application.attachments.partner_bank_statement_evidence %>
+           attachments: @form.legal_aid_application.attachments.part_bank_state_evidence %>

--- a/app/views/shared/review_application/_partner_income.erb
+++ b/app/views/shared/review_application/_partner_income.erb
@@ -3,7 +3,7 @@
 <!-- UPLOADED BANK STATEMENTS -->
 
 <% if @legal_aid_application.partner_uploading_bank_statements? %>
-  <%= render("shared/check_answers/bank_statements", bank_statements: @legal_aid_application.attachments.partner_bank_statement_evidence, read_only: true, partner: true) %>
+  <%= render("shared/check_answers/bank_statements", bank_statements: @legal_aid_application.attachments.part_bank_state_evidence, read_only: true, partner: true) %>
 <% end %>
 
 <!-- EMPLOYMENT INCOME -->

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -938,7 +938,7 @@ en:
               benefit_evidence_missing: Upload evidence that your client receives %{benefit}
               content_type_invalid: The selected file must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF or PDF
               client_employment_evidence_missing: Upload your client's employment evidence
-              partner_employment_evidence_missing: Upload the partner's employment evidence
+              part_employ_evidence_missing: Upload the partner's employment evidence
               court_application_or_order_missing: Upload the application to court or the court order for Section 8 proceedings
               court_application_missing: Upload the application to court for Section 8 proceedings
               court_order_missing: Upload the court order for Section 8 proceedings

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -790,7 +790,7 @@ en:
         list_text: 'Use this page to upload:'
         benefit_evidence: evidence that your client receives %{benefit}
         client_employment_evidence: evidence of your client's employment
-        partner_employment_evidence: evidence of the partner's employment
+        part_employ_evidence: evidence of the partner's employment
         gateway_evidence: gateway evidence for Section 8 proceedings (optional)
         court_application: the application to court for Section 8 proceedings (optional)
         court_order: the court order for Section 8 proceedings

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -543,7 +543,7 @@ en:
         evidence_types:
           benefit_evidence: Benefit evidence
           client_employment_evidence: Client's employment evidence
-          partner_employment_evidence: Partner's employment evidence
+          part_employ_evidence: Partner's employment evidence
           gateway_evidence: Gateway evidence
           court_application_or_order: Court application or order
           court_order: Court order

--- a/db/seeds/document_categories.csv
+++ b/db/seeds/document_categories.csv
@@ -4,8 +4,8 @@ benefit_evidence,FALSE,,TRUE,TRUE
 benefit_evidence_pdf,TRUE,ADMIN1,FALSE,FALSE
 client_employment_evidence,FALSE,,TRUE,TRUE
 client_employment_evidence_pdf,TRUE,ADMIN1,FALSE,FALSE
-partner_employment_evidence,FALSE,,TRUE,TRUE
-partner_employment_evidence_pdf,TRUE,ADMIN1,FALSE,FALSE
+part_employ_evidence,FALSE,,TRUE,TRUE
+part_employ_evidence_pdf,TRUE,ADMIN1,FALSE,FALSE
 gateway_evidence,FALSE,,TRUE,FALSE
 gateway_evidence_pdf,TRUE,STATE,FALSE,FALSE
 means_report,TRUE,ADMIN1,FALSE,FALSE

--- a/db/seeds/document_categories.csv
+++ b/db/seeds/document_categories.csv
@@ -22,3 +22,5 @@ expert_report,FALSE,,TRUE,FALSE
 expert_report_pdf,TRUE,ADMIN1,FALSE,FALSE
 court_application_or_order,FALSE,,TRUE,TRUE
 court_application_or_order_pdf,TRUE,ADMIN1,FALSE,FALSE
+part_bank_state_evidence,FALSE,,FALSE,FALSE
+part_bank_state_evidence_pdf,TRUE,BSTMT,FALSE,FALSE

--- a/lib/tasks/migrate_partner_attachments.rake
+++ b/lib/tasks/migrate_partner_attachments.rake
@@ -1,0 +1,43 @@
+namespace :migrate do
+  desc "AP-5141 migrate attachment names after length exceeded CCMS limits"
+
+  task partner_attachments: :environment do
+    changes = {
+      partner_bank_statement_evidence: "part_bank_state_evidence",
+      partner_bank_statement_evidence_pdf: "part_bank_state_evidence_pdf",
+      partner_employment_evidence: "part_employ_evidence",
+      partner_employment_evidence_pdf: "part_employ_evidence_pdf",
+    }
+
+    attachments = Attachment.where(attachment_type: changes.keys)
+    documents = CCMS::SubmissionDocument.where(document_type: changes.keys)
+    Rails.logger.info "Migrating filenames"
+    Rails.logger.info "----------------------------------------"
+    Rails.logger.info "Affected attachments   : #{attachments.count}"
+    Rails.logger.info "Affected documents   : #{documents.count}"
+    Rails.logger.info "-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+    Benchmark.benchmark do |bm|
+      bm.report("Migrate:") do
+        ActiveRecord::Base.transaction do
+          attachments.each do |file|
+            file.attachment_type = changes[file.attachment_type.to_sym]
+            file.save!(touch: false) # this prevents the updated_at date being changed and delaying purging of stale records
+          end
+          raise StandardError, "Not all attachments updated" if Attachment.where(attachment_type: changes.keys).count.positive?
+
+          documents.each do |file|
+            file.document_type = changes[file.document_type.to_sym]
+            file.save!(touch: false) # this prevents the updated_at date being changed and delaying purging of stale records
+          end
+          raise StandardError, "Not all documents updated" if CCMS::SubmissionDocument.where(document_type: changes.keys).count.positive?
+        end
+      end
+    end
+    Rails.logger.info "-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+    Rails.logger.info "Attachments updated    : #{Attachment.where(attachment_type: changes.values).count}"
+    Rails.logger.info "Documents updated      : #{CCMS::SubmissionDocument.where(document_type: changes.values).count}"
+    Rails.logger.info "Attachments not updated: #{Attachment.where(attachment_type: changes.keys).count}"
+    Rails.logger.info "Documents not updated  : #{CCMS::SubmissionDocument.where(document_type: changes.keys).count}"
+    Rails.logger.info "----------------------------------------"
+  end
+end

--- a/spec/factories/attachments.rb
+++ b/spec/factories/attachments.rb
@@ -22,8 +22,8 @@ FactoryBot.define do
     end
 
     trait :partner_bank_statement do
-      attachment_type { "partner_bank_statement_evidence" }
-      sequence(:attachment_name) { |n| "partner_bank_statement_evidence_#{n}" }
+      attachment_type { "part_bank_state_evidence" }
+      sequence(:attachment_name) { |n| "part_bank_state_evidence_#{n}" }
       sequence(:original_filename) { "original_filename.pdf" }
     end
 

--- a/spec/models/document_category_spec.rb
+++ b/spec/models/document_category_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DocumentCategory do
       %w[
         benefit_evidence
         client_employment_evidence
-        partner_employment_evidence
+        part_employ_evidence
         gateway_evidence
         uncategorised
         court_application_or_order
@@ -39,7 +39,7 @@ RSpec.describe DocumentCategory do
         bank_statement_evidence_pdf
         benefit_evidence_pdf
         client_employment_evidence_pdf
-        partner_employment_evidence_pdf
+        part_employ_evidence_pdf
         gateway_evidence_pdf
         means_report
         merits_report

--- a/spec/models/document_category_spec.rb
+++ b/spec/models/document_category_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe DocumentCategory do
         court_application_pdf
         court_order_pdf
         expert_report_pdf
+        part_bank_state_evidence_pdf
       ]
     end
 

--- a/spec/requests/providers/partners/bank_statements_controller_spec.rb
+++ b/spec/requests/providers/partners/bank_statements_controller_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Providers::Partners::BankStatementsController do
 
         it "sets attachment_name to model name" do
           request
-          expect(legal_aid_application.reload.attachments.last.attachment_name).to eq("partner_bank_statement_evidence")
+          expect(legal_aid_application.reload.attachments.last.attachment_name).to eq("part_bank_state_evidence")
         end
 
         context "with background job processing" do
@@ -154,34 +154,34 @@ RSpec.describe Providers::Partners::BankStatementsController do
 
           it "adds original and converted attachments types" do
             request
-            expect(legal_aid_application.reload.attachments.pluck(:attachment_type)).to match_array(%w[partner_bank_statement_evidence partner_bank_statement_evidence_pdf])
+            expect(legal_aid_application.reload.attachments.pluck(:attachment_type)).to match_array(%w[part_bank_state_evidence part_bank_state_evidence_pdf])
           end
 
           it "associates pdf converted attachment to original attachment" do
             request
-            original_attachment = legal_aid_application.attachments.find_by(attachment_type: "partner_bank_statement_evidence")
+            original_attachment = legal_aid_application.attachments.find_by(attachment_type: "part_bank_state_evidence")
             expect(original_attachment.pdf_attachment_id).not_to be_nil
           end
         end
 
         context "when the application has one bank statement attachment already" do
-          let(:partner_bank_statement_evidence) { create(:attachment, :partner_bank_statement, attachment_name: "partner_bank_statement_evidence") }
-          let!(:legal_aid_application) { create(:legal_aid_application, attachments: [partner_bank_statement_evidence]) }
+          let(:part_bank_state_evidence) { create(:attachment, :partner_bank_statement, attachment_name: "part_bank_state_evidence") }
+          let!(:legal_aid_application) { create(:legal_aid_application, attachments: [part_bank_state_evidence]) }
 
           it "increments the attachment name" do
             request
-            expect(legal_aid_application.reload.attachments.pluck(:attachment_name)).to match_array(%w[partner_bank_statement_evidence partner_bank_statement_evidence_1])
+            expect(legal_aid_application.reload.attachments.pluck(:attachment_name)).to match_array(%w[part_bank_state_evidence part_bank_state_evidence_1])
           end
         end
 
         context "when the application has multiple attachments for statement of case already" do
-          let(:bs1) { create(:attachment, :partner_bank_statement, attachment_name: "partner_bank_statement_evidence") }
-          let(:bs2) { create(:attachment, :partner_bank_statement, attachment_name: "partner_bank_statement_evidence_1") }
+          let(:bs1) { create(:attachment, :partner_bank_statement, attachment_name: "part_bank_state_evidence") }
+          let(:bs2) { create(:attachment, :partner_bank_statement, attachment_name: "part_bank_state_evidence_1") }
           let!(:legal_aid_application) { create(:legal_aid_application, attachments: [bs1, bs2]) }
 
           it "increments the attachment name" do
             request
-            expect(legal_aid_application.reload.attachments.pluck(:attachment_name)).to match_array(%w[partner_bank_statement_evidence partner_bank_statement_evidence_1 partner_bank_statement_evidence_2])
+            expect(legal_aid_application.reload.attachments.pluck(:attachment_name)).to match_array(%w[part_bank_state_evidence part_bank_state_evidence_1 part_bank_state_evidence_2])
           end
         end
       end
@@ -420,7 +420,7 @@ RSpec.describe Providers::Partners::BankStatementsController do
     before { login_as provider }
 
     context "with existing file" do
-      let(:params) { { attachment_id: legal_aid_application.attachments.partner_bank_statement_evidence.first.id } }
+      let(:params) { { attachment_id: legal_aid_application.attachments.part_bank_state_evidence.first.id } }
 
       before do
         patch(providers_legal_aid_application_partners_bank_statements_path(legal_aid_application),

--- a/spec/requests/v1/partners/bank_statements_spec.rb
+++ b/spec/requests/v1/partners/bank_statements_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe "POST /v1/partners/bank_statements" do
         request
         expect(legal_aid_application.reload.attachments.last)
           .to have_attributes(document: be_a(ActiveStorage::Attached::One),
-                              attachment_type: "partner_bank_statement_evidence",
+                              attachment_type: "part_bank_state_evidence",
                               original_filename: "hello_world.pdf",
-                              attachment_name: "partner_bank_statement_evidence")
+                              attachment_name: "part_bank_state_evidence")
       end
 
       context "with background job processing" do
@@ -53,12 +53,12 @@ RSpec.describe "POST /v1/partners/bank_statements" do
 
         it "adds original and converted attachments types" do
           request
-          expect(legal_aid_application.reload.attachments.pluck(:attachment_type)).to match_array(%w[partner_bank_statement_evidence partner_bank_statement_evidence_pdf])
+          expect(legal_aid_application.reload.attachments.pluck(:attachment_type)).to match_array(%w[part_bank_state_evidence part_bank_state_evidence_pdf])
         end
 
         it "associates pdf converted attachment to original attachment" do
           request
-          original_attachment = legal_aid_application.attachments.find_by(attachment_type: "partner_bank_statement_evidence")
+          original_attachment = legal_aid_application.attachments.find_by(attachment_type: "part_bank_state_evidence")
           expect(original_attachment.pdf_attachment_id).not_to be_nil
         end
       end
@@ -69,30 +69,30 @@ RSpec.describe "POST /v1/partners/bank_statements" do
         it "does not increment the attachment name" do
           request
           expect(legal_aid_application.attachments.count).to be 1
-          expect(legal_aid_application.reload.attachments.last.attachment_name).to match("partner_bank_statement_evidence")
+          expect(legal_aid_application.reload.attachments.last.attachment_name).to match("part_bank_state_evidence")
         end
       end
 
       context "when the application has one bank statement attachment already" do
-        let(:partner_bank_statement_evidence) { create(:attachment, :partner_bank_statement, attachment_name: "partner_bank_statement_evidence") }
-        let!(:legal_aid_application) { create(:legal_aid_application, attachments: [partner_bank_statement_evidence]) }
+        let(:part_bank_state_evidence) { create(:attachment, :partner_bank_statement, attachment_name: "part_bank_state_evidence") }
+        let!(:legal_aid_application) { create(:legal_aid_application, attachments: [part_bank_state_evidence]) }
 
         it "increments the attachment name" do
           request
           expect(legal_aid_application.attachments.count).to be 2
-          expect(legal_aid_application.attachments.order(:attachment_name).last.attachment_name).to eql("partner_bank_statement_evidence_1")
+          expect(legal_aid_application.attachments.order(:attachment_name).last.attachment_name).to eql("part_bank_state_evidence_1")
         end
       end
 
       context "when the application has multiple attachments for bank statement already" do
-        let(:bs1) { create(:attachment, :partner_bank_statement, attachment_name: "partner_bank_statement_evidence") }
-        let(:bs2) { create(:attachment, :partner_bank_statement, attachment_name: "partner_bank_statement_evidence_1") }
+        let(:bs1) { create(:attachment, :partner_bank_statement, attachment_name: "part_bank_state_evidence") }
+        let(:bs2) { create(:attachment, :partner_bank_statement, attachment_name: "part_bank_state_evidence_1") }
         let!(:legal_aid_application) { create(:legal_aid_application, attachments: [bs1, bs2]) }
 
         it "increments the attachment name" do
           request
           expect(legal_aid_application.attachments.count).to be 3
-          expect(legal_aid_application.attachments.order(:attachment_name).last.attachment_name).to eql("partner_bank_statement_evidence_2")
+          expect(legal_aid_application.attachments.order(:attachment_name).last.attachment_name).to eql("part_bank_state_evidence_2")
         end
       end
 

--- a/spec/services/ccms/requestors/document_id_requestor_spec.rb
+++ b/spec/services/ccms/requestors/document_id_requestor_spec.rb
@@ -75,7 +75,61 @@ module CCMS
               command: "casebim:DocumentUploadRQ",
               transaction_id: expected_tx_id,
               matching: %w[
-                <casebio:DocumentType>STATE</casebio:DocumentType>
+                <casebio:DocumentType>EX_RPT</casebio:DocumentType>
+                <casebio:Channel>E</casebio:Channel>
+              ],
+            )
+          end
+        end
+
+        context "when sent a client employment evidence document" do
+          let(:type) { "client_employment_evidence_pdf" }
+
+          include_context "with ccms soa configuration"
+
+          it "generates the expected XML" do
+            allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
+            expect(requestor.formatted_xml).to be_soap_envelope_with(
+              command: "casebim:DocumentUploadRQ",
+              transaction_id: expected_tx_id,
+              matching: %w[
+                <casebio:DocumentType>PAYSLIP</casebio:DocumentType>
+                <casebio:Channel>E</casebio:Channel>
+              ],
+            )
+          end
+        end
+
+        context "when sent a court_application_or_order_pdf document" do
+          let(:type) { "court_application_or_order_pdf" }
+
+          include_context "with ccms soa configuration"
+
+          it "generates the expected XML" do
+            allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
+            expect(requestor.formatted_xml).to be_soap_envelope_with(
+              command: "casebim:DocumentUploadRQ",
+              transaction_id: expected_tx_id,
+              matching: %w[
+                <casebio:DocumentType>COURT_ORD</casebio:DocumentType>
+                <casebio:Channel>E</casebio:Channel>
+              ],
+            )
+          end
+        end
+
+        context "when sent a benefit_evidence_pdf document" do
+          let(:type) { "benefit_evidence_pdf" }
+
+          include_context "with ccms soa configuration"
+
+          it "generates the expected XML" do
+            allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
+            expect(requestor.formatted_xml).to be_soap_envelope_with(
+              command: "casebim:DocumentUploadRQ",
+              transaction_id: expected_tx_id,
+              matching: %w[
+                <casebio:DocumentType>BEN_LTR</casebio:DocumentType>
                 <casebio:Channel>E</casebio:Channel>
               ],
             )

--- a/spec/services/ccms/requestors/document_upload_requestor_spec.rb
+++ b/spec/services/ccms/requestors/document_upload_requestor_spec.rb
@@ -38,7 +38,7 @@ module CCMS
               command: "casebim:DocumentUploadRQ",
               transaction_id: expected_tx_id,
               matching: %w[
-                <casebio:DocumentType>STATE</casebio:DocumentType>
+                <casebio:DocumentType>EX_RPT</casebio:DocumentType>
                 <casebio:FileExtension>pdf</casebio:FileExtension>
               ],
             )
@@ -75,6 +75,96 @@ module CCMS
               transaction_id: expected_tx_id,
               matching: %w[
                 <casebio:DocumentType>BSTMT</casebio:DocumentType>
+                <casebio:FileExtension>pdf</casebio:FileExtension>
+              ],
+            )
+          end
+        end
+
+        context "when sent a part_bank_state_evidence_pdf document" do
+          let(:requestor) { described_class.new(case_ccms_reference, document_id, document_encoded_base64, "my_login", "part_bank_state_evidence_pdf") }
+
+          include_context "with ccms soa configuration"
+
+          it "generates the expected XML" do
+            allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
+            expect(requestor.formatted_xml).to be_soap_envelope_with(
+              command: "casebim:DocumentUploadRQ",
+              transaction_id: expected_tx_id,
+              matching: %w[
+                <casebio:DocumentType>BSTMT</casebio:DocumentType>
+                <casebio:FileExtension>pdf</casebio:FileExtension>
+              ],
+            )
+          end
+        end
+
+        context "when sent a client_employment_evidence_pdf document" do
+          let(:requestor) { described_class.new(case_ccms_reference, document_id, document_encoded_base64, "my_login", "client_employment_evidence_pdf") }
+
+          include_context "with ccms soa configuration"
+
+          it "generates the expected XML" do
+            allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
+            expect(requestor.formatted_xml).to be_soap_envelope_with(
+              command: "casebim:DocumentUploadRQ",
+              transaction_id: expected_tx_id,
+              matching: %w[
+                <casebio:DocumentType>PAYSLIP</casebio:DocumentType>
+                <casebio:FileExtension>pdf</casebio:FileExtension>
+              ],
+            )
+          end
+        end
+
+        context "when sent a court_application_or_order_pdf document" do
+          let(:requestor) { described_class.new(case_ccms_reference, document_id, document_encoded_base64, "my_login", "court_application_or_order_pdf") }
+
+          include_context "with ccms soa configuration"
+
+          it "generates the expected XML" do
+            allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
+            expect(requestor.formatted_xml).to be_soap_envelope_with(
+              command: "casebim:DocumentUploadRQ",
+              transaction_id: expected_tx_id,
+              matching: %w[
+                <casebio:DocumentType>COURT_ORD</casebio:DocumentType>
+                <casebio:FileExtension>pdf</casebio:FileExtension>
+              ],
+            )
+          end
+        end
+
+        context "when sent a benefit_evidence_pdf document" do
+          let(:requestor) { described_class.new(case_ccms_reference, document_id, document_encoded_base64, "my_login", "benefit_evidence_pdf") }
+
+          include_context "with ccms soa configuration"
+
+          it "generates the expected XML" do
+            allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
+            expect(requestor.formatted_xml).to be_soap_envelope_with(
+              command: "casebim:DocumentUploadRQ",
+              transaction_id: expected_tx_id,
+              matching: %w[
+                <casebio:DocumentType>BEN_LTR</casebio:DocumentType>
+                <casebio:FileExtension>pdf</casebio:FileExtension>
+              ],
+            )
+          end
+        end
+
+        context "when sent a statement of case document" do
+          let(:requestor) { described_class.new(case_ccms_reference, document_id, document_encoded_base64, "my_login", "statement_of_case_pdf") }
+
+          include_context "with ccms soa configuration"
+
+          it "generates the expected XML" do
+            allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
+            expect(requestor.formatted_xml).to be_soap_envelope_with(
+              command: "casebim:DocumentUploadRQ",
+              transaction_id: expected_tx_id,
+              matching: %w[
+                <casebio:DocumentType>STATE</casebio:DocumentType>
                 <casebio:FileExtension>pdf</casebio:FileExtension>
               ],
             )

--- a/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
@@ -135,14 +135,16 @@ module CCMS
               )
             end
 
-            it "creates three documents as ADMIN1, one as STATE and one as BSTMT" do
+            it "creates two documents as ADMIN1, one as STATE, one as BSTMT, and one as EX_RPT" do
               instance.call
               admin1_documents = SubmissionHistory.where(submission_id: submission.id).map(&:request).map { |x| x.scan("ADMIN1") }.flatten.count
               state_documents = SubmissionHistory.where(submission_id: submission.id).map(&:request).map { |x| x.scan("STATE") }.flatten.count
               bstmt_documents = SubmissionHistory.where(submission_id: submission.id).map(&:request).map { |x| x.scan("BSTMT") }.flatten.count
-              expect(admin1_documents).to eq 3
+              expert_documents = SubmissionHistory.where(submission_id: submission.id).map(&:request).map { |x| x.scan("EX_RPT") }.flatten.count
+              expect(admin1_documents).to eq 2
               expect(state_documents).to eq 1
               expect(bstmt_documents).to eq 1
+              expect(expert_documents).to eq 1
             end
 
             it "writes the response body to the history record" do

--- a/spec/services/required_document_category_analyser_spec.rb
+++ b/spec/services/required_document_category_analyser_spec.rb
@@ -73,9 +73,9 @@ RSpec.describe RequiredDocumentCategoryAnalyser do
     context "when the provider has entered employment details for the partner" do
       let(:application) { create(:legal_aid_application, :with_applicant, :with_employed_partner_and_extra_info) }
 
-      it "updates the required_document_categories with partner_employment_evidence" do
+      it "updates the required_document_categories with part_employ_evidence" do
         call
-        expect(application.required_document_categories).to eq %w[partner_employment_evidence]
+        expect(application.required_document_categories).to eq %w[part_employ_evidence]
       end
     end
 

--- a/spec/validators/document_category_validator_spec.rb
+++ b/spec/validators/document_category_validator_spec.rb
@@ -7,6 +7,15 @@ class DummyDocumentCategory
 end
 
 RSpec.describe DocumentCategoryValidator do
+  describe "VALID_DOCUMENT_TYPE length" do
+    it "has 30 characters or fewer to be valid" do
+      doc_types = DocumentCategoryValidator::VALID_DOCUMENT_TYPES
+                    .index_with(&:length)
+                    .reject { |_k, v| v <= 30 }
+      expect(doc_types).to be_empty
+    end
+  end
+
   context "with Attachment" do
     subject(:document_category_validator) { Attachment.create! legal_aid_application: laa, attachment_type: }
 


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5141)

The default file names for partner uploads were too long to send, via SOA, into CCMS

This PR shortens the file names

### Pro 
Should work!

### Con
New names are less understandable

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
