### PR TITLE
Hail-mary: Lock puppeteer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,55 @@
-FROM ministryofjustice/apply-base:latest-3.3.4
+FROM ruby:3.3.4-alpine3.20
 MAINTAINER apply for legal aid team
+
+# fail early and print all commands
+RUN set -ex
+
+# build dependencies:
+# - virtual: create virtual package for later deletion
+# - build-base for alpine fundamentals
+# - libxml2-dev/libxslt-dev for nokogiri, at least
+# - postgresql-dev for pg/activerecord gems
+# - git for installing gems referred to use a git:// uri
+#
+RUN apk --no-cache add --virtual build-dependencies \
+                    build-base \
+                    libxml2-dev \
+                    libxslt-dev \
+                    postgresql-dev \
+                    git \
+                    curl \
+&& apk --no-cache add \
+                  postgresql-client \
+                  nodejs \
+                  yarn \
+                  jq \
+                  linux-headers \
+                  clamav-daemon \
+                  libreoffice \
+                  ttf-dejavu \
+                  ttf-droid \
+                  ttf-freefont \
+                  ttf-liberation \
+                  bash
+
+# Install Chromium and Puppeteer for PDF generation
+# Installs latest Chromium package available on Alpine (Chromium 108)
+RUN apk add --no-cache \
+        nss \
+        freetype \
+        harfbuzz \
+        ca-certificates
+
+# Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
+#ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+#ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
+# Install latest version of Puppeteer
+RUN yarn add puppeteer@22.13.1
+
+# Ensure everything is executable
+RUN chmod +x /usr/local/bin/*
+
 
 # add non-root user and group with alpine first available uid, 1000
 RUN addgroup -g 1000 -S appgroup \


### PR DESCRIPTION



## What

Locker docker file at 22.13.1 which should pull
in chrome 126. Remove apk install


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
