### PR TITLE
Chore: Test Grover

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,7 @@ jobs:
     - run:
         name: Install Puppeteer with Chromium
         command: |
-          yarn add puppeteer
+          yarn add puppeteer@22.15.0
     - run:
         name: Setup Code Climate test-reporter
         command: |

--- a/docker/apply_base.dockerfile
+++ b/docker/apply_base.dockerfile
@@ -46,7 +46,7 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 # Install latest version of Puppeteer
-RUN yarn add puppeteer
+RUN yarn add puppeteer@22.15.0
 
 # Ensure everything is executable
 RUN chmod +x /usr/local/bin/*


### PR DESCRIPTION
## What

Lock the puppeteer version at 22.15

This will allow us to test, build and deploy while we investigate the changes needed to update puppeteer to 23+

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
