### PR TITLE
Chore: allow resetting tasks to not started

### DIFF
--- a/app/controllers/providers/proceeding_merits_task/does_client_have_parental_responsibilities_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/does_client_have_parental_responsibilities_controller.rb
@@ -10,6 +10,7 @@ module Providers
         @form = Providers::ProceedingMeritsTask::ParentalResponsibilitiesForm.new(form_params)
         if @form.relationship_to_child.eql?("false") && !draft_selected?
           @form.save!
+          legal_aid_application.legal_framework_merits_task_list.reset_to_not_started!(proceeding.ccms_code.to_sym, :client_relationship_to_proceeding)
           return redirect_to providers_merits_task_list_is_client_child_subject_path(merits_task_list_id)
         end
 

--- a/app/controllers/providers/proceeding_merits_task/is_client_biological_parent_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/is_client_biological_parent_controller.rb
@@ -10,6 +10,7 @@ module Providers
         @form = Providers::ProceedingMeritsTask::BiologicalParentForm.new(form_params)
         if @form.relationship_to_child.eql?("false") && !draft_selected?
           @form.save!
+          legal_aid_application.legal_framework_merits_task_list.reset_to_not_started!(proceeding.ccms_code.to_sym, :client_relationship_to_proceeding)
           return redirect_to providers_merits_task_list_does_client_have_parental_responsibility_path(merits_task_list_id)
         end
 

--- a/app/controllers/providers/proceeding_merits_task/is_client_child_subject_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/is_client_child_subject_controller.rb
@@ -10,6 +10,7 @@ module Providers
         @form = Providers::ProceedingMeritsTask::ChildSubjectForm.new(form_params)
         if @form.relationship_to_child.eql?("false") && !draft_selected?
           @form.save!
+          legal_aid_application.legal_framework_merits_task_list.reset_to_not_started!(proceeding.ccms_code.to_sym, :client_relationship_to_proceeding)
           return redirect_to providers_merits_task_list_check_who_client_is_path(merits_task_list_id)
         end
 

--- a/app/models/legal_framework/merits_task_list.rb
+++ b/app/models/legal_framework/merits_task_list.rb
@@ -18,6 +18,12 @@ module LegalFramework
       save!
     end
 
+    def reset_to_not_started!(group, task)
+      task_list.reset_to_not_started!(group, task)
+      self.serialized_data = task_list.to_yaml
+      save!
+    end
+
     def can_proceed?
       application_states = task_list.tasks[:application].map(&:state).flatten
       proceeding_states = task_list.tasks[:proceedings].map { |task| task[1][:tasks].map(&:state) }.flatten

--- a/app/models/legal_framework/serializable_merits_task.rb
+++ b/app/models/legal_framework/serializable_merits_task.rb
@@ -26,5 +26,11 @@ module LegalFramework
 
       @state = :ignored
     end
+
+    def reset_to_not_started!
+      raise "Unmet dependency #{@dependencies.join(',')} for task #{@name}" if @dependencies.any?
+
+      @state = :not_started
+    end
   end
 end

--- a/app/models/legal_framework/serializable_merits_task_list.rb
+++ b/app/models/legal_framework/serializable_merits_task_list.rb
@@ -38,6 +38,10 @@ module LegalFramework
       unblock_dependant_tasks(task_name)
     end
 
+    def reset_to_not_started!(task_group, task_name)
+      task(task_group, task_name).reset_to_not_started!
+    end
+
     def self.new_from_serialized(yaml_string)
       YAML.safe_load(yaml_string, permitted_classes: SAFE_SERIALIZABLE_CLASSES, aliases: true)
     end

--- a/spec/models/legal_framework/merits_task_list_spec.rb
+++ b/spec/models/legal_framework/merits_task_list_spec.rb
@@ -49,6 +49,19 @@ module LegalFramework
       end
     end
 
+    describe ".reset_to_not_started!" do
+      subject(:reset_to_not_started) { merits_task_list.reset_to_not_started!(:application, task_name) }
+
+      let(:task_name) { :latest_incident_details }
+
+      it { is_expected.to be true }
+
+      it "updates the state of the task" do
+        reset_to_not_started
+        expect(merits_task_list).to have_not_started_task(:application, :latest_incident_details)
+      end
+    end
+
     describe ".can_proceed?" do
       subject(:can_proceed) { merits_task_list.can_proceed? }
 

--- a/spec/models/legal_framework/serializable_merits_task_list_spec.rb
+++ b/spec/models/legal_framework/serializable_merits_task_list_spec.rb
@@ -97,6 +97,48 @@ module LegalFramework
       end
     end
 
+    describe "#reset_to_not_started!" do
+      context "with invalid task name" do
+        it "raises an exception" do
+          expect {
+            smtl.reset_to_not_started!(:application, :rubbish)
+          }.to raise_error KeyError, "key not found: :rubbish"
+        end
+      end
+
+      context "with invalid task group name" do
+        it "raises an exception" do
+          expect {
+            smtl.reset_to_not_started!(:fake, :incident_details)
+          }.to raise_error KeyError, "key not found: :fake"
+        end
+      end
+
+      context "when task has dependencies" do
+        it "raises an exception" do
+          expect {
+            smtl.reset_to_not_started!(:DA001, :proceeding_children)
+          }.to raise_error RuntimeError, "Unmet dependency application_children for task proceeding_children"
+        end
+      end
+
+      context "when successful" do
+        context "with application group" do
+          it "marks the task as not_started" do
+            smtl.reset_to_not_started!(:application, :incident_details)
+            expect(smtl.task(:application, :incident_details).state).to eq :not_started
+          end
+        end
+
+        context "with proceeding type" do
+          it "marks the task as not_started" do
+            smtl.reset_to_not_started!(:DA004, :chances_of_success)
+            expect(smtl.task(:DA004, :chances_of_success).state).to eq :not_started
+          end
+        end
+      end
+    end
+
     def dummy_response_hash
       {
         request_id: SecureRandom.uuid,

--- a/spec/models/legal_framework/serializable_merits_task_spec.rb
+++ b/spec/models/legal_framework/serializable_merits_task_spec.rb
@@ -81,5 +81,24 @@ module LegalFramework
         end
       end
     end
+
+    describe "#reset_to_not_started!" do
+      context "with dependencies" do
+        it "raises an exception" do
+          expect {
+            serialized_merits_task.reset_to_not_started!
+          }.to raise_error RuntimeError, /Unmet dependency/
+        end
+      end
+
+      context "when successful" do
+        let(:serialized_merits_task) { described_class.new(:proceeding_children, dependencies: []) }
+
+        it "marks the task as not_started" do
+          serialized_merits_task.reset_to_not_started!
+          expect(serialized_merits_task.state).to eq :not_started
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION

## What

Chore to allow a task to be reset to not-started

It adds methods to each of the merits_task_list handlers to allow us to set something as not started

This is then used on the child relationship to client field, so if an answer is given as Yes, edited and and changed to No, it will re-set the status of the task list task to prevent the user continuing

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
