### PR TITLE
Fix: State enums

### DIFF
--- a/config/locales/en/enums.yml
+++ b/config/locales/en/enums.yml
@@ -39,6 +39,8 @@ en:
         provider_submitted: Submitted by provider
         provider_assessing_means: In progress
         provider_entering_merits: Means test completed
+        merits_parental_responsibilities: SCA relationship
+        merits_parental_responsibilities_all_rejected: SCA relationship all no
         provider_confirming_applicant_eligibility: In progress
         generating_reports: Generating reports
         submitting_assessment: Submitting application


### PR DESCRIPTION
## What

This happnened locally and only breaks teh amdin pages If a Provider has an application at the parental relationship questions on an SCA task list, the admin page breaks.  This adds the two new states into the enums and enables the admin list to work as expected

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
