### PR TITLE
AP-5307: Add firm offices to new PDA result

### DIFF
--- a/app/services/pda/provider_details_creator.rb
+++ b/app/services/pda/provider_details_creator.rb
@@ -38,7 +38,7 @@ module PDA
     end
 
     def offices
-      provider_details.offices.map do |ccms_office|
+      provider_details.firm_offices.map do |ccms_office|
         Office.find_or_initialize_by(ccms_id: ccms_office.id) do |office|
           office.code = ccms_office.code
         end

--- a/helm_deploy/apply-for-legal-aid/templates/NOTES.txt
+++ b/helm_deploy/apply-for-legal-aid/templates/NOTES.txt
@@ -1,6 +1,6 @@
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
-https://{{ .Values.ingress.host }}{{ $.Values.ingress.path }}
+https://{{ .Values.deploy.host }}{{ $.Values.ingress.path }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "apply-for-legal-aid.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/spec/cassettes/PDA_ProviderDetailsRetriever/_call/with_a_non_existent_user/returns_an_error.yml
+++ b/spec/cassettes/PDA_ProviderDetailsRetriever/_call/with_a_non_existent_user/returns_an_error.yml
@@ -12,18 +12,16 @@ http_interactions:
       X-Authorization:
       - "<PDA_AUTH_KEY>"
       User-Agent:
-      - Faraday v2.10.1
+      - Faraday v2.12.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
-      code: 200
+      code: 204
       message: ''
     headers:
       Date:
-      - Wed, 21 Aug 2024 08:30:58 GMT
-      Content-Length:
-      - '0'
+      - Fri, 20 Sep 2024 11:00:30 GMT
       Connection:
       - keep-alive
       Vary:
@@ -47,5 +45,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-  recorded_at: Wed, 21 Aug 2024 08:30:58 GMT
-recorded_with: VCR 6.2.0
+  recorded_at: Fri, 20 Sep 2024 11:00:30 GMT
+recorded_with: VCR 6.3.1

--- a/spec/cassettes/PDA_ProviderDetailsRetriever/_call/with_an_existing_user/returns_provider_details.yml
+++ b/spec/cassettes/PDA_ProviderDetailsRetriever/_call/with_an_existing_user/returns_provider_details.yml
@@ -12,7 +12,7 @@ http_interactions:
       X-Authorization:
       - "<PDA_AUTH_KEY>"
       User-Agent:
-      - Faraday v2.10.1
+      - Faraday v2.12.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -21,7 +21,7 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Wed, 21 Aug 2024 08:30:58 GMT
+      - Fri, 20 Sep 2024 11:00:30 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -48,8 +48,65 @@ http_interactions:
       - DENY
     body:
       encoding: UTF-8
-      string: '{"firm":{"firmId":3959183,"firmNumber":"50736","ccmsFirmId":0,"firmName":"DT
+      string: '{"firm":{"firmId":3959183,"firmNumber":"50736","ccmsFirmId":10835831,"firmName":"DT
         SCRIPT PROVIDER 1"},"user":{"userId":454031,"ccmsContactId":0,"userLogin":"DT_SCRIPT_USER1","name":"Dts
-        User1"},"officeCodes":[{"firmOfficeCode":"2Q242F","ccmsProviderOfficeId":34406595}]}'
-  recorded_at: Wed, 21 Aug 2024 08:30:58 GMT
-recorded_with: VCR 6.2.0
+        User1","emailAddress":"deepak.tanna@digital.justice.gov.uk","portalStatus":"Active"},"officeCodes":[{"firmOfficeId":145434,"ccmsFirmOfficeId":34406595,"firmOfficeCode":"2Q242F","officeName":"2Q242F,1
+        Skyscraper","officeCodeAlt":"DT Script Office 1"}]}'
+  recorded_at: Fri, 20 Sep 2024 11:00:30 GMT
+- request:
+    method: get
+    uri: https://laa-provider-details-api-uat.apps.live.cloud-platform.service.justice.gov.uk/provider-firms/3959183/provider-offices
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authorization:
+      - "<PDA_AUTH_KEY>"
+      User-Agent:
+      - Faraday v2.12.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 20 Sep 2024 11:00:30 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Access-Control-Request-Headers
+      - Access-Control-Request-Method
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: '{"firm":{"firmId":3959183,"firmNumber":"50736","ccmsFirmId":10835831,"firmName":"DT
+        SCRIPT PROVIDER 1"},"offices":[{"firmOfficeId":145434,"ccmsFirmOfficeId":34406595,"firmOfficeCode":"2Q242F","officeName":"2Q242F,1
+        Skyscraper","officeCodeAlt":"DT Script Office 1","addressLine1":"1 Skyscraper","addressLine2":"1
+        Some Road","addressLine3":null,"addressLine4":null,"city":"Metropolis","county":null,"postCode":"LE1
+        1AA","dxCentre":null,"dxNumber":null,"telephoneAreaCode":"01162","telephoneNumber":"555124","faxAreaCode":null,"faxNumber":null,"emailAddress":"me@email.uk","vatRegistrationNumber":null,"type":"Legal
+        Services Provider","headOffice":"N/A","creationDate":"2023-11-10","lscRegion":"Midlands","lscBidZone":"Leicester","lscAreaOffice":"Nottingham","cjsForceName":"Leicestershire","localAuthority":"City
+        of Leicester","policeStationAreaName":"Leicester","dutySolicitorAreaName":"Leicester"}]}'
+  recorded_at: Fri, 20 Sep 2024 11:00:30 GMT
+recorded_with: VCR 6.3.1

--- a/spec/services/pda/compare_provider_details_spec.rb
+++ b/spec/services/pda/compare_provider_details_spec.rb
@@ -1,72 +1,75 @@
 require "rails_helper"
 
 RSpec.describe PDA::CompareProviderDetails do
-  let(:firm_struct) { Struct.new(:id, :name) }
-  let(:office_struct) { Struct.new(:id, :code) }
-  let(:provider_details_struct) { Struct.new(:firm_id, :contact_id, :firm_name, :offices) }
-
   describe ".call" do
     subject(:call) { described_class.call(provider.id) }
 
     before do
       allow(Rails.logger).to receive(:info).at_least(:once)
       firm.providers << provider
-      provider.offices << office
+      provider.offices += offices
     end
 
-    let(:provider) { create(:provider, username:, contact_id:) }
     let(:firm) { create(:firm, ccms_id: ccms_firm_id, name: firm_name) }
-    let(:office) { create(:office, ccms_id: ccms_office_id, code: office_code) }
-    let(:firm_name) { "Test Firm" }
-    let(:office_code) { "6D456C" }
-    let(:username) { "test-user" }
-    let(:ccms_firm_id) { "1" }
-    let(:ccms_office_id) { "2" }
-    let(:contact_id) { 104 }
-    let(:ccms_firm) { firm_struct.new(ccms_firm_id, firm_name) }
-    let(:ccms_office) { office_struct.new(ccms_office_id, office_code) }
+    let(:ccms_firm_id) { 99_999 }
+    let(:firm_name) { "Test firm" }
 
-    context "when PDA returns details that match the provider's details" do
+    let(:provider) { create(:provider, contact_id: 494_000) }
+    let(:contact_id) { 494_000 }
+
+    let(:offices) do
+      [
+        create(:office, ccms_id: 111_111, code: "0A000B"),
+        create(:office, ccms_id: 222_222, code: "1A111B"),
+      ]
+    end
+
+    context "when old PDA returns details that match the new PDA provider's details" do
       before do
-        stub_provider_details_retriever(
-          provider:,
-          contact_id:,
-          firm: ccms_firm,
-          offices: [ccms_office],
-        )
+        stub_provider_offices
+        stub_provider_firm_offices
+      end
+
+      it "logs start and end time" do
+        call
+        expect(Rails.logger)
+          .to have_received(:info)
+          .with(%r{PDA::CompareProviderDetails:: start: .* end: .* duration: .* seconds})
       end
 
       it "logs that the details match" do
-        expect(Rails.logger).to receive(:info).with("PDA::CompareProviderDetails:: Provider #{provider.id} results match.")
         call
+        expect(Rails.logger)
+          .to have_received(:info)
+          .with("PDA::CompareProviderDetails:: Provider #{provider.id} results match.")
       end
     end
 
-    context "when PDA returns details that do not match the provider's details" do
+    context "when old PDA returns details that do NOT match the new PDA provider's details" do
       before do
-        stub_provider_details_retriever(
-          provider:,
-          contact_id:,
-          firm: ccms_firm,
-          offices: [ccms_office],
-        )
+        stub_provider_offices
+        stub_provider_firm_offices
       end
 
-      context "when the firm.ccms_id does not match" do
-        let(:ccms_firm) { firm_struct.new(3, firm_name) }
+      context "when users firm.ccms_id does not match" do
+        let(:ccms_firm_id) { 99_888 }
 
         it "logs that the details do not match" do
-          expect(Rails.logger).to receive(:info).with("PDA::CompareProviderDetails:: Provider #{provider.id} #{ccms_firm.id} does not match firm.ccms_id #{firm.ccms_id}")
           call
+          expect(Rails.logger)
+            .to have_received(:info)
+            .with("PDA::CompareProviderDetails:: Provider #{provider.id} 99999 does not match firm.ccms_id #{ccms_firm_id}")
         end
       end
 
       context "when the firm.name does not match" do
-        let(:ccms_firm) { firm_struct.new(ccms_firm_id, "Wrong firm name") }
+        let(:firm_name) { "Wrong firm name" }
 
         it "logs that the details do not match" do
-          expect(Rails.logger).to receive(:info).with("PDA::CompareProviderDetails:: Provider #{provider.id} #{ccms_firm.name} does not match firm.name #{firm.name}")
           call
+          expect(Rails.logger)
+            .to have_received(:info)
+            .with("PDA::CompareProviderDetails:: Provider #{provider.id} \"Test firm\" does not match firm.name \"#{firm.name}\"")
         end
       end
 
@@ -74,76 +77,147 @@ RSpec.describe PDA::CompareProviderDetails do
         before { provider.update!(contact_id: 105) }
 
         it "logs that the details do not match" do
-          expect(Rails.logger).to receive(:info).with("PDA::CompareProviderDetails:: Provider #{provider.id} #{contact_id} does not match provider.contact_id #{provider.contact_id}")
           call
+          expect(Rails.logger)
+            .to have_received(:info)
+            .with("PDA::CompareProviderDetails:: Provider #{provider.id} #{contact_id} does not match provider.contact_id #{provider.contact_id}")
         end
       end
 
-      context "when the office details do not match" do
-        context "when the office codes do not match" do
-          let(:ccms_office) { office_struct.new(ccms_office_id, "9R678Y") }
-
-          it "logs that the details do not match" do
-            expect(Rails.logger).to receive(:info).with("PDA::CompareProviderDetails:: Provider #{provider.id} [\"#{ccms_office.id} #{ccms_office.code}\"] does not match [\"#{office.ccms_id} #{office.code}\"]")
-            call
-          end
+      context "when no office codes match" do
+        let(:offices) do
+          [create(:office, ccms_id: 333_333, code: "2A222B")]
         end
 
-        context "when the office returned by PDA does not exist in apply" do
-          let(:ccms_office) { office_struct.new(3, office_code) }
+        it "logs that the details do not match" do
+          call
+          expect(Rails.logger)
+            .to have_received(:info)
+            .with("PDA::CompareProviderDetails:: Provider #{provider.id} [\"111111 0A000B\", \"222222 1A111B\"] does not match [\"333333 2A222B\"]")
+        end
+      end
 
-          it "logs that the details do not match" do
-            expect(Rails.logger).to receive(:info).with("PDA::CompareProviderDetails:: Provider #{provider.id} [\"#{ccms_office.id} #{ccms_office.code}\"] does not match [\"#{office.ccms_id} #{office.code}\"]")
-            call
-          end
+      context "when an office returned by PDA does not exist in apply" do
+        before do
+          provider.offices.find_by(ccms_id: 222_222).destroy!
         end
 
-        context "when an office is missing from the PDA response" do
-          let(:additional_office) { create(:office, ccms_id: "3", code: "4C880Q") }
+        it "logs that the details do not match" do
+          call
+          expect(Rails.logger)
+            .to have_received(:info)
+            .with("PDA::CompareProviderDetails:: Provider #{provider.id} [\"111111 0A000B\", \"222222 1A111B\"] does not match [\"111111 0A000B\"]")
+        end
+      end
 
-          it "logs that the details do not match" do
-            provider.offices << additional_office
-            expect(Rails.logger).to receive(:info).with("PDA::CompareProviderDetails:: Provider #{provider.id} [\"#{ccms_office.id} #{ccms_office.code}\"] does not match [\"#{office.ccms_id} #{office.code}\", \"#{additional_office.ccms_id} #{additional_office.code}\"]")
-            call
-          end
+      context "when an office is missing from the PDA response" do
+        let(:additional_office) { create(:office, ccms_id: 333_333, code: "2A222B") }
+
+        before do
+          provider.offices << additional_office
+        end
+
+        it "logs that the details do not match" do
+          call
+          expect(Rails.logger)
+            .to have_received(:info)
+            .with("PDA::CompareProviderDetails:: Provider #{provider.id} [\"111111 0A000B\", \"222222 1A111B\"] does not match [\"111111 0A000B\", \"222222 1A111B\", \"333333 2A222B\"]")
         end
       end
     end
 
-    context "when provider_details_retriever raises an error" do
-      context "when PDA returns an empty response" do
-        before do
-          stub_provider_details_retriever_record_not_found(
-            provider:,
-          )
-        end
-
-        it "logs that the details do not match" do
-          expect(Rails.logger).to receive(:info).with("PDA::CompareProviderDetails:: User not found for #{provider.id}.")
-          call
-        end
+    context "when PDA returns an empty response" do
+      before do
+        stub_provider_details_retriever_record_not_found(
+          provider:,
+        )
       end
 
-      context "when PDA returns an error" do
-        before do
-          stub_provider_details_retriever_api_error(
-            provider:,
-          )
-        end
+      it "logs that the details do not match" do
+        call
+        expect(Rails.logger)
+          .to have_received(:info)
+          .with("PDA::CompareProviderDetails:: User not found for #{provider.id}.")
+      end
+    end
 
-        it "logs that the details do not match" do
-          expect(Rails.logger).to receive(:info).with("PDA::CompareProviderDetails:: User #{provider.id} PDA::ProviderDetailsRetriever::ApiError")
-          call
-        end
+    context "when PDA returns an error" do
+      before do
+        stub_provider_details_retriever_api_error(
+          provider:,
+        )
+      end
+
+      it "logs that the details do not match" do
+        call
+        expect(Rails.logger)
+          .to have_received(:info)
+          .with("PDA::CompareProviderDetails:: User #{provider.id} PDA::ProviderDetailsRetriever::ApiError")
       end
     end
   end
 
-  def stub_provider_details_retriever(provider:, firm:, offices:, contact_id:)
-    allow(PDA::ProviderDetailsRetriever)
-      .to receive(:call)
-      .with(provider.username)
-      .and_return(api_response(firm:, offices:, contact_id:))
+  def stub_provider_offices
+    stub_request(:get, %r{#{Rails.configuration.x.pda.url}/provider-user/.*/provider-offices})
+      .to_return(
+        status: 200,
+        body: provider_offices_json,
+        headers: { "Content-Type" => "application/json; charset=utf-8" },
+      )
+  end
+
+  def provider_offices_json
+    {
+      firm: {
+        ccmsFirmId: 99_999,
+        firmId: 1639,
+        firmName: "Test firm",
+        firmNumber: "1639",
+      },
+      officeCodes: [
+        {
+          ccmsFirmOfficeId: 111_111,
+          firmOfficeCode: "0A000B",
+        },
+        {
+          ccmsFirmOfficeId: 222_222,
+          firmOfficeCode: "1A111B",
+        },
+      ],
+      user: {
+        ccmsContactId: 494_000,
+      },
+    }.to_json
+  end
+
+  def stub_provider_firm_offices
+    stub_request(:get, %r{#{Rails.configuration.x.pda.url}/provider-firms/.*/provider-offices})
+    .to_return(
+      status: 200,
+      body: provider_firm_offices_json,
+      headers: { "Content-Type" => "application/json; charset=utf-8" },
+    )
+  end
+
+  def provider_firm_offices_json
+    {
+      firm: {
+        ccmsFirmId: 99_999,
+        firmId: 1639,
+        firmName: "Test firm",
+        firmNumber: "1639",
+      },
+      offices: [
+        {
+          ccmsFirmOfficeId: 111_111,
+          firmOfficeCode: "0A000B",
+        },
+        {
+          ccmsFirmOfficeId: 222_222,
+          firmOfficeCode: "1A111B",
+        },
+      ],
+    }.to_json
   end
 
   def stub_provider_details_retriever_record_not_found(provider:)
@@ -158,9 +232,5 @@ RSpec.describe PDA::CompareProviderDetails do
       .to receive(:call)
       .with(provider.username)
       .and_raise(PDA::ProviderDetailsRetriever::ApiError)
-  end
-
-  def api_response(firm:, offices:, contact_id:)
-    provider_details_struct.new(firm_id: firm.id, contact_id:, firm_name: firm.name, offices:)
   end
 end

--- a/spec/services/pda/provider_details_creator_spec.rb
+++ b/spec/services/pda/provider_details_creator_spec.rb
@@ -1,17 +1,19 @@
 require "rails_helper"
+require_relative "provider_details_request_stubs"
 
 RSpec.describe PDA::ProviderDetailsCreator do
   let(:firm_struct) { Struct.new(:id, :name) }
   let(:office_struct) { Struct.new(:id, :code) }
   let(:provider_details_struct) { Struct.new(:firm_id, :contact_id, :firm_name, :firm_offices) }
 
+  before do
+    stub_provider_offices
+    stub_other_provider_offices
+    stub_provider_firm_offices
+  end
+
   describe ".call" do
     context "when the firm does not exist" do
-      before do
-        stub_provider_offices
-        stub_provider_firm_offices
-      end
-
       it "creates the firm" do
         provider = create(:provider, username: "test-user")
 
@@ -30,16 +32,8 @@ RSpec.describe PDA::ProviderDetailsCreator do
 
         offices = provider.firm.offices
         expect(offices).to contain_exactly(
-          have_attributes(
-            class: Office,
-            ccms_id: "111111",
-            code: "1A111B",
-          ),
-          have_attributes(
-            class: Office,
-            ccms_id: "222222",
-            code: "2A222B",
-          ),
+          have_attributes(class: Office, ccms_id: "111111", code: "1A111B"),
+          have_attributes(class: Office, ccms_id: "222222", code: "2A222B"),
         )
       end
 
@@ -48,19 +42,11 @@ RSpec.describe PDA::ProviderDetailsCreator do
 
         described_class.call(provider)
 
-        expect(provider).to have_attributes(
-          name: "",
-          contact_id: 494_000,
-        )
+        expect(provider).to have_attributes(name: "", contact_id: 494_000)
       end
     end
 
     context "when the provider's selected office is not returned from the API" do
-      before do
-        stub_provider_offices
-        stub_provider_firm_offices
-      end
-
       it "clears the selected office" do
         office = create(:office, code: "6D456C")
         provider = create(:provider, username: "test-user", selected_office: office)
@@ -72,11 +58,6 @@ RSpec.describe PDA::ProviderDetailsCreator do
     end
 
     context "when the provider's selected office is returned from the API" do
-      before do
-        stub_provider_offices
-        stub_provider_firm_offices
-      end
-
       it "does not clear the selected office" do
         office = create(:office, ccms_id: "111111", code: "1A111B")
         provider = create(:provider, username: "test-user", selected_office: office)
@@ -88,11 +69,6 @@ RSpec.describe PDA::ProviderDetailsCreator do
     end
 
     context "when the firm already exists with one of the offices" do
-      before do
-        stub_provider_offices
-        stub_provider_firm_offices
-      end
-
       it "does not create the firm" do
         existing_firm = create(:firm, ccms_id: "99999", name: "Test firm")
 
@@ -135,12 +111,6 @@ RSpec.describe PDA::ProviderDetailsCreator do
     end
 
     context "when another provider has the same firm, but different offices" do
-      before do
-        stub_provider_offices
-        stub_other_provider_offices
-        stub_provider_firm_offices
-      end
-
       it "associates all the firm's offices with each provider" do
         provider = create(:provider, username: "test-user")
         other_provider = create(:provider, username: "other-user")
@@ -159,99 +129,5 @@ RSpec.describe PDA::ProviderDetailsCreator do
         )
       end
     end
-  end
-
-  ###################
-  # provider offices
-  ###################
-  def stub_provider_offices
-    stub_request(:get, %r{#{Rails.configuration.x.pda.url}/provider-user/test-user/provider-offices})
-      .to_return(
-        status: 200,
-        body: provider_offices_json,
-        headers: { "Content-Type" => "application/json; charset=utf-8" },
-      )
-  end
-
-  def provider_offices_json
-    {
-      firm: {
-        ccmsFirmId: 99_999,
-        firmId: 1639,
-        firmName: "Test firm",
-        firmNumber: "1639",
-      },
-      officeCodes: [
-        {
-          ccmsFirmOfficeId: 111_111,
-          firmOfficeCode: "1A111B",
-        },
-      ],
-      user: {
-        ccmsContactId: 494_000,
-      },
-    }.to_json
-  end
-
-  def stub_other_provider_offices
-    stub_request(:get, %r{#{Rails.configuration.x.pda.url}/provider-user/other-user/provider-offices})
-      .to_return(
-        status: 200,
-        body: other_provider_offices_json,
-        headers: { "Content-Type" => "application/json; charset=utf-8" },
-      )
-  end
-
-  def other_provider_offices_json
-    {
-      firm: {
-        ccmsFirmId: 99_999,
-        firmId: 1639,
-        firmName: "Test firm",
-        firmNumber: "1639",
-      },
-      officeCodes: [
-        {
-          ccmsFirmOfficeId: 222_222,
-          firmOfficeCode: "2A222B",
-        },
-      ],
-      user: {
-        ccmsContactId: 494_000,
-      },
-    }.to_json
-  end
-
-  #################
-  # firm offices
-  #################
-  def stub_provider_firm_offices
-    stub_request(:get, %r{#{Rails.configuration.x.pda.url}/provider-firms/1639/provider-offices})
-    .to_return(
-      status: 200,
-      body: provider_firm_offices_json,
-      headers: { "Content-Type" => "application/json; charset=utf-8" },
-    )
-  end
-
-  def provider_firm_offices_json
-    {
-      firm: {
-        ccmsFirmId: 99_999,
-        firmId: 1639,
-        firmName: "Test firm",
-        firmNumber: "1639",
-      },
-      offices: [
-        {
-          ccmsFirmOfficeId: 111_111,
-          firmOfficeCode: "1A111B",
-        },
-        {
-          ccmsFirmOfficeId: 222_222,
-          firmOfficeCode: "2A222B",
-        },
-      ],
-    }.to_json
   end
 end

--- a/spec/services/pda/provider_details_creator_spec.rb
+++ b/spec/services/pda/provider_details_creator_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe PDA::ProviderDetailsCreator do
   let(:firm_struct) { Struct.new(:id, :name) }
   let(:office_struct) { Struct.new(:id, :code) }
-  let(:provider_details_struct) { Struct.new(:firm_id, :contact_id, :firm_name, :offices) }
+  let(:provider_details_struct) { Struct.new(:firm_id, :contact_id, :firm_name, :firm_offices) }
 
   describe ".call" do
     context "when the firm does not exist" do
@@ -14,7 +14,7 @@ RSpec.describe PDA::ProviderDetailsCreator do
         stub_provider_details_retriever(
           provider:,
           firm: ccms_firm,
-          offices: [ccms_office],
+          firm_offices: [ccms_office],
         )
 
         described_class.call(provider)
@@ -33,7 +33,7 @@ RSpec.describe PDA::ProviderDetailsCreator do
         stub_provider_details_retriever(
           provider:,
           firm: ccms_firm,
-          offices: [ccms_office1, ccms_office2],
+          firm_offices: [ccms_office1, ccms_office2],
         )
 
         described_class.call(provider)
@@ -60,7 +60,7 @@ RSpec.describe PDA::ProviderDetailsCreator do
         stub_provider_details_retriever(
           provider:,
           firm: ccms_firm,
-          offices: [ccms_office],
+          firm_offices: [ccms_office],
         )
 
         described_class.call(provider)
@@ -85,7 +85,7 @@ RSpec.describe PDA::ProviderDetailsCreator do
         stub_provider_details_retriever(
           provider:,
           firm: ccms_firm,
-          offices: [ccms_office],
+          firm_offices: [ccms_office],
         )
 
         described_class.call(provider)
@@ -111,7 +111,7 @@ RSpec.describe PDA::ProviderDetailsCreator do
         stub_provider_details_retriever(
           provider:,
           firm: ccms_firm,
-          offices: [ccms_office],
+          firm_offices: [ccms_office],
         )
 
         described_class.call(provider)
@@ -139,7 +139,7 @@ RSpec.describe PDA::ProviderDetailsCreator do
         stub_provider_details_retriever(
           provider:,
           firm: ccms_firm,
-          offices: [ccms_office],
+          firm_offices: [ccms_office],
         )
 
         described_class.call(provider)
@@ -166,7 +166,7 @@ RSpec.describe PDA::ProviderDetailsCreator do
         stub_provider_details_retriever(
           provider:,
           firm: ccms_firm,
-          offices: [ccms_office1, ccms_office2],
+          firm_offices: [ccms_office1, ccms_office2],
         )
 
         described_class.call(provider)
@@ -199,7 +199,7 @@ RSpec.describe PDA::ProviderDetailsCreator do
         stub_provider_details_retriever(
           provider:,
           firm: ccms_firm,
-          offices: [ccms_office],
+          firm_offices: [ccms_office],
         )
 
         described_class.call(provider)
@@ -220,13 +220,13 @@ RSpec.describe PDA::ProviderDetailsCreator do
           provider:,
           contact_id: 105,
           firm: ccms_firm,
-          offices: [ccms_office1, ccms_office2],
+          firm_offices: [ccms_office1, ccms_office2],
         )
         stub_provider_details_retriever(
           provider: other_provider,
           contact_id: 106,
           firm: ccms_firm,
-          offices: [ccms_office2, ccms_office3],
+          firm_offices: [ccms_office2, ccms_office3],
         )
 
         described_class.call(provider)
@@ -261,14 +261,14 @@ RSpec.describe PDA::ProviderDetailsCreator do
     end
   end
 
-  def stub_provider_details_retriever(provider:, firm:, offices:, contact_id: 104)
+  def stub_provider_details_retriever(provider:, firm:, firm_offices:, contact_id: 104)
     allow(PDA::ProviderDetailsRetriever)
       .to receive(:call)
       .with(provider.username)
-      .and_return(api_response(firm:, offices:, contact_id:))
+      .and_return(api_response(firm:, firm_offices:, contact_id:))
   end
 
-  def api_response(firm:, offices:, contact_id:)
-    provider_details_struct.new(firm_id: firm.id, contact_id:, firm_name: firm.name, offices:)
+  def api_response(firm:, firm_offices:, contact_id:)
+    provider_details_struct.new(firm_id: firm.id, contact_id:, firm_name: firm.name, firm_offices:)
   end
 end

--- a/spec/services/pda/provider_details_creator_spec.rb
+++ b/spec/services/pda/provider_details_creator_spec.rb
@@ -7,34 +7,24 @@ RSpec.describe PDA::ProviderDetailsCreator do
 
   describe ".call" do
     context "when the firm does not exist" do
+      before do
+        stub_provider_offices
+        stub_provider_firm_offices
+      end
+
       it "creates the firm" do
-        ccms_firm = firm_struct.new(1, "Test Firm")
-        ccms_office = office_struct.new(1, "6D424Y")
         provider = create(:provider, username: "test-user")
-        stub_provider_details_retriever(
-          provider:,
-          firm: ccms_firm,
-          firm_offices: [ccms_office],
-        )
 
         described_class.call(provider)
 
         expect(provider.firm).to have_attributes(
-          ccms_id: "1",
-          name: "Test Firm",
+          ccms_id: "99999",
+          name: "Test firm",
         )
       end
 
       it "creates the offices" do
-        ccms_firm = firm_struct.new(1, "Test Firm")
-        ccms_office1 = office_struct.new(1, "6D424Y")
-        ccms_office2 = office_struct.new(2, "4C880Q")
         provider = create(:provider, username: "test-user")
-        stub_provider_details_retriever(
-          provider:,
-          firm: ccms_firm,
-          firm_offices: [ccms_office1, ccms_office2],
-        )
 
         described_class.call(provider)
 
@@ -42,51 +32,38 @@ RSpec.describe PDA::ProviderDetailsCreator do
         expect(offices).to contain_exactly(
           have_attributes(
             class: Office,
-            ccms_id: ccms_office1.id.to_s,
-            code: ccms_office1.code,
+            ccms_id: "111111",
+            code: "1A111B",
           ),
           have_attributes(
             class: Office,
-            ccms_id: ccms_office2.id.to_s,
-            code: ccms_office2.code,
+            ccms_id: "222222",
+            code: "2A222B",
           ),
         )
       end
 
       it "updates the provider" do
-        ccms_firm = firm_struct.new(1, "Test Firm")
-        ccms_office = office_struct.new(1, "6D424Y")
         provider = create(:provider, name: nil, username: "test-user")
-        stub_provider_details_retriever(
-          provider:,
-          firm: ccms_firm,
-          firm_offices: [ccms_office],
-        )
 
         described_class.call(provider)
 
         expect(provider).to have_attributes(
           name: "",
-          contact_id: 104,
+          contact_id: 494_000,
         )
       end
     end
 
-    context "when the provider's office is not returned from the API" do
+    context "when the provider's selected office is not returned from the API" do
+      before do
+        stub_provider_offices
+        stub_provider_firm_offices
+      end
+
       it "clears the selected office" do
-        ccms_firm = firm_struct.new(1, "Test Firm")
-        ccms_office = office_struct.new(1, "6D424Y")
         office = create(:office, code: "6D456C")
-        provider = create(
-          :provider,
-          username: "test-user",
-          selected_office: office,
-        )
-        stub_provider_details_retriever(
-          provider:,
-          firm: ccms_firm,
-          firm_offices: [ccms_office],
-        )
+        provider = create(:provider, username: "test-user", selected_office: office)
 
         described_class.call(provider)
 
@@ -94,25 +71,15 @@ RSpec.describe PDA::ProviderDetailsCreator do
       end
     end
 
-    context "when the provider's office is returned from the API" do
+    context "when the provider's selected office is returned from the API" do
+      before do
+        stub_provider_offices
+        stub_provider_firm_offices
+      end
+
       it "does not clear the selected office" do
-        ccms_firm = firm_struct.new(1, "Test Firm")
-        ccms_office = office_struct.new(1, "6D456C")
-        office = create(
-          :office,
-          ccms_id: ccms_office.id,
-          code: ccms_office.code,
-        )
-        provider = create(
-          :provider,
-          username: "test-user",
-          selected_office: office,
-        )
-        stub_provider_details_retriever(
-          provider:,
-          firm: ccms_firm,
-          firm_offices: [ccms_office],
-        )
+        office = create(:office, ccms_id: "111111", code: "1A111B")
+        provider = create(:provider, username: "test-user", selected_office: office)
 
         described_class.call(provider)
 
@@ -121,154 +88,170 @@ RSpec.describe PDA::ProviderDetailsCreator do
     end
 
     context "when the firm already exists with one of the offices" do
+      before do
+        stub_provider_offices
+        stub_provider_firm_offices
+      end
+
       it "does not create the firm" do
-        ccms_firm = firm_struct.new(1, "Existing Firm")
-        ccms_office = office_struct.new(1, "6D456C")
-        existing_firm = create(
-          :firm,
-          ccms_id: ccms_firm.id,
-          name: "Existing Firm",
-        )
-        _existing_office = create(
-          :office,
-          firm: existing_firm,
-          ccms_id: ccms_office.id,
-          code: ccms_office.code,
-        )
+        existing_firm = create(:firm, ccms_id: "99999", name: "Test firm")
+
         provider = create(:provider, username: "test-user")
-        stub_provider_details_retriever(
-          provider:,
-          firm: ccms_firm,
-          firm_offices: [ccms_office],
-        )
 
-        described_class.call(provider)
-
+        expect { described_class.call(provider) }.not_to change(Firm, :count)
         expect(provider.firm).to eq(existing_firm)
       end
 
       it "updates the firms offices" do
-        ccms_firm = firm_struct.new(1, "Existing Firm")
-        ccms_office1 = office_struct.new(1, "6D456C")
-        ccms_office2 = office_struct.new(2, "4C880Q")
-        existing_firm = create(
-          :firm,
-          ccms_id: ccms_firm.id,
-          name: "Existing Firm",
-        )
-        existing_office = create(
+        existing_firm = create(:firm, ccms_id: "99999", name: "Test firm")
+
+        _existing_office = create(
           :office,
           firm: existing_firm,
-          ccms_id: ccms_office1.id,
-          code: ccms_office1.code,
-        )
-        provider = create(:provider, username: "test-user")
-        stub_provider_details_retriever(
-          provider:,
-          firm: ccms_firm,
-          firm_offices: [ccms_office1, ccms_office2],
+          ccms_id: "777777",
+          code: "5A555B",
         )
 
-        described_class.call(provider)
+        provider = create(:provider, username: "test-user")
+
+        expect { described_class.call(provider) }.to change(Office, :count).by(2)
 
         expect(existing_firm.offices).to contain_exactly(
-          existing_office,
-          have_attributes(
-            class: Office,
-            ccms_id: ccms_office2.id.to_s,
-            code: ccms_office2.code,
-          ),
+          have_attributes(class: Office, ccms_id: "777777", code: "5A555B"),
+          have_attributes(class: Office, ccms_id: "111111", code: "1A111B"),
+          have_attributes(class: Office, ccms_id: "222222", code: "2A222B"),
         )
       end
 
       it "updates the firm's name" do
-        ccms_firm = firm_struct.new(1, "New Firm Name")
-        ccms_office = office_struct.new(1, "6D456C")
-        existing_firm = create(
-          :firm,
-          ccms_id: ccms_firm.id,
-          name: "Old Firm Name",
-        )
-        _existing_office = create(
-          :office,
-          firm: existing_firm,
-          ccms_id: ccms_office.id,
-          code: ccms_office.code,
-        )
+        existing_firm = create(:firm, ccms_id: "99999", name: "Old firm name")
         provider = create(:provider, username: "test-user")
-        stub_provider_details_retriever(
-          provider:,
-          firm: ccms_firm,
-          firm_offices: [ccms_office],
-        )
 
-        described_class.call(provider)
-
-        expect(existing_firm.reload.name).to eq("New Firm Name")
+        expect { described_class.call(provider) }
+          .to change { existing_firm.reload.name }
+            .from("Old firm name")
+            .to("Test firm")
       end
     end
 
     context "when another provider has the same firm, but different offices" do
-      it "only adds offices to the correct provider" do
-        ccms_firm = firm_struct.new(1, "New Firm Name")
-        ccms_office1 = office_struct.new(1, "6D456C")
-        ccms_office2 = office_struct.new(2, "4C880Q")
-        ccms_office3 = office_struct.new(3, "9R678Y")
+      before do
+        stub_provider_offices
+        stub_other_provider_offices
+        stub_provider_firm_offices
+      end
+
+      it "associates all the firm's offices with each provider" do
         provider = create(:provider, username: "test-user")
         other_provider = create(:provider, username: "other-user")
-        stub_provider_details_retriever(
-          provider:,
-          contact_id: 105,
-          firm: ccms_firm,
-          firm_offices: [ccms_office1, ccms_office2],
-        )
-        stub_provider_details_retriever(
-          provider: other_provider,
-          contact_id: 106,
-          firm: ccms_firm,
-          firm_offices: [ccms_office2, ccms_office3],
-        )
 
         described_class.call(provider)
         described_class.call(other_provider)
 
         expect(provider.offices).to contain_exactly(
-          have_attributes(
-            class: Office,
-            ccms_id: ccms_office1.id.to_s,
-            code: ccms_office1.code,
-          ),
-          have_attributes(
-            class: Office,
-            ccms_id: ccms_office2.id.to_s,
-            code: ccms_office2.code,
-          ),
+          have_attributes(class: Office, ccms_id: "111111", code: "1A111B"),
+          have_attributes(class: Office, ccms_id: "222222", code: "2A222B"),
         )
 
         expect(other_provider.offices).to contain_exactly(
-          have_attributes(
-            class: Office,
-            ccms_id: ccms_office2.id.to_s,
-            code: ccms_office2.code,
-          ),
-          have_attributes(
-            class: Office,
-            ccms_id: ccms_office3.id.to_s,
-            code: ccms_office3.code,
-          ),
+          have_attributes(class: Office, ccms_id: "111111", code: "1A111B"),
+          have_attributes(class: Office, ccms_id: "222222", code: "2A222B"),
         )
       end
     end
   end
 
-  def stub_provider_details_retriever(provider:, firm:, firm_offices:, contact_id: 104)
-    allow(PDA::ProviderDetailsRetriever)
-      .to receive(:call)
-      .with(provider.username)
-      .and_return(api_response(firm:, firm_offices:, contact_id:))
+  ###################
+  # provider offices
+  ###################
+  def stub_provider_offices
+    stub_request(:get, %r{#{Rails.configuration.x.pda.url}/provider-user/test-user/provider-offices})
+      .to_return(
+        status: 200,
+        body: provider_offices_json,
+        headers: { "Content-Type" => "application/json; charset=utf-8" },
+      )
   end
 
-  def api_response(firm:, firm_offices:, contact_id:)
-    provider_details_struct.new(firm_id: firm.id, contact_id:, firm_name: firm.name, firm_offices:)
+  def provider_offices_json
+    {
+      firm: {
+        ccmsFirmId: 99_999,
+        firmId: 1639,
+        firmName: "Test firm",
+        firmNumber: "1639",
+      },
+      officeCodes: [
+        {
+          ccmsFirmOfficeId: 111_111,
+          firmOfficeCode: "1A111B",
+        },
+      ],
+      user: {
+        ccmsContactId: 494_000,
+      },
+    }.to_json
+  end
+
+  def stub_other_provider_offices
+    stub_request(:get, %r{#{Rails.configuration.x.pda.url}/provider-user/other-user/provider-offices})
+      .to_return(
+        status: 200,
+        body: other_provider_offices_json,
+        headers: { "Content-Type" => "application/json; charset=utf-8" },
+      )
+  end
+
+  def other_provider_offices_json
+    {
+      firm: {
+        ccmsFirmId: 99_999,
+        firmId: 1639,
+        firmName: "Test firm",
+        firmNumber: "1639",
+      },
+      officeCodes: [
+        {
+          ccmsFirmOfficeId: 222_222,
+          firmOfficeCode: "2A222B",
+        },
+      ],
+      user: {
+        ccmsContactId: 494_000,
+      },
+    }.to_json
+  end
+
+  #################
+  # firm offices
+  #################
+  def stub_provider_firm_offices
+    stub_request(:get, %r{#{Rails.configuration.x.pda.url}/provider-firms/1639/provider-offices})
+    .to_return(
+      status: 200,
+      body: provider_firm_offices_json,
+      headers: { "Content-Type" => "application/json; charset=utf-8" },
+    )
+  end
+
+  def provider_firm_offices_json
+    {
+      firm: {
+        ccmsFirmId: 99_999,
+        firmId: 1639,
+        firmName: "Test firm",
+        firmNumber: "1639",
+      },
+      offices: [
+        {
+          ccmsFirmOfficeId: 111_111,
+          firmOfficeCode: "1A111B",
+        },
+        {
+          ccmsFirmOfficeId: 222_222,
+          firmOfficeCode: "2A222B",
+        },
+      ],
+    }.to_json
   end
 end

--- a/spec/services/pda/provider_details_request_stubs.rb
+++ b/spec/services/pda/provider_details_request_stubs.rb
@@ -1,0 +1,106 @@
+###################
+# provider offices
+###################
+def stub_provider_offices
+  stub_request(:get, %r{#{Rails.configuration.x.pda.url}/provider-user/test-user/provider-offices})
+    .to_return(
+      status: 200,
+      body: provider_offices_json,
+      headers: { "Content-Type" => "application/json; charset=utf-8" },
+    )
+end
+
+def provider_offices_json
+  {
+    firm: {
+      ccmsFirmId: 99_999,
+      firmId: 1639,
+      firmName: "Test firm",
+      firmNumber: "1639",
+    },
+    officeCodes: [
+      {
+        ccmsFirmOfficeId: 111_111,
+        firmOfficeCode: "1A111B",
+      },
+    ],
+    user: {
+      ccmsContactId: 494_000,
+    },
+  }.to_json
+end
+
+def stub_other_provider_offices
+  stub_request(:get, %r{#{Rails.configuration.x.pda.url}/provider-user/other-user/provider-offices})
+    .to_return(
+      status: 200,
+      body: other_provider_offices_json,
+      headers: { "Content-Type" => "application/json; charset=utf-8" },
+    )
+end
+
+def other_provider_offices_json
+  {
+    firm: {
+      ccmsFirmId: 99_999,
+      firmId: 1639,
+      firmName: "Test firm",
+      firmNumber: "1639",
+    },
+    officeCodes: [
+      {
+        ccmsFirmOfficeId: 222_222,
+        firmOfficeCode: "2A222B",
+      },
+    ],
+    user: {
+      ccmsContactId: 494_000,
+    },
+  }.to_json
+end
+
+#################
+# firm offices
+#################
+def stub_provider_firm_offices
+  stub_request(:get, %r{#{Rails.configuration.x.pda.url}/provider-firms/1639/provider-offices})
+  .to_return(
+    status: 200,
+    body: provider_firm_offices_json,
+    headers: { "Content-Type" => "application/json; charset=utf-8" },
+  )
+end
+
+def provider_firm_offices_json
+  {
+    firm: {
+      ccmsFirmId: 99_999,
+      firmId: 1639,
+      firmName: "Test firm",
+      firmNumber: "1639",
+    },
+    offices: [
+      {
+        ccmsFirmOfficeId: 111_111,
+        firmOfficeCode: "1A111B",
+      },
+      {
+        ccmsFirmOfficeId: 222_222,
+        firmOfficeCode: "2A222B",
+      },
+    ],
+  }.to_json
+end
+
+#################
+# errors
+#################
+def stub_provider_details_retriever_record_not_found(provider:)
+  stub_request(:get, "#{Rails.configuration.x.pda.url}/provider-user/#{provider.username}/provider-offices")
+    .to_return(body: nil, status: 204)
+end
+
+def stub_provider_details_retriever_api_error(provider:)
+  stub_request(:get, "#{Rails.configuration.x.pda.url}/provider-user/#{provider.username}/provider-offices")
+    .to_return(body: "An error has occurred", status: 500)
+end

--- a/spec/services/pda/provider_details_retriever_spec.rb
+++ b/spec/services/pda/provider_details_retriever_spec.rb
@@ -16,11 +16,12 @@ RSpec.describe PDA::ProviderDetailsRetriever, :vcr do
       let(:username) { "DT_SCRIPT_USER1" }
 
       it "returns provider details" do
-        response = call
-        expect(response.contact_id).to eq 0
-        expect(response.firm_id).to eq 0
-        expect(response.firm_name).to eq "DT SCRIPT PROVIDER 1"
-        expect(response.offices.first.code).to eq "2Q242F"
+        result = call
+        expect(result.contact_id).to eq 0
+        expect(result.firm_id).to eq 10_835_831
+        expect(result.firm_name).to eq "DT SCRIPT PROVIDER 1"
+        expect(result.provider_offices.first.code).to eq "2Q242F"
+        expect(result.firm_offices.first.code).to eq "2Q242F"
       end
     end
 
@@ -34,6 +35,19 @@ RSpec.describe PDA::ProviderDetailsRetriever, :vcr do
         expect {
           call
         }.to raise_error(PDA::ProviderDetailsRetriever::ApiError, "API Call Failed: (500) An error has occurred")
+      end
+    end
+
+    context "when api returns no content" do
+      before do
+        stub_request(:get, "#{Rails.configuration.x.pda.url}/provider-user/#{username}/provider-offices")
+          .to_return(body: nil, status: 204)
+      end
+
+      it "raises ApiError" do
+        expect {
+          call
+        }.to raise_error(PDA::ProviderDetailsRetriever::ApiRecordNotFoundError, %r{Retrieval Failed: \(204\)})
       end
     end
   end


### PR DESCRIPTION
## What
Add and log firm offices from new PDA API

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5307)

The existing PDA returns all offices in the providers firm as part of the "provider offices". The new PDA
only returns the offices of the specific individual provider (a person/user). To understand the impact and how
to handle it we want to compare all the offices in the firm of the specific provider from the new PDA with those coming from the old CCSM PDA.

The new PDA requires a second call to achieve this, so the relevant part of the response body of the second call has been merged with the response body of the first call and returned as a result object.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
