### PR TITLE
AP-4926: use white button component

### DIFF
--- a/app/assets/stylesheets/interruption-panel.scss
+++ b/app/assets/stylesheets/interruption-panel.scss
@@ -8,10 +8,7 @@
   h1,
   h2,
   ul,
-  label,
-  a,
-  a:link,
-  a:visited {
+  label {
     color: govuk-colour("white");
   }
 
@@ -38,27 +35,6 @@
     float: none;
   }
 
-  #continue,
-  a.white-button,
-  button.white-button {
-    color: #1d70b8;
-    background: #ffffff;
-    box-shadow: 0 2px 0 #001526;
-    font-weight: bold;
-
-    &:focus {
-      background-color: #ffdd00;
-    }
-
-    &:active {
-      box-shadow: inset 0 0 0 1px #ffdd00;
-    }
-
-    &:hover {
-      background-color: #d0d3d6;
-    }
-  }
-
   .govuk-radios__label::before,
   & ::after {
     border-color: govuk-colour("black");
@@ -71,6 +47,7 @@
     color: govuk-colour("white");
   }
 }
+
 @media (min-width: 769px) {
   .interruption-panel {
     padding: 60px;

--- a/app/helpers/flow_helper.rb
+++ b/app/helpers/flow_helper.rb
@@ -4,6 +4,7 @@ module FlowHelper
     method: :post,
     show_continue: true,
     show_draft: false,
+    inverse_continue: false,
     continue_button_text: t("generic.save_and_continue"),
     draft_button_text: t("generic.save_and_come_back_later")
   )
@@ -12,6 +13,7 @@ module FlowHelper
       next_action_buttons(
         show_continue:,
         show_draft:,
+        inverse_continue:,
         form:,
         continue_button_text:,
         draft_button_text:,
@@ -24,6 +26,7 @@ module FlowHelper
     continue_id: :continue,
     show_continue: true,
     show_draft: false,
+    inverse_continue: false,
     continue_button_text: t("generic.save_and_continue"),
     draft_button_text: t("generic.save_and_come_back_later")
   )
@@ -34,6 +37,7 @@ module FlowHelper
       form:,
       show_continue:,
       show_draft:,
+      inverse_continue:,
       continue_button_text:,
       draft_button_text:,
     )

--- a/app/views/providers/application_merits_task/has_other_involved_children/show.html.erb
+++ b/app/views/providers/application_merits_task/has_other_involved_children/show.html.erb
@@ -9,49 +9,48 @@
                     form: do %>
 
     <% if @legal_aid_application.involved_children.count > 0 %>
-    <h1 class="govuk-heading-xl">
-      <%= t(".existing", count: pluralize(@legal_aid_application.involved_children.count, "child").to_s) %>
-    </h1>
+      <h1 class="govuk-heading-xl">
+        <%= t(".existing", count: pluralize(@legal_aid_application.involved_children.count, "child").to_s) %>
+      </h1>
 
-    <%= govuk_table do |table|
-          table.with_caption(html_attributes: { class: "govuk-visually-hidden" }, text: t(".table_caption"))
+      <%= govuk_table do |table|
+            table.with_caption(html_attributes: { class: "govuk-visually-hidden" }, text: t(".table_caption"))
 
-          table.with_head do |head|
-            head.with_row do |row|
-              row.with_cell(text: "Name")
-              row.with_cell(text: "Date of birth")
-              row.with_cell(colspan: 2, scope: "colgroup") do
-                tag.span("Change or remove child", class: "govuk-visually-hidden")
-              end
-            end
-          end
-
-          table.with_body do |body|
-            @legal_aid_application.involved_children.order(:created_at).each do |involved_child|
-              body.with_row do |row|
-                row.with_cell(text: involved_child.full_name)
-                row.with_cell(text: involved_child.date_of_birth)
-                row.with_cell do
-                  govuk_link_to(
-                    t("generic.change"),
-                    providers_legal_aid_application_involved_child_path(@legal_aid_application, involved_child),
-                    class: "change-link",
-                    "aria-label": involved_child.full_name,
-                  )
-                end
-                row.with_cell do
-                  govuk_link_to(
-                    t(".remove"),
-                    providers_legal_aid_application_remove_involved_child_path(@legal_aid_application, involved_child),
-                    class: "change-link",
-                    "aria-label": involved_child.full_name,
-                  )
+            table.with_head do |head|
+              head.with_row do |row|
+                row.with_cell(text: "Name")
+                row.with_cell(text: "Date of birth")
+                row.with_cell(colspan: 2, scope: "colgroup") do
+                  tag.span("Change or remove child", class: "govuk-visually-hidden")
                 end
               end
             end
-          end
-        end %>
 
+            table.with_body do |body|
+              @legal_aid_application.involved_children.order(:created_at).each do |involved_child|
+                body.with_row do |row|
+                  row.with_cell(text: involved_child.full_name)
+                  row.with_cell(text: involved_child.date_of_birth)
+                  row.with_cell do
+                    govuk_link_to(
+                      t("generic.change"),
+                      providers_legal_aid_application_involved_child_path(@legal_aid_application, involved_child),
+                      class: "change-link",
+                      "aria-label": involved_child.full_name,
+                    )
+                  end
+                  row.with_cell do
+                    govuk_link_to(
+                      t(".remove"),
+                      providers_legal_aid_application_remove_involved_child_path(@legal_aid_application, involved_child),
+                      class: "change-link",
+                      "aria-label": involved_child.full_name,
+                    )
+                  end
+                end
+              end
+            end
+          end %>
     <% end %>
 
     <%= form.govuk_collection_radio_buttons :has_other_involved_child,
@@ -60,6 +59,6 @@
                                             :label,
                                             legend: { text: t(".add_another"), size: "l", tag: "h2" } %>
 
-      <%= next_action_buttons(show_draft: true, form:) %>
+    <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>
 <% end %>

--- a/app/views/providers/check_benefits/index.html.erb
+++ b/app/views/providers/check_benefits/index.html.erb
@@ -9,6 +9,7 @@
           url: providers_legal_aid_application_check_benefit_path,
           method: :patch,
           show_draft: true,
+          inverse_continue: true,
           continue_button_text: t("generic.continue"),
         ) %>
   <% end %>

--- a/app/views/providers/confirm_non_means_tested_applications/show.html.erb
+++ b/app/views/providers/confirm_non_means_tested_applications/show.html.erb
@@ -14,6 +14,7 @@
           url: providers_legal_aid_application_confirm_non_means_tested_applications_path,
           method: :patch,
           show_draft: true,
+          inverse_continue: true,
           continue_button_text: t("generic.continue"),
         ) %>
   <% end %>

--- a/app/views/providers/interrupt/blocks/show.html.erb
+++ b/app/views/providers/interrupt/blocks/show.html.erb
@@ -13,7 +13,7 @@
     </div>
 
     <div class='govuk-button-group'>
-      <%= govuk_button_link_to t(".applications"), providers_legal_aid_applications_path, class: "white-button", role: "button" %>
+      <%= govuk_button_link_to t(".applications"), providers_legal_aid_applications_path, inverse: true, role: "button" %>
     </div>
   <% end %>
 </div>

--- a/app/views/providers/no_national_insurance_numbers/show.html.erb
+++ b/app/views/providers/no_national_insurance_numbers/show.html.erb
@@ -8,6 +8,7 @@
           url: providers_legal_aid_application_no_national_insurance_number_path,
           method: :patch,
           show_draft: true,
+          inverse_continue: true,
           continue_button_text: t("generic.continue"),
         ) %>
   <% end %>

--- a/app/views/providers/proceedings_sca/interrupts/show.html.erb
+++ b/app/views/providers/proceedings_sca/interrupts/show.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <div class='govuk-button-group'>
-      <%= govuk_button_link_to t(".#{@type}.applications"), providers_legal_aid_applications_path, class: "white-button", role: "button" %>
+      <%= govuk_button_link_to t(".#{@type}.applications"), providers_legal_aid_applications_path, inverse: true, role: "button" %>
     </div>
   <% end %>
 </div>

--- a/app/views/shared/_use_ccms.html.erb
+++ b/app/views/shared/_use_ccms.html.erb
@@ -14,8 +14,8 @@
     </div>
 
     <div class='govuk-button-group'>
-      <%= govuk_button_link_to t(".continue_in_ccms_html"), "https://portal.legalservices.gov.uk", class: "white-button", role: "button" %>
-      <%= govuk_link_to t(".back_to_applications"), providers_legal_aid_applications_path, class: "black_text_on_focus" %>
+      <%= govuk_button_link_to t(".continue_in_ccms_html"), "https://portal.legalservices.gov.uk", inverse: true, role: "button" %>
+      <%= govuk_link_to t(".back_to_applications"), providers_legal_aid_applications_path, inverse: true %>
     </div>
   <% end %>
 </div>

--- a/app/views/shared/forms/_next_action_buttons.html.erb
+++ b/app/views/shared/forms/_next_action_buttons.html.erb
@@ -2,6 +2,7 @@
   <% if show_continue %>
     <%= form.govuk_submit(
           continue_button_text,
+          inverse: inverse_continue,
           id: continue_id,
           name: "continue_button",
           value: continue_button_text,


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4926)

Replace custom code for white button with `inverse: true` on button component

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
