### PR TITLE
Chore: minor visual changes to ref num search page

### DIFF
--- a/app/views/providers/link_application/find_link_applications/show.html.erb
+++ b/app/views/providers/link_application/find_link_applications/show.html.erb
@@ -11,9 +11,11 @@
         template: :basic,
       ) do %>
 
-    <%= form.govuk_fieldset legend: { text: t(".heading"), tag: "h1", size: "xl" } do %>
-      <%= form.govuk_text_field :search_laa_reference, label: { text: t(".hint") } %>
-    <% end %>
+    <%= form.govuk_text_field :search_laa_reference,
+                              label: { text: t(".heading"), tag: "h1", size: "xl" },
+                              hint: { text: t(".hint") },
+                              extra_letter_spacing: true,
+                              width: 10 %>
 
     <%= next_action_buttons(continue_button_text: t("generic.search"), show_draft: true, form:) %>
   <% end %>


### PR DESCRIPTION
Changes made as suggested in the design system:
- Add extra letter spacing
- Make the text box smaller

Also changed text to hint text

Screenshot:

<img width="985" alt="image" src="https://github.com/user-attachments/assets/2cb2ead2-e8d8-4051-bfee-04ed87a92906">

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
