### PR TITLE
Chore: Add `?debug` handler to merits report

### DIFF
--- a/app/controllers/providers/merits_reports_controller.rb
+++ b/app/controllers/providers/merits_reports_controller.rb
@@ -3,10 +3,13 @@ module Providers
     authorize_with_policy_method :show_submitted_application?
 
     def show
-      html = render_to_string "show", layout: "pdf"
-      pdf = Grover.new(html).to_pdf
-
-      send_data pdf, filename: "merits_report.pdf", type: "application/pdf", disposition: "inline"
+      if params.key?(:debug)
+        render "show", layout: "pdf"
+      else
+        html = render_to_string "show", layout: "pdf"
+        pdf = Grover.new(html).to_pdf
+        send_data pdf, filename: "merits_report.pdf", type: "application/pdf", disposition: "inline"
+      end
     end
   end
 end

--- a/spec/requests/providers/merits_reports_controller_spec.rb
+++ b/spec/requests/providers/merits_reports_controller_spec.rb
@@ -55,6 +55,41 @@ RSpec.describe Providers::MeritsReportsController do
     end
   end
 
+  describe "GET /providers/applications/:legal_aid_application_id/merits_report?debug" do
+    subject(:request) do
+      get providers_legal_aid_application_merits_report_path(legal_aid_application, debug: true)
+    end
+
+    before do
+      stub_merits_task_list(legal_aid_application:, merits_task_list:)
+      allow(Grover).to receive(:new).and_call_original
+      login_provider
+      request
+    end
+
+    context "when authenticated and authorised" do
+      let(:login_provider) { login_as legal_aid_application.provider }
+
+      it "renders the merits report PDF", :aggregate_failures do
+        expect(response).to have_http_status(:ok)
+        expect(response.headers["Content-Type"]).to eq("text/html; charset=utf-8")
+        expect(Grover).not_to have_received(:new)
+      end
+    end
+
+    context "when not authenticated" do
+      let(:login_provider) { nil }
+
+      it_behaves_like "a provider not authenticated"
+    end
+
+    context "when not authorised" do
+      let(:login_provider) { login_as create(:provider) }
+
+      it_behaves_like "an authenticated provider from a different firm"
+    end
+  end
+
   def stub_merits_task_list(legal_aid_application:, merits_task_list:)
     allow(LegalFramework::MeritsTasksService)
       .to receive(:call)


### PR DESCRIPTION
## What

This was present on the means report, but never implemented on the merits report. 
This PR rectifies that so developers can check pdf appearance in browser


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
