### PR TITLE
AP-5195: PDF generation bug fix

### DIFF
--- a/config/initializers/grover.rb
+++ b/config/initializers/grover.rb
@@ -19,6 +19,6 @@ Grover.configure do |config|
       left: "10mm",
       right: "20mm",
     },
-    launch_args: ["--no-sandbox"],
+    launch_args: %w[--no-sandbox --disable-gpu],
   }
 end


### PR DESCRIPTION
## What

After chromium updated to 127+ grover stopped generating PDFs, it would hang and eventually fail.  After testing the interactions between Alpine, Chromium, Puppeteer and Grover for many days, we identified this as a working fix

Further work is needed to ensure that the issue cannot get deployed to production, but this fix will allow us to resume merging and deploying fixes, while we investigate that solution more


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
