### PR TITLE
Fix benefit checker error handling

### DIFF
--- a/app/services/benefit_check_service.rb
+++ b/app/services/benefit_check_service.rb
@@ -33,7 +33,7 @@ class BenefitCheckService
   rescue Faraday::SoapError
     false
   rescue BenefitCheckError => e
-    AlertManager.capture_exception(e.message)
+    AlertManager.capture_exception(e)
     Rails.logger.error(e.message)
     false
   end

--- a/spec/services/benefit_check_service_spec.rb
+++ b/spec/services/benefit_check_service_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe BenefitCheckService do
       end
 
       it "captures error" do
-        expect(AlertManager).to receive(:capture_exception).with("BenefitCheckError: Invalid request credentials.")
+        expect(AlertManager).to receive(:capture_exception).with(message_contains("BenefitCheckError: Invalid request credentials."))
         benefit_check_service.call
       end
 


### PR DESCRIPTION
AlertManager is expecting an exception not a string when the benefit check call fails (e.g. see https://ministryofjustice.sentry.io/issues/5325010673/events/a416dcfa6f224e11874b755399f6acaa/?project=5416054&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=next-event&statsPeriod=14d&stream_index=0)



## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
