### PR TITLE
AP-4454: Fix for DWP Override means report review reason

### DIFF
--- a/app/services/ccms/manual_review_determiner.rb
+++ b/app/services/ccms/manual_review_determiner.rb
@@ -32,7 +32,7 @@ module CCMS
     end
 
     def manual_review_required?
-      dwp_override.present? ||
+      dwp_overridden? ||
         manually_review_all_non_passported? ||
         capital_contribution_required? ||
         has_restrictions? ||
@@ -61,7 +61,7 @@ module CCMS
 
     def application_review_reasons
       application_review_reasons = []
-      application_review_reasons << :dwp_override if dwp_override
+      application_review_reasons << :dwp_override if dwp_overridden?
       application_review_reasons << :restrictions if has_restrictions?
       application_review_reasons << :policy_disregards if policy_disregards?
       application_review_reasons << :non_passported if non_passported?
@@ -71,6 +71,10 @@ module CCMS
       application_review_reasons << :partner_uploaded_bank_statements if partner_uploading_bank_statements?
       application_review_reasons << :ineligible if cfe_result.ineligible?
       application_review_reasons
+    end
+
+    def dwp_overridden?
+      dwp_override.present? && dwp_override.values_at(:passporting_benefit, :has_evidence_of_benefit).all?(&:present?)
     end
 
     def manually_review_all_non_passported?

--- a/spec/services/ccms/manual_review_determiner_spec.rb
+++ b/spec/services/ccms/manual_review_determiner_spec.rb
@@ -43,7 +43,7 @@ module CCMS
         end
 
         context "with DWP override" do
-          before { create(:dwp_override, legal_aid_application:) }
+          before { create(:dwp_override, :with_evidence, legal_aid_application:) }
 
           context "when passported, no contrib, no_restrictions" do
             let(:legal_aid_application) { create(:legal_aid_application, :with_positive_benefit_check_result) }
@@ -133,7 +133,7 @@ module CCMS
         end
 
         context "with DWP override" do
-          before { create(:dwp_override, legal_aid_application:) }
+          before { create(:dwp_override, :with_evidence, legal_aid_application:) }
 
           context "and the application is passported" do
             let(:legal_aid_application) { create(:legal_aid_application, :with_positive_benefit_check_result, has_restrictions: true) }
@@ -297,7 +297,7 @@ module CCMS
         end
 
         context "with DWP override" do
-          before { create(:dwp_override, legal_aid_application:) }
+          before { create(:dwp_override, :with_evidence, legal_aid_application:) }
 
           it "adds the dwp review to the cfe result reasons" do
             expect(review_reasons_result).to eq override_reasons

--- a/spec/services/ccms/manual_review_determiner_spec.rb
+++ b/spec/services/ccms/manual_review_determiner_spec.rb
@@ -304,6 +304,16 @@ module CCMS
           end
         end
 
+        context "with inconsistent dwp override values" do
+          # This replicates a production application that presented caseworkers with a dilemma,
+          # we were unable to replicate the steps taken to get to this state
+          before { create(:dwp_override, legal_aid_application:, has_evidence_of_benefit: nil, passporting_benefit: nil) }
+
+          it "does not add dwp_override to reason" do
+            expect(review_reasons_result).not_to include(:dwp_override)
+          end
+        end
+
         context "with client further employment information" do
           let(:legal_aid_application) { create(:legal_aid_application, :with_employed_applicant_and_extra_info) }
 


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4454)

In production a caseworker found an application where it had been flagged for caseworker review as the provider had overridden the dwp response.

In reality, they must have said yes, gone back and changed the client record and moved onto the passported flow.

A DWPOverride record was created but the questions had not been answered.

I was unable to replicate the steps needed to get the application into that state so this PR adds addition checks to the manual review determiner to ensure that we only flag an application when the object is present _and_ the questions have been answered


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
