### PR TITLE
Chore: pdf smoke test

### DIFF
--- a/config/initializers/grover.rb
+++ b/config/initializers/grover.rb
@@ -19,6 +19,6 @@ Grover.configure do |config|
       left: "10mm",
       right: "20mm",
     },
-    launch_args: %w[--no-sandbox --disable-gpu],
+    launch_args: %w[--no-sandbox],
   }
 end

--- a/config/initializers/grover.rb
+++ b/config/initializers/grover.rb
@@ -19,6 +19,6 @@ Grover.configure do |config|
       left: "10mm",
       right: "20mm",
     },
-    launch_args: %w[--no-sandbox],
+    launch_args: %w[--no-sandbox --disable-gpu],
   }
 end

--- a/docker/run
+++ b/docker/run
@@ -11,5 +11,7 @@ bundle exec rails db:prepare db:seed
 # Remove irb prompts from rails console
 echo 'IRB.conf[:USE_AUTOCOMPLETE] = false' >> ~/.irbrc
 
+bundle exec rake smoke_test:pdf
+
 # Start the Puma server
 bundle exec puma -C config/puma.rb

--- a/lib/tasks/smoke_test.rake
+++ b/lib/tasks/smoke_test.rake
@@ -4,6 +4,7 @@ namespace :smoke_test do
     Timeout.timeout(5) { Grover.new("test").to_pdf.size }
     Rails.logger.info "PDF generation succeeded"
   rescue Timeout::Error
+    Sentry.capture_message("PDF generation failed during deploy smoke test")
     raise StandardError, "PDF generation failed"
   end
 end

--- a/lib/tasks/smoke_test.rake
+++ b/lib/tasks/smoke_test.rake
@@ -1,7 +1,7 @@
 namespace :smoke_test do
   desc "Tries to generate a grover document"
   task pdf: :environment do
-    Timeout.timeout(10) { Grover.new("test").to_pdf.size }
+    Timeout.timeout(5) { Grover.new("test").to_pdf.size }
     Rails.logger.info "PDF generation succeeded"
   rescue Timeout::Error
     raise StandardError, "PDF generation failed"

--- a/lib/tasks/smoke_test.rake
+++ b/lib/tasks/smoke_test.rake
@@ -4,7 +4,7 @@ namespace :smoke_test do
     Timeout.timeout(5) { Grover.new("test").to_pdf.size }
     Rails.logger.info "PDF generation succeeded"
   rescue Timeout::Error
-    Sentry.capture_message("PDF generation failed during deploy smoke test")
+    SlackAlerter.capture_message("PDF generation failed during deploy smoke test")
     raise StandardError, "PDF generation failed"
   end
 end

--- a/lib/tasks/smoke_test.rake
+++ b/lib/tasks/smoke_test.rake
@@ -1,0 +1,9 @@
+namespace :smoke_test do
+  desc "Tries to generate a grover document"
+  task pdf: :environment do
+    Timeout.timeout(10) { Grover.new("test").to_pdf.size }
+    Rails.logger.info "PDF generation succeeded"
+  rescue Timeout::Error
+    raise StandardError, "PDF generation failed"
+  end
+end


### PR DESCRIPTION
## What

We have seen issues with tests build on circle ci passing but pdf generation on the alpine build failing

This PR attempts to add a rake task to test imapct of smoke testing a Grover test before pushing to ECR

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
