### PR TITLE
AP-5027: Fix different change link sizes

### DIFF
--- a/app/assets/stylesheets/providers/search_results.scss
+++ b/app/assets/stylesheets/providers/search_results.scss
@@ -59,6 +59,7 @@
 }
 
 .govuk-link-right {
+  @extend %govuk-body-m;
   float: right;
 }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5027)

Update govuk-link-right class to extend govuk-body so the link is the correct size

Screenshot:

<img width="685" alt="image" src="https://github.com/user-attachments/assets/8358c9d4-dace-43ff-86b5-df29249e6b2a">


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
