### PR TITLE
AP-5273: SCA level of service fix

### DIFF
--- a/app/forms/proceedings/substantive_defaults_form.rb
+++ b/app/forms/proceedings/substantive_defaults_form.rb
@@ -40,6 +40,9 @@ module Proceedings
         attributes[:substantive_level_of_service_name] = nil
         attributes[:substantive_level_of_service_stage] = nil
       else
+        model.update!(substantive_level_of_service:,
+                      substantive_level_of_service_name:,
+                      substantive_level_of_service_stage:)
         model.scope_limitations.create!(scope_type: :substantive,
                                         code: substantive_scope_limitation_code,
                                         meaning: substantive_scope_limitation_meaning,

--- a/app/views/shared/check_answers/_proceeding_details.html.erb
+++ b/app/views/shared/check_answers/_proceeding_details.html.erb
@@ -40,7 +40,7 @@
         ) %>
 
     <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{proceeding.name}_emergency_scope_limitations_#{proceeding.id}" }) do |row| %>
-      <%= row.with_key(text: t(".level_of_service.emergency.question"), classes: "govuk-!-width-one-half") %>
+      <%= row.with_key(text: t(".scope_limits.emergency.question"), classes: "govuk-!-width-one-half") %>
       <%= row.with_value { scope_limits(proceeding, "emergency") } %>
     <% end %>
   <% end %>
@@ -59,7 +59,7 @@
       ) %>
 
   <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{proceeding.name}_substantive_scope_limitations_#{proceeding.id}" }) do |row| %>
-    <%= row.with_key(text: t(".level_of_service.substantive.question"), classes: "govuk-!-width-one-half") %>
+    <%= row.with_key(text: t(".scope_limits.substantive.question"), classes: "govuk-!-width-one-half") %>
     <%= row.with_value { scope_limits(proceeding, "substantive") } %>
   <% end %>
 <% end %>

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -592,6 +592,11 @@ en:
             question: Emergency level of service
           substantive:
             question: Substantive level of service
+        scope_limits:
+          emergency:
+            question: Emergency scope limitations
+          substantive:
+            question: Substantive scope limitations
       delegated_functions:
         not_used: Not used
         section_delegated:

--- a/spec/factories/proceedings.rb
+++ b/spec/factories/proceedings.rb
@@ -36,6 +36,12 @@ FactoryBot.define do
       used_delegated_functions_reported_on { Time.zone.today }
     end
 
+    trait :no_substantive_level_of_service do
+      substantive_level_of_service { nil }
+      substantive_level_of_service_name { nil }
+      substantive_level_of_service_stage { nil }
+    end
+
     transient do
       no_scope_limitations { false }
     end

--- a/spec/forms/proceedings/substantive_defaults_form_spec.rb
+++ b/spec/forms/proceedings/substantive_defaults_form_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Proceedings::SubstantiveDefaultsForm, :vcr, type: :form do
 
     context "with a Special Childrens Act proceeding" do
       let(:params) { {} }
-      let(:proceeding) { create(:proceeding, :pb003, :without_df_date, client_involvement_type_ccms_code: "A", no_scope_limitations: true) }
+      let(:proceeding) { create(:proceeding, :pb003, :without_df_date, :no_substantive_level_of_service, client_involvement_type_ccms_code: "A", no_scope_limitations: true) }
 
       it "sets the default values" do
         expect(proceeding.substantive_level_of_service).to eq 3
@@ -122,6 +122,9 @@ RSpec.describe Proceedings::SubstantiveDefaultsForm, :vcr, type: :form do
         let(:skip_subject) { true }
 
         it "creates a scope_limitation object" do
+          expect(proceeding.substantive_level_of_service).to be_nil
+          expect(proceeding.substantive_level_of_service_name).to be_nil
+          expect(proceeding.substantive_level_of_service_stage).to be_nil
           expect { save_form }.to change(proceeding.scope_limitations, :count).by(1)
           expect(proceeding.scope_limitations.find_by(scope_type: :substantive)).to have_attributes(code: "FM062", description: "Limited to all steps up to and including final hearing and any action necessary to implement (but not enforce) the order.")
         end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5273)

Update the SubstantiveDefaultsForm handling of the default level of service

On a non-sca proceeding the view stores default values and passes them as controller params to the form.  

The SCA skip removed the submission of these and meant that the default LOS was not set

This updates the test to ensure the proceeding is instantiated in the same way that it occurs in the controller, i.e. no default values populated for the three substantive default level of service fields. It then updates the form to set the value using the values called from LFA and stored as form values

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
