### PR TITLE
Chore: Add GOVUK dependabot bundler group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,9 @@ updates:
     rubocop-gems:
       patterns:
         - "rubocop-*"
+    govuk-gems:
+      patterns:
+        - "govuk*"
   open-pull-requests-limit: 10
   ignore:
   - dependency-name: prometheus_exporter


### PR DESCRIPTION
## What

Enable all GOVUK* gems to be updated together.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
