### PR TITLE
AP-5231: SCA emergency references

### DIFF
--- a/app/services/flow/proceeding_loop.rb
+++ b/app/services/flow/proceeding_loop.rb
@@ -44,7 +44,7 @@ module Flow
         when "client_involvement_type"
           :delegated_functions
         when "delegated_functions", "confirm_delegated_functions_date"
-          current_proceeding.used_delegated_functions? ? :emergency_defaults : :substantive_defaults
+          current_proceeding.used_delegated_functions? && !current_proceeding.special_childrens_act? ? :emergency_defaults : :substantive_defaults
         when "emergency_defaults"
           current_proceeding.accepted_emergency_defaults ? :substantive_defaults : :emergency_level_of_service
         when "substantive_defaults"

--- a/app/services/flow/proceeding_loop.rb
+++ b/app/services/flow/proceeding_loop.rb
@@ -48,7 +48,7 @@ module Flow
         when "emergency_defaults"
           current_proceeding.accepted_emergency_defaults ? :substantive_defaults : :emergency_level_of_service
         when "substantive_defaults"
-          if current_proceeding.accepted_substantive_defaults
+          if current_proceeding.accepted_substantive_defaults || current_proceeding.special_childrens_act?
             if @application.checking_answers? && next_incomplete_proceeding.nil?
               :limitations
             else

--- a/app/services/query/incomplete_proceedings.rb
+++ b/app/services/query/incomplete_proceedings.rb
@@ -25,9 +25,9 @@ module Query
         (
             NOT EXISTS (select 'has_scope_limitations' FROM scope_limitations where (proceeding_id = proceedings.id))
             OR (used_delegated_functions IS NULL)
-            OR (accepted_substantive_defaults IS NULL AND matter_type != 'Special Children Act')
+            OR (accepted_substantive_defaults IS NULL AND ccms_matter_code != 'KPBLW')
             OR (client_involvement_type_ccms_code IS NULL)
-            OR (used_delegated_functions = true AND accepted_emergency_defaults IS NULL AND matter_type != 'Special Children Act')
+            OR (used_delegated_functions = true AND accepted_emergency_defaults IS NULL AND ccms_matter_code != 'KPBLW')
             OR (accepted_substantive_defaults = false
                 AND (substantive_level_of_service IS NULL
                     OR substantive_level_of_service_name IS NULL

--- a/app/services/query/incomplete_proceedings.rb
+++ b/app/services/query/incomplete_proceedings.rb
@@ -27,7 +27,7 @@ module Query
             OR (used_delegated_functions IS NULL)
             OR (accepted_substantive_defaults IS NULL AND matter_type != 'Special Children Act')
             OR (client_involvement_type_ccms_code IS NULL)
-            OR (used_delegated_functions = true AND accepted_emergency_defaults IS NULL)
+            OR (used_delegated_functions = true AND accepted_emergency_defaults IS NULL AND matter_type != 'Special Children Act')
             OR (accepted_substantive_defaults = false
                 AND (substantive_level_of_service IS NULL
                     OR substantive_level_of_service_name IS NULL

--- a/app/views/providers/check_provider_answers/_shared.html.erb
+++ b/app/views/providers/check_provider_answers/_shared.html.erb
@@ -50,7 +50,7 @@
         ) %>
   <% end %>
 
-  <% if @source_application.used_delegated_functions? %>
+  <% if @source_application.used_delegated_functions? && !@source_application.special_children_act_proceedings? %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-heading-m"><%= t ".emergency_cost_limit" %></h2>

--- a/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
+++ b/app/views/providers/legal_aid_applications/_legal_aid_applications.html.erb
@@ -54,9 +54,13 @@
                 end
                 row.with_cell(html_attributes: { class: "sortable-cell" }, text: application.application_ref)
                 row.with_cell(html_attributes: { class: "sortable-cell", "data-sort-value": application.used_delegated_functions?.to_s }) do
-                  if application.used_delegated_functions?
+                  if application.special_children_act_proceedings? && application.used_delegated_functions?
+                    concat t(".substantive")
+                    concat tag.span(class: "govuk-body-s govuk-!-display-block") {
+                      t(".backdated_to", date: l(application.used_delegated_functions_on, format: :short_date))
+                    }
+                  elsif application.used_delegated_functions?
                     concat t(".emergency")
-
                     if application.substantive_application_deadline_on? && application.summary_state == :in_progress
                       concat tag.span(class: "govuk-body-s govuk-!-display-block") {
                         t(".substantive_due", date: l(application.substantive_application_deadline_on, format: :short_date))

--- a/app/views/providers/limitations/_proceeding_type.html.erb
+++ b/app/views/providers/limitations/_proceeding_type.html.erb
@@ -17,7 +17,7 @@
       </span>
     </h3>
     <%= govuk_details(summary_text: t(".details_heading")) do %>
-      <% if proceeding.used_delegated_functions_on %>
+      <% if @legal_aid_application.display_emergency_certificate? %>
         <h4 class="govuk-heading-m"><%= t(".emergency_certificate") %></h4>
         <p><strong><%= t(".form_of_service") %></strong>
           <%= proceeding.emergency_level_of_service_name %>

--- a/app/views/shared/check_answers/_proceeding_details.html.erb
+++ b/app/views/shared/check_answers/_proceeding_details.html.erb
@@ -25,7 +25,7 @@
     <%= row.with_value { proceeding.used_delegated_functions_on&.strftime("%-d %B %Y") || t(".delegated_function_details.not_used") } %>
   <% end %>
 
-  <% if proceeding.used_delegated_functions? %>
+  <% if proceeding.used_delegated_functions? && !proceeding.special_childrens_act? %>
     <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{proceeding.name}_emergency_level_of_service_#{proceeding.id}" }) do |row| %>
       <%= row.with_key(text: t(".level_of_service.emergency.question"), classes: "govuk-!-width-one-half") %>
       <%= row.with_value { proceeding.send(:emergency_level_of_service_name) } %>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -892,6 +892,7 @@ en:
         emergency: Emergency
         substantive: Substantive
         substantive_due: "Substantive due: %{date}"
+        backdated_to: "Backdated to: %{date}"
         col_and_ref: and Ref
         col_and_state: and Status
         delete: Delete

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -549,6 +549,7 @@ en:
           court_order: Court order
           court_application: Court application
           expert_report: Expert report
+          parental_responsibility: Parental responsibility evidence
         evidence_upload_heading: Supporting evidence
       children_involved:
         involved-children-heading: Children involved in this application

--- a/spec/services/flow/proceeding_loop_spec.rb
+++ b/spec/services/flow/proceeding_loop_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Flow::ProceedingLoop do
                    df_options:,
                    provider_step:)
           end
-          let(:df_options) { { pb003: [10.days.ago, 10.days.ago], pb007: [10.days.ago, 10.days.ago], DA005: [nil, nil] } }
+          let(:df_options) { { pb003: [10.days.ago, 10.days.ago], pb007: [10.days.ago, 10.days.ago] } }
 
           it { is_expected.to be :substantive_defaults }
         end
@@ -108,6 +108,24 @@ RSpec.describe Flow::ProceedingLoop do
           before { proceeding.update!(accepted_emergency_defaults: false) }
 
           it { is_expected.to be :substantive_level_of_service }
+        end
+
+        context "and the provider has used an SCA proceeding" do
+          before { proceeding.update!(accepted_emergency_defaults: nil) }
+
+          let(:legal_aid_application) do
+            create(:legal_aid_application,
+                   :with_proceedings,
+                   :with_delegated_functions_on_proceedings,
+                   explicit_proceedings: %i[pb003 pb007],
+                   set_lead_proceeding: :pb007,
+                   df_options:,
+                   provider_step:)
+          end
+          let(:df_options) { { pb003: [10.days.ago, 10.days.ago], pb007: [10.days.ago, 10.days.ago], DA005: [nil, nil] } }
+          let(:proceeding) { legal_aid_application.proceedings.in_order_of_addition.first }
+
+          it { is_expected.to be :client_involvement_type }
         end
 
         context "when used_delegated functions_date > one month ago - test for ap-3537" do

--- a/spec/services/flow/proceeding_loop_spec.rb
+++ b/spec/services/flow/proceeding_loop_spec.rb
@@ -45,6 +45,21 @@ RSpec.describe Flow::ProceedingLoop do
           it { is_expected.to be :emergency_defaults }
         end
 
+        context "when the SCA proceeding has used delegated functions" do
+          let(:legal_aid_application) do
+            create(:legal_aid_application,
+                   :with_proceedings,
+                   :with_delegated_functions_on_proceedings,
+                   explicit_proceedings: %i[pb003 pb007],
+                   set_lead_proceeding: :pb007,
+                   df_options:,
+                   provider_step:)
+          end
+          let(:df_options) { { pb003: [10.days.ago, 10.days.ago], pb007: [10.days.ago, 10.days.ago], DA005: [nil, nil] } }
+
+          it { is_expected.to be :substantive_defaults }
+        end
+
         context "and the proceeding has not used delegated functions" do
           it { is_expected.to be :substantive_defaults }
         end

--- a/spec/services/query/incomplete_proceedings_spec.rb
+++ b/spec/services/query/incomplete_proceedings_spec.rb
@@ -96,6 +96,32 @@ module Query
       it { expect(query).to include(proceeding) }
     end
 
+    context "when a proceeding has not had the accepted_emergency_defaults question answered" do
+      context "and is not a special children act matter type" do
+        let(:proceeding) do
+          create(:proceeding, :da001, :with_df_date,
+                 accepted_emergency_defaults: nil,
+                 emergency_level_of_service: nil,
+                 emergency_level_of_service_name: nil,
+                 emergency_level_of_service_stage: nil)
+        end
+
+        it { expect(query).to include(proceeding) }
+      end
+
+      context "and is a special children act matter type" do
+        let(:proceeding) do
+          create(:proceeding, :pb003, :with_df_date,
+                 accepted_substantive_defaults: nil,
+                 client_involvement_type_ccms_code: "D",
+                 used_delegated_functions: false,
+                 accepted_emergency_defaults: nil)
+        end
+
+        it { expect(query).not_to include(proceeding) }
+      end
+    end
+
     context "when a proceeding has rejected the substantive defaults and not added scope_limitations" do
       let!(:proceeding) do
         create(:proceeding, :da001, :with_df_date,


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5231)

This updates the SCA flow to remove references to emergency certificates
* The ‘Emergency application’ page should not be shown
* The Check your answers page makes no reference to ‘Emergency’ scope or costs
* A new certificate type has been added to the Applications page
  
![image](https://github.com/user-attachments/assets/d40548bd-ae73-46ee-b817-f3d69678f0f4)



## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
