### PR TITLE
Chore: make 'in scope of laspo' page heading consistent

### DIFF
--- a/app/views/providers/application_merits_task/in_scope_of_laspos/show.html.erb
+++ b/app/views/providers/application_merits_task/in_scope_of_laspos/show.html.erb
@@ -7,8 +7,7 @@
                                             yes_no_options,
                                             :value,
                                             :label,
-                                            hint: { text: "" },
-                                            legend: { text: page_title, tag: "h1", size: "l" } %>
+                                            legend: { text: page_title, tag: "h1", size: "xl" } %>
     <%= next_action_buttons show_draft: true, form: %>
   <% end %>
 <% end %>


### PR DESCRIPTION

## What

Make 'in scope of laspo' page heading xl to be consistent with other pages

Screenshot:

<img width="1490" alt="image" src="https://github.com/user-attachments/assets/8705461d-6d09-45fe-964a-859a05f240f2">

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
