### PR TITLE
AP-4642: Update content when application is means tested

### DIFF
--- a/app/views/providers/review_and_print_applications/show.html.erb
+++ b/app/views/providers/review_and_print_applications/show.html.erb
@@ -22,7 +22,13 @@
       <% end %>
     </p>
 
-    <p class="govuk-body"><%= t(".keep_a_copy") %></p>
+    <p class="govuk-body">
+      <% if @legal_aid_application.non_means_tested? %>
+        <%= t(".keep_a_copy.non_means_tested") %>
+      <% else %>
+        <%= t(".keep_a_copy.means_tested") %>
+      <% end %>
+    </p>
 
     <p class="govuk-body"><%= t(".audit") %></p>
 

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1643,8 +1643,10 @@ en:
           non_means_tested: |
             Print the application and get the person acting for %{applicant_name} to sign it. For example,
             a litigation friend, a professional children’s guardian or a parental order report.
-        keep_a_copy: You'll need to keep a copy of it on file, along with any evidence you used to determine your client's financial situation.
         audit: You may need to show this if you’re audited by the LAA in the future.
+        keep_a_copy:
+          means_tested: You'll need to keep a copy of it on file, along with any evidence you used to determine your client's financial situation.
+          non_means_tested: You'll need to keep a copy of it on file, along with any evidence you included.
     substantive_applications:
       show:
         heading: Do you want to make a substantive application now?

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1642,7 +1642,7 @@ en:
           means_tested_with_partner: Print the application and get your client and their partner to sign the declaration.
           non_means_tested: |
             Print the application and get the person acting for %{applicant_name} to sign it. For example,
-            a litigation friend, a professional children's guardian or a parental order report.
+            a litigation friend, a professional children's guardian or a parental order reporter.
         audit: You may need to show this if you're audited by the LAA in the future.
         keep_a_copy:
           means_tested: You'll need to keep a copy of it on file, along with any evidence you used to determine your client's financial situation.

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1642,8 +1642,8 @@ en:
           means_tested_with_partner: Print the application and get your client and their partner to sign the declaration.
           non_means_tested: |
             Print the application and get the person acting for %{applicant_name} to sign it. For example,
-            a litigation friend, a professional children’s guardian or a parental order report.
-        audit: You may need to show this if you’re audited by the LAA in the future.
+            a litigation friend, a professional children's guardian or a parental order report.
+        audit: You may need to show this if you're audited by the LAA in the future.
         keep_a_copy:
           means_tested: You'll need to keep a copy of it on file, along with any evidence you used to determine your client's financial situation.
           non_means_tested: You'll need to keep a copy of it on file, along with any evidence you included.

--- a/features/providers/review_and_print.feature
+++ b/features/providers/review_and_print.feature
@@ -175,7 +175,7 @@ Feature: Review and print your application
 
     And I should see 'Non means tested'
     And I should see 'Print the application and get the person acting for'
-    And I should see 'For example, a litigation friend, a professional children’s guardian or a parental order report.'
+    And I should see "For example, a litigation friend, a professional children's guardian or a parental order report."
 
     Then the following sections should not exist:
       | tag | section |


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4642)

- Update content when application is means tested
- Minor content tidy up: change curly apostrophes to straight

## Screenshots
Means tested:
<img width="667" alt="image" src="https://github.com/user-attachments/assets/9abeea0a-c77b-4c41-98ff-5aa6771d7024">

Non means tested:
<img width="661" alt="image" src="https://github.com/user-attachments/assets/a8476167-d945-4861-8e6e-341b40b8cbfd">

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 