### PR TITLE
AP-4641: Add sca evidence upload

### DIFF
--- a/app/services/required_document_category_analyser.rb
+++ b/app/services/required_document_category_analyser.rb
@@ -23,6 +23,7 @@ class RequiredDocumentCategoryAnalyser
       required_document_categories << "court_application"
       required_document_categories << "expert_report"
     end
+    required_document_categories << "parental_responsibility" if has_parental_responsibility?
     @application.update!(required_document_categories:)
   end
 
@@ -38,5 +39,9 @@ private
 
   def has_opponents_application?
     @application.proceedings.any? { |proceeding| proceeding.opponents_application&.has_opponents_application }
+  end
+
+  def has_parental_responsibility?
+    @application.proceedings.any? { |proceeding| proceeding.relationship_to_child.in?(%w[court_order parental_responsibility_agreement]) }
   end
 end

--- a/app/validators/document_category_validator.rb
+++ b/app/validators/document_category_validator.rb
@@ -31,6 +31,8 @@ class DocumentCategoryValidator < ActiveModel::Validator
     court_application_or_order_pdf
     part_bank_state_evidence
     part_bank_state_evidence_pdf
+    parental_responsibility
+    parental_responsibility_pdf
   ].freeze
 
   def validate(record)

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -942,6 +942,7 @@ en:
               court_application_or_order_missing: Upload the application to court or the court order for Section 8 proceedings
               court_application_missing: Upload the application to court for Section 8 proceedings
               court_order_missing: Upload the court order for Section 8 proceedings
+              parental_responsibility_missing: Upload the evidence of your client's parental responsibility
               file_empty: The selected file is empty
               file_too_big: The selected file must be smaller than %{size}MB
               file_virus: "%{file_name} contains a virus"

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -811,6 +811,7 @@ en:
         court_order: the court order for Section 8 proceedings
         court_application_or_order: the application to court or court order for Section 8 proceedings
         expert_report: expert reports - for example, a CAFCASS report (optional)
+        parental_responsibility: evidence of your client's parental responsibility
         size_hint: The maximum file size is 7MB. Files must be a DOC, DOCX, RTF, ODT, JPG, BMP, PNG, TIF or PDF.
         dropzone_message: Drag and drop files here or
         choose_files_btn: Choose files

--- a/db/seeds/document_categories.csv
+++ b/db/seeds/document_categories.csv
@@ -24,3 +24,5 @@ court_application_or_order,FALSE,,TRUE,TRUE
 court_application_or_order_pdf,TRUE,ADMIN1,FALSE,FALSE
 part_bank_state_evidence,FALSE,,FALSE,FALSE
 part_bank_state_evidence_pdf,TRUE,BSTMT,FALSE,FALSE
+parental_responsibility,FALSE,,TRUE,TRUE
+parental_responsibility_pdf,TRUE,EX_RPT,FALSE,FALSE

--- a/spec/models/document_category_spec.rb
+++ b/spec/models/document_category_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe DocumentCategory do
         court_application
         court_order
         expert_report
+        parental_responsibility
       ]
     end
 
@@ -49,6 +50,7 @@ RSpec.describe DocumentCategory do
         court_order_pdf
         expert_report_pdf
         part_bank_state_evidence_pdf
+        parental_responsibility_pdf
       ]
     end
 

--- a/spec/services/required_document_category_analyser_spec.rb
+++ b/spec/services/required_document_category_analyser_spec.rb
@@ -105,5 +105,29 @@ RSpec.describe RequiredDocumentCategoryAnalyser do
         expect(application.required_document_categories).to match_array %w[court_application court_order expert_report]
       end
     end
+
+    context "when the application is SCA and the client has parental_responsibility" do
+      let(:application) { create(:legal_aid_application, :with_applicant) }
+
+      before { create(:proceeding, :pb003, relationship_to_child:, legal_aid_application: application) }
+
+      context "and have chosen parental responsibility" do
+        let(:relationship_to_child) { "parental_responsibility_agreement" }
+
+        it "updates the required_document_categories with parental_responsibility" do
+          call
+          expect(application.required_document_categories).to eq %w[parental_responsibility]
+        end
+      end
+
+      context "and has chosen court_order" do
+        let(:relationship_to_child) { "court_order" }
+
+        it "updates the required_document_categories with parental_responsibility" do
+          call
+          expect(application.required_document_categories).to eq %w[parental_responsibility]
+        end
+      end
+    end
   end
 end

--- a/spec/services/required_document_category_analyser_spec.rb
+++ b/spec/services/required_document_category_analyser_spec.rb
@@ -106,12 +106,12 @@ RSpec.describe RequiredDocumentCategoryAnalyser do
       end
     end
 
-    context "when the application is SCA and the client has parental_responsibility" do
+    context "when the application is SCA" do
       let(:application) { create(:legal_aid_application, :with_applicant) }
 
       before { create(:proceeding, :pb003, relationship_to_child:, legal_aid_application: application) }
 
-      context "and have chosen parental responsibility" do
+      context "and the client has parental responsibility" do
         let(:relationship_to_child) { "parental_responsibility_agreement" }
 
         it "updates the required_document_categories with parental_responsibility" do
@@ -120,12 +120,30 @@ RSpec.describe RequiredDocumentCategoryAnalyser do
         end
       end
 
-      context "and has chosen court_order" do
+      context "and the client has court_ordered responsibility" do
         let(:relationship_to_child) { "court_order" }
 
         it "updates the required_document_categories with parental_responsibility" do
           call
           expect(application.required_document_categories).to eq %w[parental_responsibility]
+        end
+      end
+
+      context "and the client is a biological parent" do
+        let(:relationship_to_child) { "biological" }
+
+        it "leaves the required_document_categories empty" do
+          call
+          expect(application.required_document_categories).to be_empty
+        end
+      end
+
+      context "and the client has no parental responsibility" do
+        let(:relationship_to_child) { nil }
+
+        it "leaves the required_document_categories empty" do
+          call
+          expect(application.required_document_categories).to be_empty
         end
       end
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4641)


This PR adds a new document type, `parental_responsibility`, and ensures it is added to the required_document list for the upload evidence page 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
