### PR TITLE
AP-5257: Add matter type and category of law to added proceedings page

### DIFF
--- a/app/views/providers/has_other_proceedings/show.html.erb
+++ b/app/views/providers/has_other_proceedings/show.html.erb
@@ -8,7 +8,10 @@
       <%= govuk_summary_list do |summary_list| %>
         <% @legal_aid_application.proceedings.order(:created_at).each do |proceeding| %>
           <%= summary_list.with_row(html_attributes: { id: "proceeding_type_#{proceeding.ccms_code}" }) do |row| %>
-            <%= row.with_value { proceeding.meaning } %>
+            <%= row.with_value do %>
+              <%= proceeding.meaning %><br>
+              <span class="govuk-hint"><%= proceeding.category_of_law %> (<%= proceeding.matter_type %>)</span>
+            <% end %>
             <% if proceeding.sca_type == "core" && @legal_aid_application.related_proceedings.any? %>
               <%= row.with_action(
                     text: t(".remove"),


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5257)

Add matter type and category of law to added proceedings page as per designs in the ticket

Screenshot:
<img width="1472" alt="image" src="https://github.com/user-attachments/assets/4aef3d77-d753-4894-a3c3-65cc025ca9d7">

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
