### PR TITLE
Fix code coverage: remove urls method from flow_steps class

### DIFF
--- a/app/services/flow/flow_steps.rb
+++ b/app/services/flow/flow_steps.rb
@@ -1,9 +1,5 @@
 module Flow
   class FlowSteps
     extend OmniauthPathHelper
-
-    def self.urls
-      Rails.application.routes.url_helpers
-    end
   end
 end


### PR DESCRIPTION
urls class method is no longer being used or tested since final flow step refactor. Remove to fix coverage.



## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
