### PR TITLE
AP-5136: Store dwp partner override on applicant too

### DIFF
--- a/app/controllers/providers/confirm_dwp_non_passported_applications_controller.rb
+++ b/app/controllers/providers/confirm_dwp_non_passported_applications_controller.rb
@@ -35,6 +35,7 @@ module Providers
     end
 
     def update_joint_benefit_response
+      applicant.update!(shared_benefit_with_partner: @form.receives_joint_benefit?)
       return if partner.nil?
 
       partner.shared_benefit_with_applicant = @form.receives_joint_benefit?

--- a/app/models/application_digest.rb
+++ b/app/models/application_digest.rb
@@ -9,6 +9,7 @@ class ApplicationDigest < ApplicationRecord
     referred_to_caseworker
     has_partner
     contrary_interest
+    partner_dwp_challenge
     non_means_tested
   ].freeze
 
@@ -50,7 +51,7 @@ class ApplicationDigest < ApplicationRecord
         true_layer_data: laa.bank_transactions.any?,
         has_partner: laa.applicant_has_partner?,
         contrary_interest: laa.applicant_has_partner? ? !laa.applicant_has_partner_with_no_contrary_interest? : nil,
-        partner_dwp_challenge: laa&.partner&.shared_benefit_with_applicant? || nil,
+        partner_dwp_challenge: laa&.partner&.shared_benefit_with_applicant? || laa.applicant.shared_benefit_with_partner,
         applicant_age: applicant_age(laa),
         non_means_tested: laa.non_means_tested?,
       }

--- a/app/services/reports/mis/application_detail_csv_line.rb
+++ b/app/services/reports/mis/application_detail_csv_line.rb
@@ -409,7 +409,7 @@ module Reports
         @line << yesno(laa.applicant_has_partner?)
         if laa.applicant_has_partner?
           @line << yesno(!laa.applicant_has_partner_with_no_contrary_interest? || nil)
-          @line << yesno(laa&.partner&.shared_benefit_with_applicant? || nil)
+          @line << yesno(laa&.partner&.shared_benefit_with_applicant? || laa&.applicant&.shared_benefit_with_partner? || nil)
         else
           @line << nil
           @line << nil

--- a/db/migrate/20240722082922_add_shared_benefit_column_to_applicant.rb
+++ b/db/migrate/20240722082922_add_shared_benefit_column_to_applicant.rb
@@ -1,0 +1,12 @@
+class AddSharedBenefitColumnToApplicant < ActiveRecord::Migration[7.1]
+  def up
+    add_column :applicants, :shared_benefit_with_partner, :boolean
+    Partner.where.not(shared_benefit_with_applicant: nil).each do |partner|
+      partner.legal_aid_application.applicant.update!(shared_benefit_with_partner: partner.shared_benefit_with_applicant)
+    end
+  end
+
+  def down
+    remove_column :applicants, :shared_benefit_with_partner
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_11_135846) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_22_082922) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -139,6 +139,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_11_135846) do
     t.boolean "same_correspondence_and_home_address"
     t.boolean "no_fixed_residence"
     t.string "correspondence_address_choice"
+    t.boolean "shared_benefit_with_partner"
     t.index ["confirmation_token"], name: "index_applicants_on_confirmation_token", unique: true
     t.index ["email"], name: "index_applicants_on_email"
     t.index ["unlock_token"], name: "index_applicants_on_unlock_token", unique: true

--- a/spec/models/application_digest_spec.rb
+++ b/spec/models/application_digest_spec.rb
@@ -173,6 +173,7 @@ RSpec.describe ApplicationDigest do
           let(:applicant) do
             create(:applicant,
                    :with_partner,
+                   shared_benefit_with_partner: false,
                    partner_has_contrary_interest: true)
           end
 
@@ -180,9 +181,23 @@ RSpec.describe ApplicationDigest do
             application_digest
             expect(digest.has_partner).to be true
             expect(digest.contrary_interest).to be true
-            # TODO: The partner_dwp_challenge should be false but a bug is preventing it being recorded
-            # Replace `be_nil` with `be false` and update the test harnesses once ticket 5136 is resolved
-            expect(digest.partner_dwp_challenge).to be_nil
+            expect(digest.partner_dwp_challenge).to be false
+          end
+        end
+
+        context "when the applicant has a partner with contrary interest and disputed benefits" do
+          let(:applicant) do
+            create(:applicant,
+                   :with_partner,
+                   shared_benefit_with_partner: true,
+                   partner_has_contrary_interest: true)
+          end
+
+          it "returns the expected data" do
+            application_digest
+            expect(digest.has_partner).to be true
+            expect(digest.contrary_interest).to be true
+            expect(digest.partner_dwp_challenge).to be true
           end
         end
 

--- a/spec/requests/providers/confirm_dwp_non_passported_applications_controller_spec.rb
+++ b/spec/requests/providers/confirm_dwp_non_passported_applications_controller_spec.rb
@@ -203,6 +203,11 @@ RSpec.describe Providers::ConfirmDWPNonPassportedApplicationsController do
           expect(partner.reload.shared_benefit_with_applicant).to be true
         end
 
+        it "sets the applicant shared benefit field to true" do
+          patch_request
+          expect(application.reload.applicant.shared_benefit_with_partner).to be true
+        end
+
         it "redirects to the next page" do
           patch_request
           expect(response).to have_http_status(:redirect)

--- a/spec/services/reports/mis/application_detail_csv_line_spec.rb
+++ b/spec/services/reports/mis/application_detail_csv_line_spec.rb
@@ -704,6 +704,14 @@ module Reports
               expect(value_for("Contrary interest?")).to eq "Yes"
               expect(value_for("Partner DWP challenge?")).to eq "No"
             end
+
+            context "and the DWP result was overridden with a shared benefit" do
+              before { applicant.update!(shared_benefit_with_partner: true) }
+
+              it "returns the expected data" do
+                expect(value_for("Partner DWP challenge?")).to eq "Yes"
+              end
+            end
           end
         end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5136)

This stores the shared benefit override answer on the applicant as well as the partner

This caused issues with reporting when the partner has a contrary interest and the answer was only stored on the partner model, it was unavailable

Now we record on, and check, both models and improve the reporting accuracy

We _could_ remove the partner handling but that should probably be a separate ticket as it would be out of the scope of a bug fix ticket

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
