### PR TITLE
Ap 5230 link cannot be removed

### DIFF
--- a/app/controllers/providers/check_provider_answers_controller.rb
+++ b/app/controllers/providers/check_provider_answers_controller.rb
@@ -20,7 +20,8 @@ module Providers
           source_application = LegalAidApplication.find(legal_aid_application.copy_case_id)
           case_cloned_response = CopyCase::ClonerService.call(legal_aid_application, source_application)
           legal_aid_application.update!(case_cloned: case_cloned_response)
-        elsif destroy_lead_linked_application?
+        end
+        if destroy_lead_linked_application?
           legal_aid_application.lead_linked_application.destroy!
           legal_aid_application.update!(copy_case: nil, copy_case_id: nil)
         end
@@ -40,8 +41,9 @@ module Providers
     def destroy_lead_linked_application?
       application_link = legal_aid_application.lead_linked_application
       return false unless application_link
+      return false if application_link.confirm_link == true
 
-      application_link.link_type_code == "false" || application_link == false
+      true
     end
 
     def update_applicant_age_for_means_test_purposes!

--- a/app/views/providers/check_provider_answers/_standard.html.erb
+++ b/app/views/providers/check_provider_answers/_standard.html.erb
@@ -17,7 +17,7 @@
              address: @address,
              read_only: @read_only) %>
 
-  <%= if @legal_aid_application&.lead_linked_application&.link_type_code == "FC_LEAD"
+  <%= if @legal_aid_application&.lead_linked_application&.confirm_link == true && @legal_aid_application&.lead_linked_application&.link_type_code == "FC_LEAD"
         govuk_warning_text(text: t(".copy_case.family_warning"))
       end %>
 

--- a/app/views/shared/check_answers/_linking_and_copying.html.erb
+++ b/app/views/shared/check_answers/_linking_and_copying.html.erb
@@ -33,7 +33,7 @@
           end
         end
       end %>
-  <% if all_linked_applications_details(@legal_aid_application).present? %>
+  <% if @legal_aid_application&.lead_linked_application&.confirm_link? && all_linked_applications_details(@legal_aid_application).present? %>
     <div class="govuk-grid-row" id="app-check-your-answers__other_links">
       <div class="govuk-grid-column-full">
         <h2 class="govuk-heading-m"><%= t ".other_links_section.#{@legal_aid_application.lead_linked_application.link_type_code}" %></h2>

--- a/spec/requests/providers/check_provider_answers_controller_spec.rb
+++ b/spec/requests/providers/check_provider_answers_controller_spec.rb
@@ -335,7 +335,7 @@ RSpec.describe Providers::CheckProviderAnswersController do
             end
 
             context "when the provider does not want to link or copy" do
-              let(:link_type_code) { "false" }
+              let(:confirm_link) { false }
               let(:copy_case) { false }
 
               it "deletes the lead_linked_application amd copy data" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5230)

- Delete linked applications if confirm_link != true. NB in order for the back link to work as expected we do not actually delete the linked applciation record until the provider goes past the cya page.
- Hide linked applications on the cya page if confirm_link != true

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
