### PR TITLE
AP-5169 Add separate representation required to merits report

### DIFF
--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -31,3 +31,8 @@
 <%= render("shared/check_answers/merits_proceeding_section", read_only:) %>
 
 <%= render("shared/check_answers/supporting_evidence", read_only:) %>
+
+<!--This is to prevent the separate representation section from showing up anywhere other than the merits report -->
+<% if @legal_aid_application.summary_state.to_s == 'submitted' && @legal_aid_application.special_children_act_proceedings? %>
+  <%= render("shared/check_answers/separate_representation") %>
+<% end %>

--- a/app/views/shared/check_answers/_separate_representation.html.erb
+++ b/app/views/shared/check_answers/_separate_representation.html.erb
@@ -1,0 +1,12 @@
+<% if @legal_aid_application.separate_representation_required %>
+  <section class="print-no-break">
+    <h2 class="govuk-heading-l"><%= t(".heading") %></h2>
+
+    <%= govuk_summary_list(actions: false, classes: "govuk-!-margin-bottom-9") do |summary_list| %>
+        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__separate_representation_required" }) do |row| %>
+          <%= row.with_key(text: t(".separate_representation"), classes: "govuk-!-width-one-half") %>
+          <%= row.with_value(text: t(".confirmed")) %>
+      <% end %>
+    <% end %>
+  </section>
+<% end %>

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -524,6 +524,10 @@ en:
         police_notified: Have the police been notified?
         understands_terms_of_court_order: Do all parties have the mental capacity to understand the terms of a court order?
         warning_letter_sent: Has a warning letter been sent to the opponent?
+      separate_representation:
+        heading: Separate representation
+        separate_representation: Client wants separate representation?
+        confirmed: Confirmed
       undertaking:
         heading: Client offer of undertakings
         undertaking_offered: Has the client offered undertakings?


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5169)

Add separate representation required question to merits report.
Made sure this section doesn't appear on the CYA page or RTA page (which all use the same partials) by checking the application `summary_state`.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
