### PR TITLE
AP-5354: Update CircleCI Slack & AWS-CLI Orbs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 orbs:
-  aws-cli: circleci/aws-cli@4.1.3
+  aws-cli: circleci/aws-cli@5.1.0
   browser-tools: circleci/browser-tools@1.4.8
-  slack: circleci/slack@4.13.2
+  slack: circleci/slack@5.0.0
 
 executors:
   basic-executor:


### PR DESCRIPTION

## What

[Update CircleCi Orbs ](https://dsdmoj.atlassian.net/browse/AP-5345)

- Bump circleci/aws-cli from 4.1.3 to 5.1.0
- Bump circleci/slack from 4.13.2 to 5.0.0

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
