### PR TITLE
ap-5168: Fix sca merits report unable to display age

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -50,7 +50,7 @@ class Applicant < ApplicationRecord
   end
 
   def age
-    return age_for_means_test_purposes if no_means_test_required? || under_16_blocked?
+    return age_for_means_test_purposes if no_means_test_required? || under_16_blocked? || legal_aid_application&.special_children_act_proceedings?
 
     AgeCalculator.call(date_of_birth, legal_aid_application.calculation_date)
   end

--- a/app/views/providers/proceeding_merits_task/check_who_client_is/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/check_who_client_is/show.html.erb
@@ -7,7 +7,7 @@
     <p class="govuk-body"><%= t(".paragraph") %></p>
   <% end %>
 
-  <%= render("shared/check_answers/relationship_to_child", proceeding: @proceeding, relationship_to_child: @relationship_to_child) %>
+  <%= render("shared/check_answers/relationship_to_child", proceeding: @proceeding, relationship_to_child: @relationship_to_child, read_only: false) %>
 
   <%= next_action_buttons_with_form(
         url: providers_merits_task_list_check_who_client_is_path(@proceeding),

--- a/app/views/shared/check_answers/_merits_proceeding_section.html.erb
+++ b/app/views/shared/check_answers/_merits_proceeding_section.html.erb
@@ -96,7 +96,7 @@
     <% end %>
 
     <% if proceeding.relationship_to_child %>
-      <%= render("shared/check_answers/relationship_to_child", proceeding:, relationship_to_child: proceeding.relationship_to_child) %>
+      <%= render("shared/check_answers/relationship_to_child", proceeding:, relationship_to_child: proceeding.relationship_to_child, read_only:) %>
     <% end %>
 
     <%= govuk_summary_list(actions: !read_only) do |summary_list| %>

--- a/app/views/shared/check_answers/_relationship_to_child.html.erb
+++ b/app/views/shared/check_answers/_relationship_to_child.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_summary_list do |summary_list|
+<%= govuk_summary_list(actions: !read_only) do |summary_list|
       summary_list.with_row do |row|
         row.with_key(text: t(".biological_parent"), classes: "govuk-!-width-one-half")
         row.with_value(text: yes_no(relationship_to_child.eql?("biological")))

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -167,6 +167,18 @@ RSpec.describe Applicant do
         expect(age).to be 17
       end
     end
+
+    context "when sca application" do
+      let(:legal_aid_application) { create(:legal_aid_application, :with_multiple_sca_proceedings, applicant:) }
+
+      before do
+        applicant.age_for_means_test_purposes = 48
+      end
+
+      it "returns age stored in age_for_means_test_purposes" do
+        expect(age).to be 48
+      end
+    end
   end
 
   describe "#under_18?" do


### PR DESCRIPTION
The merits report was failing for SCA applications (without a DF date) because it was unable to calculate the applicant's age to display. Use age_for_means_test_purposes attribute.



## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5168)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
