### PR TITLE
AP-5219: Update spacing to make consistent and use default margins

### DIFF
--- a/app/views/providers/link_application/confirm_links/show.html.erb
+++ b/app/views/providers/link_application/confirm_links/show.html.erb
@@ -19,15 +19,15 @@
           actions: false,
         ) do |summary_list| %>
       <%= summary_list.with_row do |row| %>
-        <%= row.with_key(text: t(".laa_reference"), classes: "govuk-!-width-one-half") %>
+        <%= row.with_key(text: t(".laa_reference")) %>
         <%= row.with_value(text: @legal_aid_application.target_application&.application_ref) %>
       <% end %>
       <%= summary_list.with_row do |row| %>
-        <%= row.with_key(text: t(".client"), classes: "govuk-!-width-one-half") %>
+        <%= row.with_key(text: t(".client")) %>
         <%= row.with_value(text: @legal_aid_application.target_application&.applicant&.full_name) %>
       <% end %>
       <%= summary_list.with_row do |row| %>
-        <%= row.with_key(text: t(".proceedings"), classes: "govuk-!-width-one-half") %>
+        <%= row.with_key(text: t(".proceedings")) %>
         <%= row.with_value(text: @legal_aid_application.target_application&.proceedings&.map(&:meaning)&.join(", ")) %>
       <% end %>
     <% end %>

--- a/app/views/providers/link_application/copies/show.html.erb
+++ b/app/views/providers/link_application/copies/show.html.erb
@@ -10,7 +10,7 @@
         form:,
         template: :basic,
       ) do %>
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-1"><%= t(".heading") %></h1>
+    <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
     <%= govuk_summary_list(actions: false, classes: "govuk-summary-list--no-border") do |summary_list|
           summary_list.with_row do |row|
             row.with_key { t(".reference") }


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5219)

Update spacing to make consistent and use default margins.

Screenshots:
<img width="1474" alt="image" src="https://github.com/user-attachments/assets/b7806187-3317-46f7-849d-ba53a9fbd35b">
<img width="1477" alt="image" src="https://github.com/user-attachments/assets/889a74f8-736b-431a-9a5d-4d7f305398b1">


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
