### PR TITLE
AP-5315: Fix SCA proceeding search bug

### DIFF
--- a/app/javascript/src/modules/proceedings.js
+++ b/app/javascript/src/modules/proceedings.js
@@ -160,13 +160,16 @@ function showResults (results, inputText) {
       ariaText = `${codes.length} ${pluralizedMatches} found for ${inputText}, use tab to move to options`
       hide(document.querySelector('.no-proceeding-items'))
     } else {
-      show(document.querySelector('.no-proceeding-items'))
-      ariaText = `No results found matching ${inputText}`
+      showNoResults(inputText)
     }
   } else {
-    show(document.querySelector('.no-proceeding-items'))
-    ariaText = `No results found matching ${inputText}`
+    showNoResults(inputText)
   }
+}
+
+function showNoResults (inputText) {
+  show(document.querySelector('.no-proceeding-items'))
+  ariaText = `No results found matching ${inputText}`
 }
 
 // Hide any search results and the 'no results found' text

--- a/app/javascript/src/modules/proceedings.js
+++ b/app/javascript/src/modules/proceedings.js
@@ -109,6 +109,7 @@ function showResults (results, inputText) {
   if (results.length > 0) {
     deselectPreviousProceedingItem()
     const codes = results.map(obj => obj.ccms_code)
+    let shown = 0
     let proceedingsContainer = document.querySelector('.govuk-radios') // with MP flag on
     if (proceedingsContainer == null) { proceedingsContainer = document.querySelector('#proceeding-list') } // with MP flag off
     codes.forEach((code, idx) => {
@@ -119,12 +120,9 @@ function showResults (results, inputText) {
       // proceedings is turned off, then codes will only contain those proceeding types
       // that are not filtered out by the LegalFramework::ProceedingTypes::All service,
       // so we just ignore them here if they aren't in the list
-      if (element == null) {
-        show(document.querySelector('.no-proceeding-items'))
-        ariaText = `No results found matching ${inputText}`
-        return
-      }
+      if (element == null) { return }
 
+      shown++ // increment the count if this code is actually shown to the user
       // We want to highlight anything in the label or hint text that
       // matches the user's search criteria
       const label = element.querySelector('label')
@@ -153,11 +151,18 @@ function showResults (results, inputText) {
       proceedingsContainer.insertBefore(element, proceedingsContainer.children[idx])
       // show hidden proceedings item
       show(element)
-      hide(document.querySelector('.no-proceeding-items'))
     })
-    // the below alerts screen reader users that results appeared on the page
-    const pluralizedMatches = pluralize(codes.length, 'match', 'matches')
-    ariaText = `${codes.length} ${pluralizedMatches} found for ${inputText}, use tab to move to options`
+    // once we have looped over all returned codes, check if any were shown to the user
+    // and set the appropriate ariaText and show/hide the no-proceedings found element
+    if (shown > 0) {
+      // the below alerts screen reader users that results appeared on the page
+      const pluralizedMatches = pluralize(codes.length, 'match', 'matches')
+      ariaText = `${codes.length} ${pluralizedMatches} found for ${inputText}, use tab to move to options`
+      hide(document.querySelector('.no-proceeding-items'))
+    } else {
+      show(document.querySelector('.no-proceeding-items'))
+      ariaText = `No results found matching ${inputText}`
+    }
   } else {
     show(document.querySelector('.no-proceeding-items'))
     ariaText = `No results found matching ${inputText}`


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5315)

When LFA returns a code that is not present on the page, i.e. an SCA related proceeding on an initial search, previously it showed the failure message and returned from the loop.

This updates the proceedings javascript so that it counts successfully displayed proceedings, using a new, `shown`, variable. After the loop is complete it then sets the ariaText and shows/hides the no-proceeding-items element accordingly.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
