### PR TITLE
AP-5154: Revisit SCA parental relationship CYA

### DIFF
--- a/app/controllers/concerns/providers/draftable.rb
+++ b/app/controllers/concerns/providers/draftable.rb
@@ -6,9 +6,9 @@ module Providers
   module Draftable
     ENDPOINT = Flow::KeyPoint.path_for(journey: :providers, key_point: :home).freeze
 
-    def update_task_save_continue_or_draft(level, task)
+    def update_task_save_continue_or_draft(level, task, **)
       update_task(level, task)
-      save_continue_or_draft(@form)
+      save_continue_or_draft(@form, **)
     end
 
     def update_task(level, task)

--- a/app/controllers/providers/proceeding_merits_task/check_who_client_is_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/check_who_client_is_controller.rb
@@ -2,10 +2,12 @@ module Providers
   module ProceedingMeritsTask
     class CheckWhoClientIsController < ProviderBaseController
       def show
+        legal_aid_application.rejected_all_parental_responsibilities!
         @relationship_to_child = @proceeding.relationship_to_child
       end
 
       def update
+        legal_aid_application.provider_enter_merits!
         continue_or_draft
       end
 

--- a/app/controllers/providers/proceeding_merits_task/does_client_have_parental_responsibilities_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/does_client_have_parental_responsibilities_controller.rb
@@ -2,6 +2,7 @@ module Providers
   module ProceedingMeritsTask
     class DoesClientHaveParentalResponsibilitiesController < ProviderBaseController
       def show
+        legal_aid_application.provider_recording_parental_responsibilities!
         @form = Providers::ProceedingMeritsTask::ParentalResponsibilitiesForm.new(model: proceeding)
       end
 
@@ -12,7 +13,7 @@ module Providers
           return redirect_to providers_merits_task_list_is_client_child_subject_path(merits_task_list_id)
         end
 
-        render :show unless update_task_save_continue_or_draft(proceeding.ccms_code.to_sym, :client_relationship_to_proceeding)
+        render :show unless update_task_save_continue_or_draft(proceeding.ccms_code.to_sym, :client_relationship_to_proceeding, reshow_check_client: legal_aid_application.merits_parental_responsibilities_all_rejected?)
       end
 
     private

--- a/app/controllers/providers/proceeding_merits_task/is_client_biological_parent_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/is_client_biological_parent_controller.rb
@@ -2,6 +2,7 @@ module Providers
   module ProceedingMeritsTask
     class IsClientBiologicalParentController < ProviderBaseController
       def show
+        legal_aid_application.provider_recording_parental_responsibilities!
         @form = Providers::ProceedingMeritsTask::BiologicalParentForm.new(model: proceeding)
       end
 
@@ -12,7 +13,7 @@ module Providers
           return redirect_to providers_merits_task_list_does_client_have_parental_responsibility_path(merits_task_list_id)
         end
 
-        render :show unless update_task_save_continue_or_draft(proceeding.ccms_code.to_sym, :client_relationship_to_proceeding)
+        render :show unless update_task_save_continue_or_draft(proceeding.ccms_code.to_sym, :client_relationship_to_proceeding, reshow_check_client: legal_aid_application.merits_parental_responsibilities_all_rejected?)
       end
 
     private

--- a/app/controllers/providers/proceeding_merits_task/is_client_child_subject_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/is_client_child_subject_controller.rb
@@ -2,6 +2,7 @@ module Providers
   module ProceedingMeritsTask
     class IsClientChildSubjectController < ProviderBaseController
       def show
+        legal_aid_application.provider_recording_parental_responsibilities!
         @form = Providers::ProceedingMeritsTask::ChildSubjectForm.new(model: proceeding)
       end
 
@@ -12,7 +13,7 @@ module Providers
           return redirect_to providers_merits_task_list_check_who_client_is_path(merits_task_list_id)
         end
 
-        render :show unless update_task_save_continue_or_draft(proceeding.ccms_code.to_sym, :client_relationship_to_proceeding)
+        render :show unless update_task_save_continue_or_draft(proceeding.ccms_code.to_sym, :client_relationship_to_proceeding, reshow_check_client: legal_aid_application.merits_parental_responsibilities_all_rejected?)
       end
 
     private

--- a/app/models/concerns/base_state_machine.rb
+++ b/app/models/concerns/base_state_machine.rb
@@ -133,7 +133,13 @@ class BaseStateMachine < ApplicationRecord
 
     event :provider_enter_merits do
       transitions from: :checking_non_passported_means, to: :provider_entering_merits
-      transitions from: :applicant_details_checked, to: :provider_entering_merits, guard: :non_means_tested?
+      transitions from: %i[
+                    merits_parental_responsibilities_all_rejected
+                    merits_parental_responsibilities
+                    applicant_details_checked
+                  ],
+                  to: :provider_entering_merits,
+                  guard: :non_means_tested?
     end
 
     event :check_merits_answers do
@@ -144,8 +150,13 @@ class BaseStateMachine < ApplicationRecord
                     assessment_submitted
                   ],
                   to: :checking_merits_answers
-
       transitions from: :applicant_details_checked, to: :checking_merits_answers, guard: :non_means_tested?
+      transitions from: %i[
+                    merits_parental_responsibilities_all_rejected
+                    merits_parental_responsibilities
+                  ],
+                  to: :checking_merits_answers,
+                  guard: :non_means_tested?
     end
 
     event :generate_reports do

--- a/app/models/concerns/non_means_tested_state_machine.rb
+++ b/app/models/concerns/non_means_tested_state_machine.rb
@@ -3,6 +3,22 @@ class NonMeansTestedStateMachine < BaseStateMachine
     CCMS::Requestors::NonMeansTestedCaseAddRequestor
   end
 
+  aasm do
+    state :merits_parental_responsibilities
+    state :merits_parental_responsibilities_all_rejected
+
+    event :provider_recording_parental_responsibilities do
+      transitions from: :provider_entering_merits, to: :merits_parental_responsibilities
+      transitions from: :merits_parental_responsibilities, to: :merits_parental_responsibilities
+      transitions from: :merits_parental_responsibilities_all_rejected, to: :merits_parental_responsibilities_all_rejected
+    end
+
+    event :rejected_all_parental_responsibilities do
+      transitions from: :provider_entering_merits, to: :merits_parental_responsibilities_all_rejected
+      transitions from: :merits_parental_responsibilities, to: :merits_parental_responsibilities_all_rejected
+      transitions from: :merits_parental_responsibilities_all_rejected, to: :merits_parental_responsibilities_all_rejected
+    end
+  end
   # The following methods override events that are not applicable for a
   # non-means-tested journey but which, nonetheless, must be responded to when calls
   # are made to legal_aid_application#checking_answers? or refered to by other "helper"

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -125,6 +125,10 @@ class LegalAidApplication < ApplicationRecord
            :use_ccms?,
            :summary_state,
            :ccms_reason,
+           :provider_recording_parental_responsibilities!,
+           :rejected_all_parental_responsibilities!,
+           :merits_parental_responsibilities?,
+           :merits_parental_responsibilities_all_rejected?,
            to: :state_machine_proxy
 
   scope :latest, -> { order(created_at: :desc) }

--- a/app/services/flow/steps/provider_merits/biological_parent_step.rb
+++ b/app/services/flow/steps/provider_merits/biological_parent_step.rb
@@ -6,7 +6,9 @@ module Flow
           proceeding = application.proceedings.find(application.provider_step_params["merits_task_list_id"])
           Steps.urls.providers_merits_task_list_is_client_biological_parent_path(proceeding)
         end,
-        forward: lambda do |application|
+        forward: lambda do |application, options|
+          return :check_who_client_is if options[:reshow_check_client].eql?(true)
+
           proceeding = application.proceedings.find(application.provider_step_params["merits_task_list_id"])
           Flow::MeritsLoop.forward_flow(application, proceeding.ccms_code.to_sym)
         end,

--- a/app/services/flow/steps/provider_merits/child_subject_step.rb
+++ b/app/services/flow/steps/provider_merits/child_subject_step.rb
@@ -6,7 +6,9 @@ module Flow
           proceeding = application.proceedings.find(application.provider_step_params["merits_task_list_id"])
           Steps.urls.providers_merits_task_list_is_client_child_subject_path(proceeding)
         end,
-        forward: lambda do |application|
+        forward: lambda do |application, options|
+          return :check_who_client_is if options[:reshow_check_client].eql?(true)
+
           proceeding = application.proceedings.find(application.provider_step_params["merits_task_list_id"])
           Flow::MeritsLoop.forward_flow(application, proceeding.ccms_code.to_sym)
         end,

--- a/app/services/flow/steps/provider_merits/parental_responsibilities_step.rb
+++ b/app/services/flow/steps/provider_merits/parental_responsibilities_step.rb
@@ -6,7 +6,9 @@ module Flow
           proceeding = application.proceedings.find(application.provider_step_params["merits_task_list_id"])
           Steps.urls.providers_merits_task_list_does_client_have_parental_responsibility_path(proceeding)
         end,
-        forward: lambda do |application|
+        forward: lambda do |application, options|
+          return :check_who_client_is if options[:reshow_check_client].eql?(true)
+
           proceeding = application.proceedings.find(application.provider_step_params["merits_task_list_id"])
           Flow::MeritsLoop.forward_flow(application, proceeding.ccms_code.to_sym)
         end,

--- a/spec/concerns/non_means_tested_state_machine_spec.rb
+++ b/spec/concerns/non_means_tested_state_machine_spec.rb
@@ -1,7 +1,10 @@
 require "rails_helper"
+require "aasm/rspec"
 
 RSpec.describe NonMeansTestedStateMachine do
-  subject(:legal_aid_application) { create(:legal_aid_application, :with_non_means_tested_state_machine) }
+  subject(:state_machine) { legal_aid_application.state_machine }
+
+  let(:legal_aid_application) { create(:legal_aid_application, :with_non_means_tested_state_machine) }
 
   it { expect(legal_aid_application).not_to be_applicant_entering_means }
   it { expect(legal_aid_application).not_to be_awaiting_applicant }
@@ -9,4 +12,38 @@ RSpec.describe NonMeansTestedStateMachine do
   it { expect(legal_aid_application).not_to be_checking_passported_answers }
   it { expect(legal_aid_application).not_to be_checking_citizen_answers }
   it { expect(legal_aid_application).not_to be_checking_non_passported_means }
+
+  describe "#provider_recording_parental_responsibilities" do
+    let(:event) { :provider_recording_parental_responsibilities }
+
+    it { is_expected.to transition_from(:provider_entering_merits).to(:merits_parental_responsibilities).on_event(event) }
+    it { is_expected.to transition_from(:merits_parental_responsibilities).to(:merits_parental_responsibilities).on_event(event) }
+    it { is_expected.to transition_from(:merits_parental_responsibilities_all_rejected).to(:merits_parental_responsibilities_all_rejected).on_event(event) }
+  end
+
+  describe "#rejected_all_parental_responsibilities" do
+    let(:event) { :rejected_all_parental_responsibilities }
+
+    it { is_expected.to transition_from(:merits_parental_responsibilities).to(:merits_parental_responsibilities_all_rejected).on_event(event) }
+    it { is_expected.to transition_from(:merits_parental_responsibilities_all_rejected).to(:merits_parental_responsibilities_all_rejected).on_event(event) }
+  end
+
+  describe "#provider_enter_merits" do
+    let(:event) { :provider_enter_merits }
+
+    before { allow(legal_aid_application).to receive(:non_means_tested?).and_return(true) }
+
+    it { is_expected.to transition_from(:merits_parental_responsibilities_all_rejected).to(:provider_entering_merits).on_event(event) }
+    it { is_expected.to transition_from(:merits_parental_responsibilities).to(:provider_entering_merits).on_event(event) }
+  end
+
+  describe "#check_merits_answers" do
+    let(:event) { :check_merits_answers }
+
+    before { allow(legal_aid_application).to receive(:non_means_tested?).and_return(true) }
+
+    it { is_expected.to transition_from(:applicant_details_checked).to(:checking_merits_answers).on_event(event) }
+    it { is_expected.to transition_from(:merits_parental_responsibilities_all_rejected).to(:checking_merits_answers).on_event(event) }
+    it { is_expected.to transition_from(:merits_parental_responsibilities).to(:checking_merits_answers).on_event(event) }
+  end
 end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -291,6 +291,12 @@ FactoryBot.define do
       end
     end
 
+    trait :merits_parental_responsibilities do
+      before(:create) do |application|
+        application.state_machine_proxy.update!(aasm_state: :merits_parental_responsibilities)
+      end
+    end
+
     trait :submitting_assessment do
       before(:create) do |application|
         application.state_machine_proxy.update!(aasm_state: :submitting_assessment)

--- a/spec/requests/providers/proceeding_merits_task/check_who_client_is_controller_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/check_who_client_is_controller_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 module Providers
   module ProceedingMeritsTask
-    RSpec.describe SpecificIssueController do
+    RSpec.describe CheckWhoClientIsController do
       let(:smtl) { create(:legal_framework_merits_task_list, :pb003_pb059, legal_aid_application:) }
-      let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings, explicit_proceedings: %i[pb003 pb059]) }
+      let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings, :merits_parental_responsibilities, :with_non_means_tested_state_machine, explicit_proceedings: %i[pb003 pb059]) }
       let(:proceeding) { legal_aid_application.proceedings.find_by(ccms_code: "PB003") }
       let(:login) { login_as legal_aid_application.provider }
 

--- a/spec/requests/providers/proceeding_merits_task/does_client_have_parental_responsibilities_controller_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/does_client_have_parental_responsibilities_controller_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 module Providers
   module ProceedingMeritsTask
-    RSpec.describe SpecificIssueController do
+    RSpec.describe DoesClientHaveParentalResponsibilitiesController do
       let(:smtl) { create(:legal_framework_merits_task_list, :pb003_pb059, legal_aid_application:) }
-      let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings, explicit_proceedings: %i[pb003 pb059]) }
+      let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings, :provider_entering_merits, :with_non_means_tested_state_machine, explicit_proceedings: %i[pb003 pb059]) }
       let(:proceeding) { legal_aid_application.proceedings.find_by(ccms_code: "PB003") }
       let(:login) { login_as legal_aid_application.provider }
 

--- a/spec/requests/providers/proceeding_merits_task/is_client_biological_parent_controller_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/is_client_biological_parent_controller_spec.rb
@@ -4,7 +4,7 @@ module Providers
   module ProceedingMeritsTask
     RSpec.describe IsClientBiologicalParentController do
       let(:smtl) { create(:legal_framework_merits_task_list, :pb003_pb059, legal_aid_application:) }
-      let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings, explicit_proceedings: %i[pb003 pb059]) }
+      let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings, :provider_entering_merits, :with_non_means_tested_state_machine, explicit_proceedings: %i[pb003 pb059]) }
       let(:proceeding) { legal_aid_application.proceedings.find_by(ccms_code: "PB003") }
       let(:login) { login_as legal_aid_application.provider }
 

--- a/spec/requests/providers/proceeding_merits_task/is_client_child_subject_controller_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/is_client_child_subject_controller_spec.rb
@@ -4,7 +4,7 @@ module Providers
   module ProceedingMeritsTask
     RSpec.describe IsClientChildSubjectController do
       let(:smtl) { create(:legal_framework_merits_task_list, :pb003_pb059, legal_aid_application:) }
-      let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings, explicit_proceedings: %i[pb003 pb059]) }
+      let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings, :provider_entering_merits, :with_non_means_tested_state_machine, explicit_proceedings: %i[pb003 pb059]) }
       let(:proceeding) { legal_aid_application.proceedings.find_by(ccms_code: "PB003") }
       let(:login) { login_as legal_aid_application.provider }
 

--- a/spec/services/flow/steps/provider_merits/biological_parent_step_spec.rb
+++ b/spec/services/flow/steps/provider_merits/biological_parent_step_spec.rb
@@ -16,8 +16,18 @@ RSpec.describe Flow::Steps::ProviderMerits::BiologicalParentStep, type: :request
   end
 
   describe "#forward" do
-    subject { described_class.forward.call(legal_aid_application) }
+    subject { described_class.forward.call(legal_aid_application, options) }
 
-    it { is_expected.to eq :merits_task_lists }
+    context "when reshow_check_client is set to true" do
+      let(:options) { { reshow_check_client: true } }
+
+      it { is_expected.to eq :check_who_client_is }
+    end
+
+    context "when reshow_check_client is set to false" do
+      let(:options) { { options: { reshow_check_client: false } } }
+
+      it { is_expected.to eq :merits_task_lists }
+    end
   end
 end

--- a/spec/services/flow/steps/provider_merits/child_subject_step_spec.rb
+++ b/spec/services/flow/steps/provider_merits/child_subject_step_spec.rb
@@ -16,8 +16,18 @@ RSpec.describe Flow::Steps::ProviderMerits::ChildSubjectStep, type: :request do
   end
 
   describe "#forward" do
-    subject { described_class.forward.call(legal_aid_application) }
+    subject { described_class.forward.call(legal_aid_application, options) }
 
-    it { is_expected.to eq :merits_task_lists }
+    context "when reshow_check_client is set to true" do
+      let(:options) { { reshow_check_client: true } }
+
+      it { is_expected.to eq :check_who_client_is }
+    end
+
+    context "when reshow_check_client is set to false" do
+      let(:options) { { options: { reshow_check_client: false } } }
+
+      it { is_expected.to eq :merits_task_lists }
+    end
   end
 end

--- a/spec/services/flow/steps/provider_merits/parental_responsibilities_step_spec.rb
+++ b/spec/services/flow/steps/provider_merits/parental_responsibilities_step_spec.rb
@@ -16,8 +16,18 @@ RSpec.describe Flow::Steps::ProviderMerits::ParentalResponsibilitiesStep, type: 
   end
 
   describe "#forward" do
-    subject { described_class.forward.call(legal_aid_application) }
+    subject { described_class.forward.call(legal_aid_application, options) }
 
-    it { is_expected.to eq :merits_task_lists }
+    context "when reshow_check_client is set to true" do
+      let(:options) { { reshow_check_client: true } }
+
+      it { is_expected.to eq :check_who_client_is }
+    end
+
+    context "when reshow_check_client is set to false" do
+      let(:options) { { options: { reshow_check_client: false } } }
+
+      it { is_expected.to eq :merits_task_lists }
+    end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5154)

This PR changes the forms for parental responsibility. 

It uses changes to the state machine to track a) the start of the parental_responsibility questions and b) when all answers are no

It adds a global splat variable to the `update_task_save_continue_or_draft` draftable method so we can pass a value that allows the flow to route accordingly

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
