### PR TITLE
AP-5180: Client address tracking data

### DIFF
--- a/app/models/application_digest.rb
+++ b/app/models/application_digest.rb
@@ -13,6 +13,7 @@ class ApplicationDigest < ApplicationRecord
     non_means_tested
     family_linked
     legal_linked
+    no_fixed_address
   ].freeze
 
   class << self
@@ -62,6 +63,7 @@ class ApplicationDigest < ApplicationRecord
         legal_linked: laa.legal_linked?,
         legal_linked_lead_or_associated: laa.legal_linked_lead_or_associated,
         number_of_legal_linked_applications: laa.legal_linked_applications_count,
+        no_fixed_address: laa.applicant.no_fixed_residence?,
       }
     end
 

--- a/app/services/reports/mis/application_detail_csv_line.rb
+++ b/app/services/reports/mis/application_detail_csv_line.rb
@@ -171,6 +171,7 @@ module Reports
           "Legal Linked?",
           "Legal link lead?",
           "Number of legal links",
+          "No fixed address",
         ]
       end
 
@@ -205,6 +206,7 @@ module Reports
         banking_data
         partner
         linked_applications
+        home_address
         sanitise
       end
 
@@ -440,6 +442,10 @@ module Reports
           @line << nil
           @line << nil
         end
+      end
+
+      def home_address
+        @line << yesno(laa.applicant.no_fixed_residence?)
       end
 
       def yesno(value)

--- a/db/migrate/20240930074635_add_address_to_digest.rb
+++ b/db/migrate/20240930074635_add_address_to_digest.rb
@@ -1,0 +1,5 @@
+class AddAddressToDigest < ActiveRecord::Migration[7.1]
+  def change
+    add_column :application_digests, :no_fixed_address, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_23_104047) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_30_074635) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -182,6 +182,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_23_104047) do
     t.boolean "legal_linked"
     t.string "legal_linked_lead_or_associated"
     t.integer "number_of_legal_linked_applications"
+    t.boolean "no_fixed_address"
     t.index ["legal_aid_application_id"], name: "index_application_digests_on_legal_aid_application_id", unique: true
   end
 

--- a/spec/models/application_digest_spec.rb
+++ b/spec/models/application_digest_spec.rb
@@ -495,5 +495,32 @@ RSpec.describe ApplicationDigest do
         end
       end
     end
+
+    describe "applicant address" do
+      context "when they have no fixed residence" do
+        before { laa.applicant.update(no_fixed_residence: true) }
+
+        it "sets no_fixed_address to true" do
+          application_digest
+          expect(digest.no_fixed_address).to be true
+        end
+      end
+
+      context "when they have a home address" do
+        before { laa.applicant.update(no_fixed_residence: false) }
+
+        it "sets no_fixed_address to false" do
+          application_digest
+          expect(digest.no_fixed_address).to be false
+        end
+      end
+
+      context "when the question is not answered (legacy applications)" do
+        it "sets no_fixed_address to false" do
+          application_digest
+          expect(digest.no_fixed_address).to be false
+        end
+      end
+    end
   end
 end

--- a/spec/services/reports/mis/application_detail_csv_line_spec.rb
+++ b/spec/services/reports/mis/application_detail_csv_line_spec.rb
@@ -866,6 +866,32 @@ module Reports
             expect(value_for("Applicant age")).to be_nil
           end
         end
+
+        describe "applicant address" do
+          context "when they have no fixed residence" do
+            let(:applicant) { create(:applicant, no_fixed_residence: true) }
+
+            it "sets no_fixed_address to true" do
+              expect(value_for("No fixed address")).to eq "Yes"
+            end
+          end
+
+          context "when they have a home address" do
+            let(:applicant) { create(:applicant, no_fixed_residence: false) }
+
+            it "sets no_fixed_address to false" do
+              expect(value_for("No fixed address")).to eq "No"
+            end
+          end
+
+          context "when the question is not answered (legacy applications)" do
+            let(:applicant) { create(:applicant, no_fixed_residence: nil) }
+
+            it "sets no_fixed_address to false" do
+              expect(value_for("No fixed address")).to eq "No"
+            end
+          end
+        end
       end
 
       def value_for(name)


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5180)

Add tracking of `No fixed address` responses to the Application Digest and Admin reports

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
