### PR TITLE
Chore: remove notify feedback template config code

### DIFF
--- a/config/govuk_notify_templates.yml
+++ b/config/govuk_notify_templates.yml
@@ -1,5 +1,4 @@
 citizen_start_application: 6cfe6265-c465-4379-bafc-81c44d412ac6
-feedback_notification: abb5932d-24a3-49fe-a103-907d367dd75f
 submission_confirmation: 5472b10b-bc11-432a-a18d-9f20de5b2854
 reminder_to_submit_an_application: 96e58b6c-83e2-4ae8-be67-028803e98398
 client_completed_means: b343446d-b487-4f8b-9673-2aaf21ea10a1


### PR DESCRIPTION
## What

Remove notify feedback template config code

To do:
- [ ] Remove notify template before merging

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
