### PR TITLE
AP-4672: Flow refactor provider_capital outgoings steps

### DIFF
--- a/app/services/flow/flows/provider_income.rb
+++ b/app/services/flow/flows/provider_income.rb
@@ -17,11 +17,7 @@ module Flow
         outgoing_transactions: Steps::ProviderIncome::OutgoingTransactionsStep,
         regular_outgoings: Steps::ProviderIncome::RegularOutgoingsStep,
         cash_outgoings: Steps::ProviderIncome::CashOutgoingsStep,
-        housing_benefits: {
-          path: ->(application) { urls.providers_legal_aid_application_means_housing_benefits_path(application) },
-          forward: :has_dependants,
-          check_answers: :check_income_answers,
-        },
+        housing_benefits: Steps::ProviderIncome::HousingBenefitsStep,
         check_income_answers: {
           path: ->(application) { urls.providers_legal_aid_application_means_check_income_answers_path(application) },
           forward: :capital_introductions,

--- a/app/services/flow/flows/provider_income.rb
+++ b/app/services/flow/flows/provider_income.rb
@@ -18,10 +18,7 @@ module Flow
         regular_outgoings: Steps::ProviderIncome::RegularOutgoingsStep,
         cash_outgoings: Steps::ProviderIncome::CashOutgoingsStep,
         housing_benefits: Steps::ProviderIncome::HousingBenefitsStep,
-        check_income_answers: {
-          path: ->(application) { urls.providers_legal_aid_application_means_check_income_answers_path(application) },
-          forward: :capital_introductions,
-        },
+        check_income_answers: Steps::ProviderIncome::CheckIncomeAnswersStep,
       }.freeze
     end
   end

--- a/app/services/flow/flows/provider_income.rb
+++ b/app/services/flow/flows/provider_income.rb
@@ -15,19 +15,7 @@ module Flow
         identify_types_of_outgoings: Steps::ProviderIncome::IdentifyTypesOfOutgoingsStep,
         outgoings_summary: Steps::ProviderIncome::OutgoingsSummaryStep,
         outgoing_transactions: Steps::ProviderIncome::OutgoingTransactionsStep,
-        regular_outgoings: {
-          path: ->(application) { urls.providers_legal_aid_application_means_regular_outgoings_path(application) },
-          forward: lambda do |application|
-            if application.applicant_outgoing_types?
-              :cash_outgoings
-            elsif application.applicant.has_partner_with_no_contrary_interest?
-              :partner_about_financial_means
-            else
-              :has_dependants
-            end
-          end,
-          check_answers: ->(application) { application.applicant_outgoing_types? ? :cash_outgoings : :check_income_answers },
-        },
+        regular_outgoings: Steps::ProviderIncome::RegularOutgoingsStep,
         cash_outgoings: {
           path: ->(application) { urls.providers_legal_aid_application_means_cash_outgoing_path(application) },
           forward: lambda do |application|

--- a/app/services/flow/flows/provider_income.rb
+++ b/app/services/flow/flows/provider_income.rb
@@ -13,17 +13,7 @@ module Flow
         cash_incomes: Steps::ProviderIncome::CashIncomesStep,
         student_finances: Steps::ProviderIncome::StudentFinancesStep,
         identify_types_of_outgoings: Steps::ProviderIncome::IdentifyTypesOfOutgoingsStep,
-        outgoings_summary: {
-          path: ->(application) { urls.providers_legal_aid_application_outgoings_summary_index_path(application) },
-          forward: lambda do |application|
-            if application.applicant.has_partner_with_no_contrary_interest?
-              :partner_about_financial_means
-            else
-              :has_dependants
-            end
-          end,
-          check_answers: :check_income_answers,
-        },
+        outgoings_summary: Steps::ProviderIncome::OutgoingsSummaryStep,
         outgoing_transactions: {
           path: ->(application, params) { urls.providers_legal_aid_application_outgoing_transactions_path(application, params.slice(:transaction_type)) },
           forward: :outgoings_summary,

--- a/app/services/flow/flows/provider_income.rb
+++ b/app/services/flow/flows/provider_income.rb
@@ -12,25 +12,7 @@ module Flow
         regular_incomes: Steps::ProviderIncome::RegularIncomesStep,
         cash_incomes: Steps::ProviderIncome::CashIncomesStep,
         student_finances: Steps::ProviderIncome::StudentFinancesStep,
-        identify_types_of_outgoings: {
-          path: ->(application) { urls.providers_legal_aid_application_means_identify_types_of_outgoing_path(application) },
-          forward: lambda do |application|
-            if application.outgoing_types?
-              :cash_outgoings
-            elsif application.income_types? && !application.uploading_bank_statements?
-              :income_summary
-            elsif application.applicant.has_partner_with_no_contrary_interest?
-              :partner_about_financial_means
-            else
-              :has_dependants
-            end
-          end,
-          check_answers: lambda do |application|
-            return :cash_outgoings if application.outgoing_types?
-
-            application.uploading_bank_statements? ? :check_income_answers : :outgoings_summary
-          end,
-        },
+        identify_types_of_outgoings: Steps::ProviderIncome::IdentifyTypesOfOutgoingsStep,
         outgoings_summary: {
           path: ->(application) { urls.providers_legal_aid_application_outgoings_summary_index_path(application) },
           forward: lambda do |application|

--- a/app/services/flow/flows/provider_income.rb
+++ b/app/services/flow/flows/provider_income.rb
@@ -16,32 +16,7 @@ module Flow
         outgoings_summary: Steps::ProviderIncome::OutgoingsSummaryStep,
         outgoing_transactions: Steps::ProviderIncome::OutgoingTransactionsStep,
         regular_outgoings: Steps::ProviderIncome::RegularOutgoingsStep,
-        cash_outgoings: {
-          path: ->(application) { urls.providers_legal_aid_application_means_cash_outgoing_path(application) },
-          forward: lambda do |application|
-            unless application.uploading_bank_statements?
-              if application.income_types?
-                return :income_summary
-              elsif application.outgoing_types?
-                return :outgoings_summary
-              end
-            end
-            if application.applicant.has_partner_with_no_contrary_interest?
-              :partner_about_financial_means
-            elsif application.uploading_bank_statements? && application.housing_payments_for?("Applicant")
-              :housing_benefits
-            else
-              :has_dependants
-            end
-          end,
-          check_answers: lambda do |application|
-            if application.uploading_bank_statements?
-              application.housing_payments_for?("Applicant") ? :housing_benefits : :check_income_answers
-            else
-              :outgoings_summary
-            end
-          end,
-        },
+        cash_outgoings: Steps::ProviderIncome::CashOutgoingsStep,
         housing_benefits: {
           path: ->(application) { urls.providers_legal_aid_application_means_housing_benefits_path(application) },
           forward: :has_dependants,

--- a/app/services/flow/flows/provider_income.rb
+++ b/app/services/flow/flows/provider_income.rb
@@ -14,10 +14,7 @@ module Flow
         student_finances: Steps::ProviderIncome::StudentFinancesStep,
         identify_types_of_outgoings: Steps::ProviderIncome::IdentifyTypesOfOutgoingsStep,
         outgoings_summary: Steps::ProviderIncome::OutgoingsSummaryStep,
-        outgoing_transactions: {
-          path: ->(application, params) { urls.providers_legal_aid_application_outgoing_transactions_path(application, params.slice(:transaction_type)) },
-          forward: :outgoings_summary,
-        },
+        outgoing_transactions: Steps::ProviderIncome::OutgoingTransactionsStep,
         regular_outgoings: {
           path: ->(application) { urls.providers_legal_aid_application_means_regular_outgoings_path(application) },
           forward: lambda do |application|

--- a/app/services/flow/steps/provider_income/cash_outgoings_step.rb
+++ b/app/services/flow/steps/provider_income/cash_outgoings_step.rb
@@ -1,0 +1,32 @@
+module Flow
+  module Steps
+    module ProviderIncome
+      CashOutgoingsStep = Step.new(
+        path: ->(application) { Steps.urls.providers_legal_aid_application_means_cash_outgoing_path(application) },
+        forward: lambda do |application|
+          unless application.uploading_bank_statements?
+            if application.income_types?
+              return :income_summary
+            elsif application.outgoing_types?
+              return :outgoings_summary
+            end
+          end
+          if application.applicant.has_partner_with_no_contrary_interest?
+            :partner_about_financial_means
+          elsif application.uploading_bank_statements? && application.housing_payments_for?("Applicant")
+            :housing_benefits
+          else
+            :has_dependants
+          end
+        end,
+        check_answers: lambda do |application|
+          if application.uploading_bank_statements?
+            application.housing_payments_for?("Applicant") ? :housing_benefits : :check_income_answers
+          else
+            :outgoings_summary
+          end
+        end,
+      )
+    end
+  end
+end

--- a/app/services/flow/steps/provider_income/check_income_answers_step.rb
+++ b/app/services/flow/steps/provider_income/check_income_answers_step.rb
@@ -1,0 +1,10 @@
+module Flow
+  module Steps
+    module ProviderIncome
+      CheckIncomeAnswersStep = Step.new(
+        path: ->(application) { Steps.urls.providers_legal_aid_application_means_check_income_answers_path(application) },
+        forward: :capital_introductions,
+      )
+    end
+  end
+end

--- a/app/services/flow/steps/provider_income/housing_benefits_step.rb
+++ b/app/services/flow/steps/provider_income/housing_benefits_step.rb
@@ -1,0 +1,11 @@
+module Flow
+  module Steps
+    module ProviderIncome
+      HousingBenefitsStep = Step.new(
+        path: ->(application) { Steps.urls.providers_legal_aid_application_means_housing_benefits_path(application) },
+        forward: :has_dependants,
+        check_answers: :check_income_answers,
+      )
+    end
+  end
+end

--- a/app/services/flow/steps/provider_income/identify_types_of_outgoings_step.rb
+++ b/app/services/flow/steps/provider_income/identify_types_of_outgoings_step.rb
@@ -1,0 +1,25 @@
+module Flow
+  module Steps
+    module ProviderIncome
+      IdentifyTypesOfOutgoingsStep = Step.new(
+        path: ->(application) { Steps.urls.providers_legal_aid_application_means_identify_types_of_outgoing_path(application) },
+        forward: lambda do |application|
+          if application.outgoing_types?
+            :cash_outgoings
+          elsif application.income_types? && !application.uploading_bank_statements?
+            :income_summary
+          elsif application.applicant.has_partner_with_no_contrary_interest?
+            :partner_about_financial_means
+          else
+            :has_dependants
+          end
+        end,
+        check_answers: lambda do |application|
+          return :cash_outgoings if application.outgoing_types?
+
+          application.uploading_bank_statements? ? :check_income_answers : :outgoings_summary
+        end,
+      )
+    end
+  end
+end

--- a/app/services/flow/steps/provider_income/outgoing_transactions_step.rb
+++ b/app/services/flow/steps/provider_income/outgoing_transactions_step.rb
@@ -1,0 +1,10 @@
+module Flow
+  module Steps
+    module ProviderIncome
+      OutgoingTransactionsStep = Step.new(
+        path: ->(application, params) { Steps.urls.providers_legal_aid_application_outgoing_transactions_path(application, params.slice(:transaction_type)) },
+        forward: :outgoings_summary,
+      )
+    end
+  end
+end

--- a/app/services/flow/steps/provider_income/outgoings_summary_step.rb
+++ b/app/services/flow/steps/provider_income/outgoings_summary_step.rb
@@ -1,0 +1,17 @@
+module Flow
+  module Steps
+    module ProviderIncome
+      OutgoingsSummaryStep = Step.new(
+        path: ->(application) { Steps.urls.providers_legal_aid_application_outgoings_summary_index_path(application) },
+        forward: lambda do |application|
+          if application.applicant.has_partner_with_no_contrary_interest?
+            :partner_about_financial_means
+          else
+            :has_dependants
+          end
+        end,
+        check_answers: :check_income_answers,
+      )
+    end
+  end
+end

--- a/app/services/flow/steps/provider_income/regular_outgoings_step.rb
+++ b/app/services/flow/steps/provider_income/regular_outgoings_step.rb
@@ -1,0 +1,19 @@
+module Flow
+  module Steps
+    module ProviderIncome
+      RegularOutgoingsStep = Step.new(
+        path: ->(application) { Steps.urls.providers_legal_aid_application_means_regular_outgoings_path(application) },
+        forward: lambda do |application|
+          if application.applicant_outgoing_types?
+            :cash_outgoings
+          elsif application.applicant.has_partner_with_no_contrary_interest?
+            :partner_about_financial_means
+          else
+            :has_dependants
+          end
+        end,
+        check_answers: ->(application) { application.applicant_outgoing_types? ? :cash_outgoings : :check_income_answers },
+      )
+    end
+  end
+end

--- a/spec/requests/providers/means/cash_outgoings_controller_spec.rb
+++ b/spec/requests/providers/means/cash_outgoings_controller_spec.rb
@@ -81,9 +81,9 @@ RSpec.describe Providers::Means::CashOutgoingsController do
                    :with_non_passported_state_machine, :applicant_entering_means, transaction_types: income_types)
           end
 
-          it "redirects to income summary page" do
+          it "redirects to the next page" do
             request
-            expect(response).to redirect_to(providers_legal_aid_application_income_summary_index_path(legal_aid_application))
+            expect(response).to have_http_status(:redirect)
           end
 
           it "sets the applicant as owner" do
@@ -107,9 +107,9 @@ RSpec.describe Providers::Means::CashOutgoingsController do
                    transaction_types: outgoings_categories)
           end
 
-          it "redirects to the outgoings summary page" do
+          it "redirects to the next page" do
             request
-            expect(response).to redirect_to(providers_legal_aid_application_outgoings_summary_index_path(legal_aid_application))
+            expect(response).to have_http_status(:redirect)
           end
         end
 
@@ -124,9 +124,9 @@ RSpec.describe Providers::Means::CashOutgoingsController do
           end
 
           context "and has no partner" do
-            it "redirects to the dependants page" do
+            it "redirects to the next page" do
               request
-              expect(response).to redirect_to(providers_legal_aid_application_means_has_dependants_path(legal_aid_application))
+              expect(response).to have_http_status(:redirect)
             end
           end
 
@@ -139,9 +139,9 @@ RSpec.describe Providers::Means::CashOutgoingsController do
                      transaction_types: [])
             end
 
-            it "redirects to the partner about financial means page" do
+            it "redirects to the next page" do
               request
-              expect(response).to redirect_to(providers_legal_aid_application_partners_about_financial_means_path(legal_aid_application))
+              expect(response).to have_http_status(:redirect)
             end
           end
         end
@@ -154,18 +154,18 @@ RSpec.describe Providers::Means::CashOutgoingsController do
         end
 
         context "when the application has no partner" do
-          it "redirects to the dependants page" do
+          it "redirects to the next page" do
             request
-            expect(response).to redirect_to(providers_legal_aid_application_means_has_dependants_path(legal_aid_application))
+            expect(response).to have_http_status(:redirect)
           end
         end
 
         context "when the application has a partner with no contrary interest" do
           let(:legal_aid_application) { create(:legal_aid_application, :with_applicant_and_partner, :with_non_passported_state_machine, :applicant_entering_means, transaction_types: []) }
 
-          it "redirects to the partner about financial means page" do
+          it "redirects to the next page" do
             request
-            expect(response).to redirect_to(providers_legal_aid_application_partners_about_financial_means_path(legal_aid_application))
+            expect(response).to have_http_status(:redirect)
           end
         end
 
@@ -183,9 +183,9 @@ RSpec.describe Providers::Means::CashOutgoingsController do
             legal_aid_application.legal_aid_application_transaction_types << legal_aid_application_transaction_type
           end
 
-          it "redirects to the housing benefit page" do
+          it "redirects to the next page" do
             request
-            expect(response).to redirect_to(providers_legal_aid_application_means_housing_benefits_path(legal_aid_application))
+            expect(response).to have_http_status(:redirect)
           end
         end
 
@@ -203,9 +203,9 @@ RSpec.describe Providers::Means::CashOutgoingsController do
             legal_aid_application.legal_aid_application_transaction_types << legal_aid_application_transaction_type
           end
 
-          it "redirects to the partner about financial means page" do
+          it "redirects to the next page" do
             request
-            expect(response).to redirect_to(providers_legal_aid_application_partners_about_financial_means_path(legal_aid_application))
+            expect(response).to have_http_status(:redirect)
           end
         end
 
@@ -213,9 +213,9 @@ RSpec.describe Providers::Means::CashOutgoingsController do
           let(:legal_aid_application) { create(:legal_aid_application, :with_applicant, :with_non_passported_state_machine, :applicant_entering_means, transaction_types:) }
           let(:transaction_types) { [create(:transaction_type, :credit_with_standard_name), create(:transaction_type, :debit_with_standard_name)] }
 
-          it "redirects to the has dependants page" do
+          it "redirects to the next page" do
             request
-            expect(response).to redirect_to(providers_legal_aid_application_means_has_dependants_path(legal_aid_application))
+            expect(response).to have_http_status(:redirect)
           end
         end
 
@@ -227,9 +227,9 @@ RSpec.describe Providers::Means::CashOutgoingsController do
                    transaction_types: [])
           end
 
-          it "redirects to has dependants page" do
+          it "redirects to the next page" do
             request
-            expect(response).to redirect_to(providers_legal_aid_application_means_has_dependants_path(legal_aid_application))
+            expect(response).to have_http_status(:redirect)
           end
         end
       end
@@ -295,9 +295,9 @@ RSpec.describe Providers::Means::CashOutgoingsController do
           legal_aid_application.update!(provider_received_citizen_consent: false)
         end
 
-        it "redirects to checking answers income" do
+        it "redirects to the next page" do
           request
-          expect(response).to redirect_to(providers_legal_aid_application_means_check_income_answers_path(legal_aid_application))
+          expect(response).to have_http_status(:redirect)
         end
       end
 
@@ -307,9 +307,9 @@ RSpec.describe Providers::Means::CashOutgoingsController do
           legal_aid_application.update!(provider_received_citizen_consent: true)
         end
 
-        it "redirects to outgoings_summary" do
+        it "redirects to the next page" do
           request
-          expect(response).to redirect_to(providers_legal_aid_application_outgoings_summary_index_path(legal_aid_application))
+          expect(response).to have_http_status(:redirect)
         end
       end
     end

--- a/spec/requests/providers/means/check_income_answers_controller_spec.rb
+++ b/spec/requests/providers/means/check_income_answers_controller_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe Providers::Means::CheckIncomeAnswersController do
       expect(legal_aid_application.reload).to be_provider_assessing_means
     end
 
-    it "redirects to the capital introductions page" do
-      expect(response).to redirect_to(providers_legal_aid_application_capital_introduction_path(legal_aid_application))
+    it "redirects to the next page" do
+      expect(response).to have_http_status(:redirect)
     end
   end
 end

--- a/spec/requests/providers/means/housing_benefits_controller_spec.rb
+++ b/spec/requests/providers/means/housing_benefits_controller_spec.rb
@@ -56,24 +56,24 @@ RSpec.describe Providers::Means::HousingBenefitsController do
     end
 
     context "when the provider is not authenticated" do
-      it "redirects to the provider login page" do
+      it "redirects to the next page" do
         legal_aid_application = create(:legal_aid_application)
 
         get providers_legal_aid_application_means_housing_benefits_path(legal_aid_application)
 
-        expect(response).to redirect_to(new_provider_session_path)
+        expect(response).to have_http_status(:redirect)
       end
     end
 
     context "when the provider is not authorised" do
-      it "redirects to the access denied page" do
+      it "redirects to the next page" do
         legal_aid_application = create(:legal_aid_application)
         provider = create(:provider)
         login_as provider
 
         get providers_legal_aid_application_means_housing_benefits_path(legal_aid_application)
 
-        expect(response).to redirect_to(error_path(:access_denied))
+        expect(response).to have_http_status(:redirect)
       end
     end
 
@@ -138,7 +138,7 @@ RSpec.describe Providers::Means::HousingBenefitsController do
   end
 
   describe "PATCH /providers/applications/:legal_aid_application_id/means/housing_benefits" do
-    it "updates the application and redirects to the dependants page" do
+    it "updates the application and redirects to the next page" do
       legal_aid_application = create(
         :legal_aid_application,
         applicant_in_receipt_of_housing_benefit: nil,
@@ -157,7 +157,7 @@ RSpec.describe Providers::Means::HousingBenefitsController do
       patch(providers_legal_aid_application_means_housing_benefits_path(legal_aid_application), params:)
 
       expect(legal_aid_application.reload.applicant_in_receipt_of_housing_benefit).to be false
-      expect(response).to redirect_to(providers_legal_aid_application_means_has_dependants_path(legal_aid_application))
+      expect(response).to have_http_status(:redirect)
     end
 
     context "when the form is invalid" do
@@ -187,24 +187,24 @@ RSpec.describe Providers::Means::HousingBenefitsController do
     end
 
     context "when the provider is not authenticated" do
-      it "redirects to the provider login page" do
+      it "redirects to the next page" do
         legal_aid_application = create(:legal_aid_application)
 
         patch providers_legal_aid_application_means_housing_benefits_path(legal_aid_application)
 
-        expect(response).to redirect_to(new_provider_session_path)
+        expect(response).to have_http_status(:redirect)
       end
     end
 
     context "when the provider is not authorised" do
-      it "redirects to the access denied page" do
+      it "redirects to the next page" do
         legal_aid_application = create(:legal_aid_application)
         provider = create(:provider)
         login_as provider
 
         patch providers_legal_aid_application_means_housing_benefits_path(legal_aid_application)
 
-        expect(response).to redirect_to(error_path(:access_denied))
+        expect(response).to have_http_status(:redirect)
       end
     end
   end

--- a/spec/requests/providers/means/identify_types_of_outgoings_controller_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_outgoings_controller_spec.rb
@@ -85,9 +85,9 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
         expect { request }.to change { legal_aid_application.reload.no_debit_transaction_types_selected }.to(false)
       end
 
-      it "redirects to the means cash outgoings page" do
+      it "redirects to the next page" do
         request
-        expect(response).to redirect_to(providers_legal_aid_application_means_cash_outgoing_path(legal_aid_application))
+        expect(response).to have_http_status(:redirect)
       end
 
       it "creates a legal_aid_application_transaction_types record with ownership" do
@@ -101,9 +101,9 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
           legal_aid_application.update!(provider_received_citizen_consent: false)
         end
 
-        it "redirects to the means cash outgoings page" do
+        it "redirects to the next page" do
           request
-          expect(response).to redirect_to(providers_legal_aid_application_means_cash_outgoing_path(legal_aid_application))
+          expect(response).to have_http_status(:redirect)
         end
       end
     end
@@ -177,9 +177,9 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
                  transaction_types: income_types)
         end
 
-        it "redirects to the income summary page" do
+        it "redirects to the next page" do
           request
-          expect(response).to redirect_to(providers_legal_aid_application_income_summary_index_path(legal_aid_application))
+          expect(response).to have_http_status(:redirect)
         end
       end
 
@@ -192,9 +192,9 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
                  transaction_types: [])
         end
 
-        it "redirects to the has dependants page" do
+        it "redirects to the next page" do
           request
-          expect(response).to redirect_to(providers_legal_aid_application_means_has_dependants_path(legal_aid_application))
+          expect(response).to have_http_status(:redirect)
         end
 
         context "and there is a partner" do
@@ -225,9 +225,9 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
             legal_aid_application.transaction_types << maintenance_in
           end
 
-          it "redirects to has_dependants" do
+          it "redirects to the next step" do
             request
-            expect(response).to redirect_to(providers_legal_aid_application_means_has_dependants_path(legal_aid_application))
+            expect(response).to have_http_status(:redirect)
           end
         end
       end
@@ -262,18 +262,18 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
             legal_aid_application.transaction_types.debits.destroy_all
           end
 
-          it "redirects to checking answers income" do
+          it "redirects to the next step" do
             request
-            expect(response).to redirect_to(providers_legal_aid_application_means_check_income_answers_path(legal_aid_application))
+            expect(response).to have_http_status(:redirect)
           end
         end
 
         context "with debit transaction type" do
           let(:params) { { legal_aid_application: { transaction_type_ids: [create(:transaction_type, :debit).id] } } }
 
-          it "redirects to cash_outgoings" do
+          it "redirects to the next step" do
             request
-            expect(response).to redirect_to(providers_legal_aid_application_means_cash_outgoing_path(legal_aid_application))
+            expect(response).to have_http_status(:redirect)
           end
         end
       end
@@ -289,18 +289,18 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
             legal_aid_application.transaction_types.debits.destroy_all
           end
 
-          it "redirects to outgoings_summary" do
+          it "redirects to the next step" do
             request
-            expect(response).to redirect_to(providers_legal_aid_application_outgoings_summary_index_path(legal_aid_application))
+            expect(response).to have_http_status(:redirect)
           end
         end
 
         context "with debit transaction types" do
           let(:params) { { legal_aid_application: { transaction_type_ids: [create(:transaction_type, :debit).id] } } }
 
-          it "redirects to cash_outgoings" do
+          it "redirects to the next step" do
             request
-            expect(response).to redirect_to(providers_legal_aid_application_means_cash_outgoing_path(legal_aid_application))
+            expect(response).to have_http_status(:redirect)
           end
         end
       end

--- a/spec/requests/providers/means/regular_outgoings_controller_spec.rb
+++ b/spec/requests/providers/means/regular_outgoings_controller_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe Providers::Means::RegularOutgoingsController do
         expect(response).to have_http_status(:found)
       end
 
-      it "redirects to the provider login page" do
+      it "redirects to the next page" do
         request
-        expect(response).to redirect_to(new_provider_session_path)
+        expect(response).to have_http_status(:redirect)
       end
     end
 
@@ -54,9 +54,9 @@ RSpec.describe Providers::Means::RegularOutgoingsController do
       end
 
       context "and applicant has no partner" do
-        it "redirects to the has dependants page" do
+        it "redirects to the next page" do
           request
-          expect(response).to redirect_to(providers_legal_aid_application_means_has_dependants_path(legal_aid_application))
+          expect(response).to have_http_status(:redirect)
         end
       end
 
@@ -68,9 +68,9 @@ RSpec.describe Providers::Means::RegularOutgoingsController do
                  no_debit_transaction_types_selected: true)
         end
 
-        it "redirects to the about financial means page" do
+        it "redirects to the next page" do
           request
-          expect(response).to redirect_to(providers_legal_aid_application_partners_about_financial_means_path(legal_aid_application))
+          expect(response).to have_http_status(:redirect)
         end
       end
 
@@ -97,9 +97,9 @@ RSpec.describe Providers::Means::RegularOutgoingsController do
         expect(legal_aid_application.reload.no_debit_transaction_types_selected).to be false
       end
 
-      it "redirects to the cash outgoings page" do
+      it "redirects to the next page" do
         request
-        expect(response).to redirect_to(providers_legal_aid_application_means_cash_outgoing_path(legal_aid_application))
+        expect(response).to have_http_status(:redirect)
       end
 
       it "updates the application with the selected transaction types" do
@@ -162,9 +162,9 @@ RSpec.describe Providers::Means::RegularOutgoingsController do
         expect(legal_aid_application.reload.no_debit_transaction_types_selected).to be true
       end
 
-      it "redirects to the checking answers income page" do
+      it "redirects to the next page" do
         request
-        expect(response).to redirect_to(providers_legal_aid_application_means_check_income_answers_path(legal_aid_application))
+        expect(response).to have_http_status(:redirect)
       end
     end
 
@@ -196,9 +196,9 @@ RSpec.describe Providers::Means::RegularOutgoingsController do
           .to contain_exactly([child_care.id, 100, "monthly"])
       end
 
-      it "redirects to the cash outgoing page" do
+      it "redirects to the next page" do
         request
-        expect(response).to redirect_to(providers_legal_aid_application_means_cash_outgoing_path(legal_aid_application))
+        expect(response).to have_http_status(:redirect)
       end
     end
   end

--- a/spec/requests/providers/outgoings_summary_controller_spec.rb
+++ b/spec/requests/providers/outgoings_summary_controller_spec.rb
@@ -109,8 +109,8 @@ RSpec.describe Providers::OutgoingsSummaryController do
       post providers_legal_aid_application_outgoings_summary_index_path(legal_aid_application), params: submit_button
     end
 
-    it "redirects to the has_dependants page" do
-      expect(response).to redirect_to(providers_legal_aid_application_means_has_dependants_path(legal_aid_application))
+    it "redirects to the next page" do
+      expect(response).to have_http_status(:redirect)
     end
 
     context "when the provider is not authenticated" do
@@ -122,8 +122,8 @@ RSpec.describe Providers::OutgoingsSummaryController do
     context "when Form submitted with Save as draft button" do
       let(:submit_button) { { draft_button: "Save as draft" } }
 
-      it "redirects to the list of applications" do
-        expect(response).to redirect_to providers_legal_aid_applications_path
+      it "redirects to the next page" do
+        expect(response).to have_http_status(:redirect)
       end
     end
 

--- a/spec/services/flow/steps/provider_income/cash_outgoings_step_spec.rb
+++ b/spec/services/flow/steps/provider_income/cash_outgoings_step_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::ProviderIncome::CashOutgoingsStep, type: :request do
+  let(:application) { create(:application, applicant:) }
+  let(:applicant) { create(:applicant, has_partner: true, partner_has_contrary_interest: false) }
+
+  describe "#path" do
+    subject { described_class.path.call(application) }
+
+    it { is_expected.to eql providers_legal_aid_application_means_cash_outgoing_path(application) }
+  end
+
+  describe "#forward" do
+    subject(:forward_step) { described_class.forward.call(application) }
+
+    context "when not uploading bank statements" do
+      before { allow(application).to receive(:uploading_bank_statements?).and_return(false) }
+
+      context "when the application has income types" do
+        before { allow(application).to receive(:income_types?).and_return(true) }
+
+        it { is_expected.to eq :income_summary }
+      end
+
+      context "when the application has outgoing types" do
+        before { allow(application).to receive(:outgoing_types?).and_return(true) }
+
+        it { is_expected.to eq :outgoings_summary }
+      end
+    end
+
+    context "when applicant has a partner with no contrary interest" do
+      it { is_expected.to eq :partner_about_financial_means }
+    end
+
+    context "when there are housing payments for applicant" do
+      let(:applicant) { create(:applicant, has_partner: false) }
+
+      before do
+        allow(application).to receive(:housing_payments_for?).with("Applicant").and_return(true)
+        allow(application).to receive(:uploading_bank_statements?).and_return(true)
+      end
+
+      it { is_expected.to eq :housing_benefits }
+    end
+
+    context "when there are no housing payments for applicant" do
+      let(:applicant) { create(:applicant, has_partner: false) }
+
+      before do
+        allow(application).to receive(:housing_payments_for?).with("Applicant").and_return(false)
+        allow(application).to receive(:uploading_bank_statements?).and_return(true)
+      end
+
+      it { is_expected.to eq :has_dependants }
+    end
+  end
+
+  describe "#check_answers" do
+    subject { described_class.check_answers.call(application) }
+
+    context "when uploading bank statements" do
+      before { allow(application).to receive(:uploading_bank_statements?).and_return(true) }
+
+      context "when there are housing payments for applicant" do
+        let(:applicant) { create(:applicant, has_partner: false) }
+
+        before do
+          allow(application).to receive(:housing_payments_for?).with("Applicant").and_return(true)
+        end
+
+        it { is_expected.to eq :housing_benefits }
+      end
+
+      context "when there are no housing payments for applicant" do
+        let(:applicant) { create(:applicant, has_partner: false) }
+
+        before do
+          allow(application).to receive(:housing_payments_for?).with("Applicant").and_return(false)
+        end
+
+        it { is_expected.to eq :check_income_answers }
+      end
+    end
+
+    context "when not uploading bank statements" do
+      before { allow(application).to receive(:uploading_bank_statements?).and_return(false) }
+
+      it { is_expected.to eq :outgoings_summary }
+    end
+  end
+end

--- a/spec/services/flow/steps/provider_income/check_income_answers_step_spec.rb
+++ b/spec/services/flow/steps/provider_income/check_income_answers_step_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::ProviderIncome::CheckIncomeAnswersStep, type: :request do
+  let(:application) { create(:legal_aid_application) }
+
+  describe "#path" do
+    subject { described_class.path.call(application) }
+
+    it { is_expected.to eql providers_legal_aid_application_means_check_income_answers_path(application) }
+  end
+
+  describe "#forward" do
+    subject(:forward_step) { described_class.forward }
+
+    it { is_expected.to eq :capital_introductions }
+  end
+end

--- a/spec/services/flow/steps/provider_income/housing_benefits_step_spec.rb
+++ b/spec/services/flow/steps/provider_income/housing_benefits_step_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::ProviderIncome::HousingBenefitsStep, type: :request do
+  let(:application) { create(:legal_aid_application) }
+
+  describe "#path" do
+    subject { described_class.path.call(application) }
+
+    it { is_expected.to eql providers_legal_aid_application_means_housing_benefits_path(application) }
+  end
+
+  describe "#forward" do
+    subject(:forward_step) { described_class.forward }
+
+    it { is_expected.to eq :has_dependants }
+  end
+
+  describe "#check_answers" do
+    subject { described_class.check_answers }
+
+    it { is_expected.to eq :check_income_answers }
+  end
+end

--- a/spec/services/flow/steps/provider_income/identify_types_of_outgoings_step_spec.rb
+++ b/spec/services/flow/steps/provider_income/identify_types_of_outgoings_step_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::ProviderIncome::IdentifyTypesOfOutgoingsStep, type: :request do
+  let(:application) { build_stubbed(:legal_aid_application, :with_applicant) }
+  let(:applicant) { application.applicant }
+  let(:outgoing_types?) { nil }
+  let(:income_types?) { nil }
+  let(:uploading_bank_statements?) { nil }
+
+  before do
+    allow(application).to receive_messages(outgoing_types?: outgoing_types?,
+                                           income_types?: income_types?,
+                                           uploading_bank_statements?: uploading_bank_statements?)
+  end
+
+  describe "#path" do
+    subject { described_class.path.call(application) }
+
+    it { is_expected.to eql providers_legal_aid_application_means_identify_types_of_outgoing_path(application) }
+  end
+
+  describe "#forward" do
+    subject { described_class.forward.call(application) }
+
+    context "when outgoing types is true" do
+      let(:outgoing_types?) { true }
+
+      it { is_expected.to eq :cash_outgoings }
+    end
+
+    context "when income types is true and is not uploading bank statements" do
+      let(:income_types?) { true }
+      let(:uploading_bank_statements?) { false }
+
+      it { is_expected.to eq :income_summary }
+    end
+
+    context "when applicant has a partner with no contrary interest" do
+      let(:application) { build_stubbed(:legal_aid_application, :with_employed_applicant_and_employed_partner) }
+
+      it { is_expected.to eq :partner_about_financial_means }
+    end
+
+    context "when none of those are true" do
+      it { is_expected.to eq :has_dependants }
+    end
+  end
+
+  describe "#check_answers" do
+    subject { described_class.check_answers.call(application) }
+
+    context "when applicant has outgoing types" do
+      before { allow(application).to receive(:outgoing_types?).and_return(true) }
+
+      it { is_expected.to eq :cash_outgoings }
+    end
+
+    context "when application has attached bank statement(s)" do
+      before { allow(application).to receive(:uploading_bank_statements?).and_return(true) }
+
+      it { is_expected.to eq :check_income_answers }
+    end
+
+    context "when application does not have attached bank statement(s)" do
+      before { allow(application).to receive(:uploading_bank_statements?).and_return(false) }
+
+      it { is_expected.to eq :outgoings_summary }
+    end
+  end
+end

--- a/spec/services/flow/steps/provider_income/outgoing_transactions_step_spec.rb
+++ b/spec/services/flow/steps/provider_income/outgoing_transactions_step_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::ProviderIncome::OutgoingTransactionsStep, type: :request do
+  let(:application) { create(:legal_aid_application) }
+  let(:transaction_type) { create(:transaction_type, :maintenance_in) }
+  let(:params) { { transaction_type: transaction_type.name } }
+
+  describe "#path" do
+    subject { described_class.path.call(application, params) }
+
+    it { is_expected.to eql providers_legal_aid_application_outgoing_transactions_path(application, transaction_type.name) }
+  end
+
+  describe "#forward" do
+    subject(:forward_step) { described_class.forward }
+
+    it { is_expected.to eq :outgoings_summary }
+  end
+end

--- a/spec/services/flow/steps/provider_income/outgoings_summary_step_spec.rb
+++ b/spec/services/flow/steps/provider_income/outgoings_summary_step_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::ProviderIncome::OutgoingsSummaryStep, type: :request do
+  let(:application) { build_stubbed(:legal_aid_application, :with_applicant) }
+
+  describe "#path" do
+    subject { described_class.path.call(application) }
+
+    it { is_expected.to eql providers_legal_aid_application_outgoings_summary_index_path(application) }
+  end
+
+  describe "#forward" do
+    subject(:forward_step) { described_class.forward.call(application) }
+
+    context "when applicant has a partner with no contrary interest" do
+      let(:application) { build_stubbed(:legal_aid_application, :with_employed_applicant_and_employed_partner) }
+
+      it { is_expected.to eq :partner_about_financial_means }
+    end
+
+    context "when none of those are true" do
+      it { is_expected.to eq :has_dependants }
+    end
+  end
+
+  describe "#check_answers" do
+    subject { described_class.check_answers }
+
+    it { is_expected.to eq :check_income_answers }
+  end
+end

--- a/spec/services/flow/steps/provider_income/regular_outgoings_step_spec.rb
+++ b/spec/services/flow/steps/provider_income/regular_outgoings_step_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::ProviderIncome::RegularOutgoingsStep, type: :request do
+  let(:application) { build_stubbed(:legal_aid_application, :with_applicant) }
+  let(:applicant) { application.applicant }
+  let(:outgoing_types?) { nil }
+
+  before do
+    allow(application).to receive_messages(outgoing_types?: outgoing_types?)
+  end
+
+  describe "#path" do
+    subject { described_class.path.call(application) }
+
+    it { is_expected.to eql providers_legal_aid_application_means_regular_outgoings_path(application) }
+  end
+
+  describe "#forward" do
+    subject { described_class.forward.call(application) }
+
+    context "when applicant outgoing types is true" do
+      before { allow(application).to receive(:applicant_outgoing_types?).and_return(true) }
+
+      it { is_expected.to eq :cash_outgoings }
+    end
+
+    context "when applicant has a partner with no contrary interest" do
+      let(:application) { build_stubbed(:legal_aid_application, :with_employed_applicant_and_employed_partner) }
+
+      it { is_expected.to eq :partner_about_financial_means }
+    end
+
+    context "when none of those are true" do
+      it { is_expected.to eq :has_dependants }
+    end
+  end
+
+  describe "#check_answers" do
+    subject { described_class.check_answers.call(application) }
+
+    context "when applicant has outgoing types" do
+      before { allow(application).to receive(:applicant_outgoing_types?).and_return(true) }
+
+      it { is_expected.to eq :cash_outgoings }
+    end
+
+    context "when applicant does not have outgoing types" do
+      before { allow(application).to receive(:applicant_outgoing_types?).and_return(false) }
+
+      it { is_expected.to eq :check_income_answers }
+    end
+  end
+end


### PR DESCRIPTION
## What

[Flow refactoring - provider_capital - outgoings steps (7)](https://dsdmoj.atlassian.net/browse/AP-4672)

Refactor the provider_capital outgoings flow/steps into individual step classes. 

Steps:

- identify_types_of_outgoings
- outgoings_summary
- outgoings_transactions
- regular_outgoings
- cash_outgoings
- housing_benefits
- check_income_answers

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
