### PR TITLE
AP-5149: Update SCA proceeding questions to remove core

### DIFF
--- a/app/views/providers/proceedings_sca/heard_as_alternatives/show.html.erb
+++ b/app/views/providers/proceedings_sca/heard_as_alternatives/show.html.erb
@@ -4,7 +4,7 @@
       method: :patch,
       local: true,
     ) do |form| %>
-  <%= page_template page_title: t(".page_title.#{@amount}"),
+  <%= page_template page_title: t(".page_title.multiple"),
                     template: :basic,
                     form: do %>
     <%= form.govuk_collection_radio_buttons :heard_as_alternative,

--- a/app/views/providers/proceedings_sca/heard_togethers/show.html.erb
+++ b/app/views/providers/proceedings_sca/heard_togethers/show.html.erb
@@ -5,13 +5,13 @@
       method: :patch,
       local: true,
     ) do |form| %>
-  <%= page_template page_title: t(".page_title"), form:, template: :basic do %>
+  <%= page_template page_title: t(".page_title.multiple"), form:, template: :basic do %>
     <%= form.govuk_collection_radio_buttons :heard_together,
                                             yes_no_options,
                                             :value,
                                             :label,
                                             caption: { text: @current_proceeding.meaning, size: "xl" },
-                                            legend: { text: t(".page_heading.#{@amount}", core_sca: @core_proceedings.first.meaning), size: "xl", tag: "h1" } do %>
+                                            legend: { text: t(".page_title.#{@amount}", core_sca: @core_proceedings.first.meaning), size: "xl", tag: "h1" } do %>
                                               <% if @amount.eql?("multiple") %>
                                                 <p class="govuk-body">These are:</p>
                                                 <%= govuk_list @core_proceedings.pluck(:meaning), type: :bullet %>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1699,12 +1699,11 @@ en:
         hint: We'll use this to send your client a link to the service.
     proceedings_sca:
       heard_togethers:
-        error: Select yes if this proceeding will be heard together with any special children act core proceedings
+        error: Select yes if this proceeding will be heard together with any special children act proceedings
         show:
-          page_title: Will this proceeding be heard together with any special children act core proceedings?
-          page_heading:
+          page_title:
             single: Will this proceeding be heard together with the '%{core_sca}' proceeding?
-            multiple: Will this proceeding be heard together with any of the core proceedings?
+            multiple: Will this proceeding be heard together with any of the special children act proceedings?
       supervision_orders:
         error: Select yes if the application is to vary, discharge or extend a supervision order
         show:
@@ -1717,14 +1716,10 @@ en:
       heard_as_alternatives:
         show:
           error:
-            Select yes if this proceeding will be heard as an alternative to any of
-            the special children act core proceedings
+            Select yes if this proceeding will be heard as an alternative to any of the special children act proceedings
           page_title:
-            single:
-              Will this proceeding be heard as an alternative to the '%{proceeding}' proceeding?
-            multiple:
-              Will this proceeding be heard as an alternative to any of the special
-              children act core proceedings?
+            single: Will this proceeding be heard as an alternative to the '%{proceeding}' proceeding?
+            multiple: Will this proceeding be heard as an alternative to any of the special children act proceedings?
       change_of_names:
         error: Select yes if this proceeding is for a change of name application
         show:

--- a/spec/requests/providers/proceedings_sca/heard_as_alternatives_controller_spec.rb
+++ b/spec/requests/providers/proceedings_sca/heard_as_alternatives_controller_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe Providers::ProceedingsSCA::HeardAsAlternativesController do
       context "when there is one core proceeding" do
         it "returns http success" do
           expect(response).to have_http_status(:ok)
-          expect(unescaped_response_body).to include(I18n.t("providers.proceedings_sca.heard_as_alternatives.show.page_title.single"))
+          expect(response.body).to include("Will this proceeding be heard as an alternative to the &#39;Child assessment order&#39; proceeding?").once
+          expect(response.body).to include("Will this proceeding be heard as an alternative to any of the special children act proceedings?").once
         end
       end
 
@@ -79,7 +80,7 @@ RSpec.describe Providers::ProceedingsSCA::HeardAsAlternativesController do
 
         it "renders the same page with an error message" do
           expect(response).to have_http_status(:unprocessable_content)
-          expect(response.body).to include("Select yes if this proceeding will be heard as an alternative to any of the special children act core proceedings").twice
+          expect(response.body).to include("Select yes if this proceeding will be heard as an alternative to any of the special children act proceedings").twice
         end
       end
     end

--- a/spec/requests/providers/proceedings_sca/heard_togethers_controller_spec.rb
+++ b/spec/requests/providers/proceedings_sca/heard_togethers_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Providers::ProceedingsSCA::HeardTogethersController do
 
         it "returns http success" do
           expect(response).to have_http_status(:ok)
-          expect(unescaped_response_body).to include(I18n.t("providers.proceedings_sca.heard_togethers.show.page_heading.single", core_sca:))
+          expect(unescaped_response_body).to include(I18n.t("providers.proceedings_sca.heard_togethers.show.page_title.single", core_sca:))
         end
       end
 
@@ -37,7 +37,7 @@ RSpec.describe Providers::ProceedingsSCA::HeardTogethersController do
 
         it "returns http success" do
           expect(response).to have_http_status(:ok)
-          expect(response.body).to include(I18n.t("providers.proceedings_sca.heard_togethers.show.page_heading.multiple"))
+          expect(response.body).to include(I18n.t("providers.proceedings_sca.heard_togethers.show.page_title.multiple"))
         end
       end
     end
@@ -84,7 +84,7 @@ RSpec.describe Providers::ProceedingsSCA::HeardTogethersController do
 
         it "renders the same page with an error message" do
           expect(response).to have_http_status(:unprocessable_content)
-          expect(response.body).to include("Select yes if this proceeding will be heard together with any special children act core proceedings").twice
+          expect(response.body).to include("Select yes if this proceeding will be heard together with any special children act proceedings").twice
         end
       end
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

`core` is a descriptive term only used by the Civil Apply team, using it on provider pages could cause confusion 

This PR ensures we have consistent page titles, H1's and error messages on the two SCA proceeding loop questions

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
