### PR TITLE
Chore: Reduce Sass deprecation warnings

### DIFF
--- a/app/assets/stylesheets/check-your-answers.scss
+++ b/app/assets/stylesheets/check-your-answers.scss
@@ -1,9 +1,9 @@
 // Recommended - Use these styles for the check your answers pattern
 
 .app-check-your-answers {
+  border-top: 1px solid $govuk-border-colour;
   @include govuk-font(19);
   @include govuk-responsive-margin(3, "bottom");
-  border-top: 1px solid $govuk-border-colour;
   @include govuk-responsive-padding(3, "top");
 
   .govuk-grid-row div:first-child {
@@ -12,9 +12,9 @@
 }
 
 .app-check-your-answers--long {
+  border-top: 1px solid $govuk-border-colour;
   @include govuk-font(19);
   @include govuk-responsive-margin(3, "bottom");
-  border-top: 1px solid $govuk-border-colour;
   @include govuk-responsive-padding(3, "top");
 
   .govuk-grid-row div:first-child {
@@ -42,12 +42,12 @@
 }
 
 .govuk-summary-list__total-row {
-  @include govuk-media-query($from: tablet) {
-    display: table-row;
-  }
   border-top: 3px solid #000000;
   border-bottom: 1px solid #000000;
   font-weight: bold;
+  @include govuk-media-query($from: tablet) {
+    display: table-row;
+  }
 }
 
 .govuk-summary-list__key {

--- a/app/assets/stylesheets/language-switcher.scss
+++ b/app/assets/stylesheets/language-switcher.scss
@@ -1,6 +1,6 @@
 .language-switcher {
-  @include govuk-font-size($size: 16);
   margin-top: govuk-spacing(3);
   margin-bottom: govuk-spacing(3);
   text-align: right;
+  @include govuk-font-size($size: 16);
 }

--- a/app/assets/stylesheets/sort-transactions.scss
+++ b/app/assets/stylesheets/sort-transactions.scss
@@ -14,8 +14,8 @@
 }
 
 .sort-transactions__items {
-  @include govuk-responsive-margin(9, "bottom");
   padding-left: 0;
+  @include govuk-responsive-margin(9, "bottom");
   @include govuk-media-query($from: tablet) {
     padding-left: govuk-spacing(6);
   }

--- a/app/assets/stylesheets/tables.scss
+++ b/app/assets/stylesheets/tables.scss
@@ -14,8 +14,8 @@
 }
 
 .govuk-table__footer--numeric {
-  @include govuk-font($size: false, $weight: "bold", $tabular: true);
   text-align: right;
+  @include govuk-font($size: false, $weight: "bold", $tabular: true);
 }
 
 .govuk-table__footer:last-child {


### PR DESCRIPTION
## What

This resequences the includes in line with the guidance from sass on [their website](https://sass-lang.com/documentation/breaking-changes/mixed-decls/)

No deprecation warnings are now outputted when running the `yarn build:css` command

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
