### PR TITLE
Revert "build(deps): bump the bundling-gems group with 2 updates"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,7 +179,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
-    cssbundling-rails (1.4.1)
+    cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
     csv (3.3.0)
     cucumber (9.2.0)
@@ -369,7 +369,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jmespath (1.6.2)
-    jsbundling-rails (1.3.1)
+    jsbundling-rails (1.3.0)
       railties (>= 6.0.0)
     json (2.7.2)
     json_expressions (0.9.0)


### PR DESCRIPTION
Reverts ministryofjustice/laa-apply-for-legal-aid#6974

We are seeing report creation issues, reverting this to see if it is the cause of the grover timeout