### PR TITLE
Ap 5142 zero cost limits associated applications

### DIFF
--- a/app/controllers/providers/limitations_controller.rb
+++ b/app/controllers/providers/limitations_controller.rb
@@ -22,7 +22,7 @@ module Providers
     end
 
     def form_needs_checking?
-      (legal_aid_application.used_delegated_functions? && !legal_aid_application.special_children_act_proceedings?) || @legal_aid_application.substantive_cost_overridable?
+      @legal_aid_application.emergency_cost_overridable? || @legal_aid_application.substantive_cost_overridable?
     end
 
     def clear_limit_and_reason

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -438,6 +438,14 @@ class LegalAidApplication < ApplicationRecord
     lead_proceeding.delegated_functions_cost_limitation
   end
 
+  def additional_family_lead_delegated_functions_cost_limitation
+    default_delegated_functions_cost_limitation / 2
+  end
+
+  def family_linked_associated_application?
+    lead_linked_application&.link_type_code == "FC_LEAD"
+  end
+
   def find_or_create_ccms_submission
     create_ccms_submission! unless ccms_submission
     ccms_submission
@@ -649,9 +657,5 @@ private
     required_document_categories.each do |category|
       errors.add(:required_document_categories, "must be valid document categories") unless DocumentCategory.displayable_document_category_names.include?(category)
     end
-  end
-
-  def family_linked_associated_application?
-    lead_linked_application&.link_type_code == "FC_LEAD"
   end
 end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -411,7 +411,11 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def substantive_cost_overridable?
-    substantive_cost_limitation.present? && default_substantive_cost_limitation < MAX_SUBSTANTIVE_COST_LIMIT && !special_children_act_proceedings?
+    substantive_cost_limitation.present? && default_substantive_cost_limitation < MAX_SUBSTANTIVE_COST_LIMIT && !special_children_act_proceedings? && !family_linked_associated_application?
+  end
+
+  def emergency_cost_overridable?
+    display_emergency_certificate? && !family_linked_associated_application?
   end
 
   def substantive_cost_limitation
@@ -423,10 +427,14 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def default_substantive_cost_limitation
+    return 0.0 if family_linked_associated_application?
+
     proceedings.map(&:substantive_cost_limitation).max
   end
 
   def default_delegated_functions_cost_limitation
+    return 0.0 if family_linked_associated_application?
+
     lead_proceeding.delegated_functions_cost_limitation
   end
 
@@ -641,5 +649,9 @@ private
     required_document_categories.each do |category|
       errors.add(:required_document_categories, "must be valid document categories") unless DocumentCategory.displayable_document_category_names.include?(category)
     end
+  end
+
+  def family_linked_associated_application?
+    lead_linked_application&.link_type_code == "FC_LEAD"
   end
 end

--- a/app/services/copy_case/cloner_service.rb
+++ b/app/services/copy_case/cloner_service.rb
@@ -67,9 +67,6 @@ module CopyCase
       merits = %i[
         allegation
         domestic_abuse_summary
-        emergency_cost_override
-        emergency_cost_reasons
-        emergency_cost_requested
         latest_incident
         in_scope_of_laspo
         matter_opposition

--- a/app/views/providers/limitations/_cost_limits.html.erb
+++ b/app/views/providers/limitations/_cost_limits.html.erb
@@ -1,6 +1,4 @@
-<h3 class="govuk-heading-m">
-  <%= t(title_translation_path) %>
-</h3>
+<h3 class="govuk-heading-m"><%= t(".substantive_certificate") %></h3>
 
 <p><%= t(".default_substantive_limit_is") %> <strong><%= gds_number_to_currency(@legal_aid_application.default_substantive_cost_limitation, precision: 0) %></strong></p>
 

--- a/app/views/providers/limitations/show.html.erb
+++ b/app/views/providers/limitations/show.html.erb
@@ -27,7 +27,7 @@
           </strong>
         </p>
 
-        <% unless @legal_aid_application.family_linked_associated_application? %>
+        <% if Setting.linked_applications? && !@legal_aid_application.family_linked_associated_application? %>
           <%= govuk_details(summary_text: t(".emergency_certificate_details_heading")) do %>
             <p><%= sanitize(t(".emergency_certificate_details", limit: "<strong>#{gds_number_to_currency(
                      @legal_aid_application.additional_family_lead_delegated_functions_cost_limitation,

--- a/app/views/providers/limitations/show.html.erb
+++ b/app/views/providers/limitations/show.html.erb
@@ -26,23 +26,25 @@
                 ) %>
           </strong>
         </p>
-        <%= form.govuk_radio_buttons_fieldset(:emergency_cost_override,
-                                              legend: { size: "s", tag: "h2", text: t(".cost_override_question") }) do %>
-          <%= form.govuk_radio_button(:emergency_cost_override, true, link_errors: true, label: { text: t("generic.yes") }) do %>
-            <%= form.govuk_text_field(
-                  :emergency_cost_requested,
-                  label: { text: t(".enter_cost_limit") },
-                  value: number_to_currency_or_original_string(@form.emergency_cost_requested),
-                  prefix_text: t("currency.gbp"),
-                  width: "one-third",
-                ) %>
+        <% if @legal_aid_application.emergency_cost_overridable? %>
+          <%= form.govuk_radio_buttons_fieldset(:emergency_cost_override,
+                                                legend: { size: "s", tag: "h2", text: t(".cost_override_question") }) do %>
+            <%= form.govuk_radio_button(:emergency_cost_override, true, link_errors: true, label: { text: t("generic.yes") }) do %>
+              <%= form.govuk_text_field(
+                    :emergency_cost_requested,
+                    label: { text: t(".enter_cost_limit") },
+                    value: number_to_currency_or_original_string(@form.emergency_cost_requested),
+                    prefix_text: t("currency.gbp"),
+                    width: "one-third",
+                  ) %>
 
-          <%= form.govuk_text_area(
-                :emergency_cost_reasons,
-                label: { text: t(".enter_cost_reasons") },
-              ) %>
+            <%= form.govuk_text_area(
+                  :emergency_cost_reasons,
+                  label: { text: t(".enter_cost_reasons") },
+                ) %>
+          <% end %>
+          <%= form.govuk_radio_button(:emergency_cost_override, false, label: { text: t("generic.no") }) %>
         <% end %>
-        <%= form.govuk_radio_button(:emergency_cost_override, false, label: { text: t("generic.no") }) %>
       <% end %>
     <% end %>
 

--- a/app/views/providers/limitations/show.html.erb
+++ b/app/views/providers/limitations/show.html.erb
@@ -26,6 +26,16 @@
                 ) %>
           </strong>
         </p>
+
+        <% unless @legal_aid_application.family_linked_associated_application? %>
+          <%= govuk_details(summary_text: t(".emergency_certificate_details_heading")) do %>
+            <p><%= sanitize(t(".emergency_certificate_details", limit: "<strong>#{gds_number_to_currency(
+                     @legal_aid_application.additional_family_lead_delegated_functions_cost_limitation,
+                     precision: 0,
+                   )}</strong>")) %></p>
+          <% end %>
+        <% end %>
+
         <% if @legal_aid_application.emergency_cost_overridable? %>
           <%= form.govuk_radio_buttons_fieldset(:emergency_cost_override,
                                                 legend: { size: "s", tag: "h2", text: t(".cost_override_question") }) do %>

--- a/app/views/providers/limitations/show.html.erb
+++ b/app/views/providers/limitations/show.html.erb
@@ -12,8 +12,8 @@
                collection: @legal_aid_application.proceedings.in_order_of_addition, as: :proceeding,
                locals: { translation_path: "providers.limitations.show" } %>
 
+    <h2 class="govuk-heading-l"><%= t(".cost_heading") %></h2>
     <% if @legal_aid_application.display_emergency_certificate? %>
-      <h2 class="govuk-heading-l"><%= t(".cost_heading") %></h2>
       <h3 class="govuk-heading-m"><%= t(".emergency_certificate") %></h3>
 
       <p class="govuk-body">
@@ -58,11 +58,14 @@
       <% end %>
     <% end %>
 
-    <% title_translation = @legal_aid_application.used_delegated_functions? ? ".substantive_certificate" : ".cost_heading" %>
     <%= render partial: "providers/limitations/cost_limits",
-               locals: { title_translation_path: title_translation, form: } %>
-    <div class="govuk-!-padding-bottom-6"></div>
+               locals: { form: } %>
 
+    <%= if @legal_aid_application&.lead_linked_application&.link_type_code == "FC_LEAD"
+          govuk_warning_text(text: t(".family_warning"))
+        end %>
+
+    <div class="govuk-!-padding-bottom-6"></div>
     <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/proceedings_sca/supervision_orders/show.html.erb
+++ b/app/views/providers/proceedings_sca/supervision_orders/show.html.erb
@@ -9,7 +9,7 @@
                                             yes_no_options,
                                             :value,
                                             :label,
-                                            caption: { text: t(".caption"), size: "l" },
+                                            caption: { text: t(".caption"), size: "xl" },
                                             legend: { text: content_for(:page_title), size: "xl", tag: "h1" } %>
 
     <%= next_action_buttons(show_draft: true, form:) %>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -935,6 +935,7 @@ en:
         default_limit_is: The default emergency cost limit is
         emergency_certificate_details_heading: What to add for family link applications
         emergency_certificate_details: You can request %{limit} more for each application that will be family linked to this one
+        family_warning: As you have made a family link, the cost limit will be on the certificate of the application you submitted first.
       proceeding_type:
         client_role: "Client role: "
         details_heading: Scope limitations

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -933,6 +933,8 @@ en:
         substantive_certificate: Substantive certificate
         emergency_certificate: Emergency certificate
         default_limit_is: The default emergency cost limit is
+        emergency_certificate_details_heading: What to add for family link applications
+        emergency_certificate_details: You can request %{limit} more for each application that will be family linked to this one
       proceeding_type:
         client_role: "Client role: "
         details_heading: Scope limitations

--- a/features/providers/linked_applications/check_your_answers_link_and_copy.feature
+++ b/features/providers/linked_applications/check_your_answers_link_and_copy.feature
@@ -106,9 +106,7 @@ Scenario: If I change the copied from Yes to No
 
   Then I should be on a page showing "What you're applying for"
   And I should be on a page showing "default substantive cost limit"
-  And I should be on a page showing "Do you want to request a higher emergency cost limit?"
 
-  When I choose 'No'
   And I click 'Save and continue'
   Then I should be on a page showing 'Check your answers'
   And I should see "Non-molestation order"

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -896,6 +896,47 @@ RSpec.describe LegalAidApplication do
     end
   end
 
+  describe "#additional_family_lead_delegated_functions_cost_limitation" do
+    subject(:additional_family_lead_delegated_functions_cost_limitation) { legal_aid_application.additional_family_lead_delegated_functions_cost_limitation }
+
+    before do
+      create(:proceeding, :da006, legal_aid_application:, delegated_functions_cost_limitation: 5_000, lead_proceeding: true)
+      create(:proceeding, :se013, legal_aid_application:, delegated_functions_cost_limitation: 10_000)
+    end
+
+    it { is_expected.to eq 2_500 }
+
+    context "when the application is is an associated family linked application" do
+      let(:lead_application) { create(:legal_aid_application) }
+
+      before { create(:linked_application, lead_application:, associated_application: legal_aid_application, link_type_code: "FC_LEAD") }
+
+      it { is_expected.to eq 0 }
+    end
+  end
+
+  describe "#family_linked_associated_application?" do
+    subject(:family_linked_associated_application?) { legal_aid_application.family_linked_associated_application? }
+
+    let(:lead_application) { create(:legal_aid_application) }
+
+    context "when the application does not have a lead application" do
+      it { is_expected.to be false }
+    end
+
+    context "when the application has been legal linked" do
+      before { create(:linked_application, lead_application:, associated_application: legal_aid_application, link_type_code: "LEGAL") }
+
+      it { is_expected.to be false }
+    end
+
+    context "when the application has been family linked" do
+      before { create(:linked_application, lead_application:, associated_application: legal_aid_application, link_type_code: "FC_LEAD") }
+
+      it { is_expected.to be true }
+    end
+  end
+
   describe "#bank_transactions" do
     subject(:bank_transactions) { legal_aid_application.bank_transactions }
 

--- a/spec/services/copy_case/cloner_service_spec.rb
+++ b/spec/services/copy_case/cloner_service_spec.rb
@@ -115,9 +115,6 @@ RSpec.describe CopyCase::ClonerService do
       expect { call }
         .to change { target.reload.allegation }.from(nil)
         .and change { target.reload.domestic_abuse_summary }.from(nil)
-        .and change { target.reload.emergency_cost_override.present? }.from(false).to(true)
-        .and change { target.reload.emergency_cost_reasons.present? }.from(false).to(true)
-        .and change { target.reload.emergency_cost_requested.present? }.from(false).to(true)
         .and change { target.reload.in_scope_of_laspo }.from(nil).to(true)
         .and change { target.reload.involved_children.size }.from(0).to(3)
         .and change { target.reload.latest_incident }.from(nil)


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5142)

Updated logic to zero cost limitations for family associated linked applications.
Added additional details panel to limitations page for non family associated linked applications.
This should automatically update the CCMS payload with the 0 default subsantive cost limit for associated family linked applications.
NB additional BA work required to determine whether the merits report needs to be updated with the 0 emergency cost limit for associated family linked applications.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
