### PR TITLE
ap-5145: fix merits cya

### DIFF
--- a/app/views/providers/proceeding_merits_task/check_who_client_is/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/check_who_client_is/show.html.erb
@@ -7,7 +7,7 @@
     <p class="govuk-body"><%= t(".paragraph") %></p>
   <% end %>
 
-  <%= render("shared/check_answers/relationship_to_child") %>
+  <%= render("shared/check_answers/relationship_to_child", proceeding: @proceeding, relationship_to_child: @relationship_to_child) %>
 
   <%= next_action_buttons_with_form(
         url: providers_merits_task_list_check_who_client_is_path(@proceeding),

--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -16,10 +16,12 @@
 
 <%= render("shared/check_answers/urgency", read_only:, urgency:) if @legal_aid_application.urgency %>
 
-<% if @legal_aid_application.section_8_proceedings? %>
+<% if @legal_aid_application.involved_children.any? %>
   <%= render("shared/check_answers/children_involved", read_only:) %>
 
-  <%= render("shared/check_answers/laspo", read_only:) %>
+  <% if @legal_aid_application.section_8_proceedings? %>
+    <%= render("shared/check_answers/laspo", read_only:) %>
+  <% end %>
 <% end %>
 
 <%= render("shared/check_answers/matter_opposition", read_only:) if @legal_aid_application.matter_opposition %>

--- a/app/views/shared/check_answers/_merits_proceeding_section.html.erb
+++ b/app/views/shared/check_answers/_merits_proceeding_section.html.erb
@@ -95,6 +95,10 @@
       <hr class="govuk-section-break govuk-section-break--visible govuk-!-width-full">
     <% end %>
 
+    <% if proceeding.relationship_to_child %>
+      <%= render("shared/check_answers/relationship_to_child", proceeding:, relationship_to_child: proceeding.relationship_to_child) %>
+    <% end %>
+
     <%= govuk_summary_list(actions: !read_only) do |summary_list| %>
       <% if proceeding.vary_order %>
         <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{proceeding.id}_vary_order" }) do |row| %>

--- a/app/views/shared/check_answers/_merits_proceeding_section.html.erb
+++ b/app/views/shared/check_answers/_merits_proceeding_section.html.erb
@@ -2,38 +2,40 @@
   <section class="print-no-break govuk-!-padding-top-6">
     <h2 class="govuk-heading-l"><%= proceeding.meaning %></h2>
 
-    <%= govuk_summary_list(actions: !read_only, classes: "govuk-!-margin-bottom-0") do |summary_list| %>
-      <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{proceeding.id}_success_likely" }) do |row| %>
-        <%= row.with_key(text: t(".prospects_of_success"), classes: "govuk-!-width-one-half") %>
-        <%= row.with_value(text: yes_no(proceeding.chances_of_success.success_likely)) %>
-        <%= row.with_action(
-              text: t("generic.change"),
-              href: providers_merits_task_list_chances_of_success_index_path(proceeding),
-              visually_hidden_text: t(".prospects_of_success"),
-            ) %>
-      <% end %>
-      <% unless proceeding.chances_of_success.success_likely? %>
-        <%= summary_list.with_row(
-              classes: "govuk-summary-list__row--no-border",
-              html_attributes: { id: "app-check-your-answers__#{proceeding.id}_success_prospect" },
-            ) do |row| %>
-          <%= row.with_key(text: t(".success_prospect"), classes: "govuk-!-width-one-half") %>
-          <%= row.with_value(text: t("shared.forms.success_prospect.#{proceeding.chances_of_success.success_prospect}")) %>
+    <% if proceeding.chances_of_success %>
+      <%= govuk_summary_list(actions: !read_only, classes: "govuk-!-margin-bottom-0") do |summary_list| %>
+        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{proceeding.id}_success_likely" }) do |row| %>
+          <%= row.with_key(text: t(".prospects_of_success"), classes: "govuk-!-width-one-half") %>
+          <%= row.with_value(text: yes_no(proceeding.chances_of_success.success_likely)) %>
           <%= row.with_action(
                 text: t("generic.change"),
-                href: providers_merits_task_list_success_prospects_path(proceeding),
-                visually_hidden_text: t(".success_prospect"),
+                href: providers_merits_task_list_chances_of_success_index_path(proceeding),
+                visually_hidden_text: t(".prospects_of_success"),
               ) %>
         <% end %>
+        <% unless proceeding.chances_of_success.success_likely? %>
+          <%= summary_list.with_row(
+                classes: "govuk-summary-list__row--no-border",
+                html_attributes: { id: "app-check-your-answers__#{proceeding.id}_success_prospect" },
+              ) do |row| %>
+            <%= row.with_key(text: t(".success_prospect"), classes: "govuk-!-width-one-half") %>
+            <%= row.with_value(text: t("shared.forms.success_prospect.#{proceeding.chances_of_success.success_prospect}")) %>
+            <%= row.with_action(
+                  text: t("generic.change"),
+                  href: providers_merits_task_list_success_prospects_path(proceeding),
+                  visually_hidden_text: t(".success_prospect"),
+                ) %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <% if proceeding.chances_of_success.success_prospect_details %>
+        <p class='govuk-body'><%= proceeding.chances_of_success.success_prospect_details %></p>
+        <hr class="govuk-section-break govuk-section-break--visible govuk-!-width-full">
       <% end %>
     <% end %>
 
-    <% if proceeding.chances_of_success.success_prospect_details %>
-      <p class='govuk-body'><%= proceeding.chances_of_success.success_prospect_details %></p>
-      <hr class="govuk-section-break govuk-section-break--visible govuk-!-width-full">
-    <% end %>
-
-    <% if proceeding.attempts_to_settle || proceeding.section8? || proceeding.specific_issue || proceeding.prohibited_steps %>
+    <% if proceeding.attempts_to_settle || proceeding.section8? || proceeding.specific_issue || proceeding.prohibited_steps || proceeding.special_childrens_act? %>
       <%= govuk_summary_list(actions: !read_only, classes: "govuk-!-margin-bottom-0") do |summary_list| %>
         <% if proceeding.attempts_to_settle %>
           <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{proceeding.id}_attempts_to_settle" }) do |row| %>
@@ -46,7 +48,7 @@
                 ) %>
           <% end %>
         <% end %>
-        <% if proceeding.section8? %>
+        <% if proceeding.section8? || (proceeding.special_childrens_act? && proceeding.client_involvement_type_ccms_code == "D") %>
           <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{proceeding.id}_linked_children" }) do |row| %>
             <%= row.with_key(text: t(".linked_children"), classes: "govuk-!-width-one-half") %>
             <%= row.with_value(text: linked_children_names(proceeding)) %>

--- a/app/views/shared/check_answers/_opponent_details.html.erb
+++ b/app/views/shared/check_answers/_opponent_details.html.erb
@@ -13,22 +13,27 @@
       <% end %>
     <% end %>
 
-    <%= summary_list.with_row(
-          classes: "govuk-summary-list__row--no-border",
-          html_attributes: { id: "app-check-your-answers__opponent_understands_terms_of_court_order" },
-        ) do |row| %>
-      <%= row.with_key(text: t(".understands_terms_of_court_order"), classes: "govuk-!-width-one-half") %>
-      <%= row.with_value(text: yes_no(parties_mental_capacity.understands_terms_of_court_order)) %>
-      <%= row.with_action(
-            text: t("generic.change"),
-            href: providers_legal_aid_application_opponents_mental_capacity_path(@legal_aid_application),
-            visually_hidden_text: t(".understands_terms_of_court_order"),
-          ) %>
+    <% if parties_mental_capacity %>
+      <%= summary_list.with_row(
+            classes: "govuk-summary-list__row--no-border",
+            html_attributes: { id: "app-check-your-answers__opponent_understands_terms_of_court_order" },
+          ) do |row| %>
+        <%= row.with_key(text: t(".understands_terms_of_court_order"), classes: "govuk-!-width-one-half") %>
+        <%= row.with_value(text: yes_no(parties_mental_capacity.understands_terms_of_court_order)) %>
+        <%= row.with_action(
+              text: t("generic.change"),
+              href: providers_legal_aid_application_opponents_mental_capacity_path(@legal_aid_application),
+              visually_hidden_text: t(".understands_terms_of_court_order"),
+            ) %>
+      <% end %>
     <% end %>
   <% end %>
-  <div class='govuk-body'><%= parties_mental_capacity.understands_terms_of_court_order_details %></div>
 
-  <hr class="govuk-section-break govuk-section-break--visible govuk-!-width-full">
+  <% if parties_mental_capacity %>
+    <div class='govuk-body'><%= parties_mental_capacity.understands_terms_of_court_order_details %></div>
+
+    <hr class="govuk-section-break govuk-section-break--visible govuk-!-width-full">
+  <% end %>
 
   <% if task_list_includes?(@legal_aid_application, :domestic_abuse_summary) %>
     <%= govuk_summary_list(actions: !read_only, classes: "govuk-!-margin-bottom-2") do |summary_list| %>
@@ -82,30 +87,33 @@
     <div class='govuk-body'><%= domestic_abuse_summary.bail_conditions_set_details %></div>
     <hr class="govuk-section-break govuk-section-break--visible govuk-!-width-full">
   <% end %>
-  <%= govuk_summary_list(actions: !read_only, classes: "govuk-!-margin-bottom-2") do |summary_list| %>
-    <%= summary_list.with_row(
-          classes: "govuk-summary-list__row--no-border",
-          html_attributes: { id: "app-check-your-answers__statement_of_case" },
-        ) do |row| %>
-      <%= row.with_key(text: t("shared.check_answers.merits.statement-of-case-heading"), classes: "govuk-!-width-one-half") %>
-      <%= row.with_value do %>
-        <% if attachments_with_size(statement_of_case&.original_attachments).present? %>
-          <ul class="govuk-list">
-            <% attachments_with_size(statement_of_case&.original_attachments).each do |item| %>
-              <li><%= item %></li>
-            <% end %>
-          </ul>
+
+  <% unless @legal_aid_application.special_children_act_proceedings? %>
+    <%= govuk_summary_list(actions: !read_only, classes: "govuk-!-margin-bottom-2") do |summary_list| %>
+      <%= summary_list.with_row(
+            classes: "govuk-summary-list__row--no-border",
+            html_attributes: { id: "app-check-your-answers__statement_of_case" },
+          ) do |row| %>
+        <%= row.with_key(text: t("shared.check_answers.merits.statement-of-case-heading"), classes: "govuk-!-width-one-half") %>
+        <%= row.with_value do %>
+          <% if attachments_with_size(statement_of_case&.original_attachments).present? %>
+            <ul class="govuk-list">
+              <% attachments_with_size(statement_of_case&.original_attachments).each do |item| %>
+                <li><%= item %></li>
+              <% end %>
+            </ul>
+          <% end %>
         <% end %>
+        <%= row.with_action(
+              text: t("generic.change"),
+              href: providers_legal_aid_application_statement_of_case_path(@legal_aid_application),
+              visually_hidden_text: t("shared.check_answers.merits.statement-of-case-heading"),
+            ) %>
       <% end %>
-      <%= row.with_action(
-            text: t("generic.change"),
-            href: providers_legal_aid_application_statement_of_case_path(@legal_aid_application),
-            visually_hidden_text: t("shared.check_answers.merits.statement-of-case-heading"),
-          ) %>
     <% end %>
+    <div class='govuk-body'><%= statement_of_case&.statement %></div>
+    <hr class="govuk-section-break govuk-section-break--visible govuk-!-width-full">
   <% end %>
-  <div class='govuk-body'><%= statement_of_case&.statement %></div>
-  <hr class="govuk-section-break govuk-section-break--visible govuk-!-width-full">
 
   <% if @legal_aid_application.allegation %>
     <%= govuk_summary_list(actions: !read_only, classes: "govuk-!-margin-bottom-2") do |summary_list| %>

--- a/app/views/shared/check_answers/_relationship_to_child.html.erb
+++ b/app/views/shared/check_answers/_relationship_to_child.html.erb
@@ -1,22 +1,22 @@
 <%= govuk_summary_list do |summary_list|
       summary_list.with_row do |row|
         row.with_key(text: t(".biological_parent"), classes: "govuk-!-width-one-half")
-        row.with_value(text: yes_no(@relationship_to_child.eql?("biological")))
-        row.with_action(text: t("generic.change"), href: providers_merits_task_list_is_client_biological_parent_path(@proceeding), visually_hidden_text: t(".biological_parent"))
+        row.with_value(text: yes_no(relationship_to_child.eql?("biological")))
+        row.with_action(text: t("generic.change"), href: providers_merits_task_list_is_client_biological_parent_path(proceeding), visually_hidden_text: t(".biological_parent"))
       end
 
-      unless @relationship_to_child.eql?("biological")
+      unless relationship_to_child.eql?("biological")
         summary_list.with_row do |row|
           row.with_key(text: t(".parental_responsibilities"))
-          row.with_value(text: @relationship_to_child.nil? || @relationship_to_child.eql?("child_subject") ? t("generic.no") : t(".#{@relationship_to_child}"))
-          row.with_action(text: t("generic.change"), href: providers_merits_task_list_does_client_have_parental_responsibility_path(@proceeding), visually_hidden_text: t(".parental_responsibilities"))
+          row.with_value(text: relationship_to_child.nil? || relationship_to_child.eql?("child_subject") ? t("generic.no") : t(".#{relationship_to_child}"))
+          row.with_action(text: t("generic.change"), href: providers_merits_task_list_does_client_have_parental_responsibility_path(proceeding), visually_hidden_text: t(".parental_responsibilities"))
         end
 
-        if @relationship_to_child.eql?("child_subject") || @relationship_to_child.nil?
+        if relationship_to_child.eql?("child_subject") || relationship_to_child.nil?
           summary_list.with_row do |row|
             row.with_key(text: t(".child_subject"))
-            row.with_value(text: yes_no(@relationship_to_child.eql?("child_subject")))
-            row.with_action(text: t("generic.change"), href: providers_merits_task_list_is_client_child_subject_path(@proceeding), visually_hidden_text: t(".child_subject"))
+            row.with_value(text: yes_no(relationship_to_child.eql?("child_subject")))
+            row.with_action(text: t("generic.change"), href: providers_merits_task_list_is_client_child_subject_path(proceeding), visually_hidden_text: t(".child_subject"))
           end
         end
       end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5145)

This pr fixes the errors that were preventing the merits cya page from being displayed for SCA applications and adds the relationship to child question to the page.
It does not update the page to use the new styling.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
