### PR TITLE
Rails 7.2 bump with javascript strategy

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -92,7 +92,7 @@ ActionController::Base.allow_rescue = false
 # Remove/comment out the lines below if your app doesn't have a database.
 # For some databases (like MongoDB and CouchDB) you may need to use :truncation instead.
 begin
-  DatabaseCleaner.strategy = :truncation, { except: %w[document_categories] }
+  DatabaseCleaner.strategy = :transaction
 rescue NameError
   raise "You need to add database_cleaner to your Gemfile (in the :test group) if you wish to use it."
 end
@@ -115,7 +115,7 @@ end
 # Possible values are :truncation and :transaction
 # The :transaction strategy is faster, but might give you threading problems.
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
-Cucumber::Rails::Database.javascript_strategy = :transaction
+Cucumber::Rails::Database.javascript_strategy = :deletion, { except: %w[document_categories] }
 load Rails.root.join("db/seeds.rb")
 
 Before do |_scenario|


### PR DESCRIPTION
## What
Use javascript_strategy of :deletion only 

Local testing results show me a bit of an increase between a general `:truncation`
strategy and a javascript_strategy of `:deletion`, rather than truncation.

```
\# rails 7.1 transaction strategy only - baseline
cucumber  797.65s user 547.86s system 105% cpu 21:19.52 total
```

```
\# with strategy of truncation generally
cucumber  883.71s user 606.80s system 101% cpu 24:33.67 total
```

```
\# with javascript strategy of :truncation otherwise :transaction
cucumber  881.75s user 594.94s system 107% cpu 22:53.44 total
```

\* best performer for rails 7.2
```
\# with javascript strategy of :deletion otherwise :transaction
cucumber  836.40s user 561.81s system 115% cpu 20:10.36 total
```

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
