### PR TITLE
AP-5297: Fix proceeding search requests for SCA

### DIFF
--- a/app/services/legal_framework/proceeding_types/all.rb
+++ b/app/services/legal_framework/proceeding_types/all.rb
@@ -42,7 +42,7 @@ module LegalFramework
 
       def request_body
         {
-          current_proceedings: @legal_aid_application.proceedings&.map(&:ccms_code)&.join(","),
+          current_proceedings: @legal_aid_application.proceedings&.map(&:ccms_code),
           allowed_categories: %w[MAT], # TODO: replace with details from new PDA, for now hardcoded to only current category type
           search_term: "", # TODO: add optional parameter to the initializer, but for now leave always empty
         }.to_json


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5297)

When submitting the current proceedings to LFA it expects an array of proceeding codes, e.g. `["PB003", "PB019"]`

The previous (join) code in Apply was merging them and sending `["PB003, PB019"]`

This caused the proceeding search code to fail and would not match the individual codes, i.e. it could not find a proceeding with the code "PB003, PB019" and would return non-SCA data

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
