### PR TITLE
AP-5152: Fix proceeding loop bug

### DIFF
--- a/app/services/flow/proceeding_loop.rb
+++ b/app/services/flow/proceeding_loop.rb
@@ -121,7 +121,7 @@ module Flow
     end
 
     def next_incomplete_proceeding
-      @next_incomplete_proceeding ||= Query::IncompleteProceedings.call(@application).in_order_of_addition.first
+      @next_incomplete_proceeding ||= Query::IncompleteProceedings.call(@application)&.in_order_of_addition&.first
     end
 
     def current_proceeding_id

--- a/app/services/query/incomplete_proceedings.rb
+++ b/app/services/query/incomplete_proceedings.rb
@@ -25,8 +25,7 @@ module Query
         (
             NOT EXISTS (select 'has_scope_limitations' FROM scope_limitations where (proceeding_id = proceedings.id))
             OR (used_delegated_functions IS NULL)
-            OR (accepted_substantive_defaults IS NULL)
-            OR (accepted_substantive_defaults IS NULL)
+            OR (accepted_substantive_defaults IS NULL AND matter_type != 'Special Children Act')
             OR (client_involvement_type_ccms_code IS NULL)
             OR (used_delegated_functions = true AND accepted_emergency_defaults IS NULL)
             OR (accepted_substantive_defaults = false

--- a/spec/factories/proceedings.rb
+++ b/spec/factories/proceedings.rb
@@ -309,6 +309,9 @@ FactoryBot.define do
     client_involvement_type_ccms_code { "A" }
     client_involvement_type_description { "Applicant/Claimant/Petitioner" }
     sca_type { "core" }
+    after(:create) do |proceeding, evaluator|
+      create(:scope_limitation, :substantive, proceeding:) unless evaluator.no_scope_limitations
+    end
   end
 
   trait :pb007 do

--- a/spec/services/query/incomplete_proceedings_spec.rb
+++ b/spec/services/query/incomplete_proceedings_spec.rb
@@ -49,22 +49,27 @@ module Query
       it { expect(query).to include(proceeding) }
     end
 
-    context "when a proceeding has not had the accepted_emergency_defaults question answered" do
-      let(:proceeding) do
-        create(:proceeding, :da001, :with_df_date,
-               accepted_emergency_defaults: nil)
-      end
-
-      it { expect(query).to include(proceeding) }
-    end
-
     context "when a proceeding has not had the accepted_substantive_defaults question answered" do
-      let(:proceeding) do
-        create(:proceeding, :da001, :with_df_date,
-               accepted_substantive_defaults: nil)
+      context "and is not a special children act matter type" do
+        let(:proceeding) do
+          create(:proceeding, :da001, :with_df_date,
+                 accepted_substantive_defaults: nil)
+        end
+
+        it { expect(query).to include(proceeding) }
       end
 
-      it { expect(query).to include(proceeding) }
+      context "and is a special children act matter type" do
+        let(:proceeding) do
+          create(:proceeding, :pb003, :without_df_date,
+                 accepted_substantive_defaults: nil,
+                 client_involvement_type_ccms_code: "D",
+                 used_delegated_functions: false,
+                 accepted_emergency_defaults: nil)
+        end
+
+        it { expect(query).not_to include(proceeding) }
+      end
     end
 
     context "when a proceeding has not accepted_substantive_defaults and not set a new default" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5152)

- Proceeding loop expects `accepted_substantive_defaults` not to be null to proceed. As this is not set for SCA proceedings, proceeding loop doesn't proceed. Update SQL query to fix this and spec to cover this scenario.
- Add safe navigation operator when calling `IncompleteProceedings` as it sometimes returns nil.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
