### PR TITLE
AP-4707: Prevent none plus other checkbox selection when JS not enabled

### DIFF
--- a/app/controllers/providers/means/identify_types_of_incomes_controller.rb
+++ b/app/controllers/providers/means/identify_types_of_incomes_controller.rb
@@ -7,24 +7,25 @@ module Providers
 
       def update
         synchronize_credit_transaction_types
+        validate
 
-        if none_selected?
-          legal_aid_application.update!(no_credit_transaction_types_selected: true)
+        if legal_aid_application.errors.present?
+          return continue_or_draft if draft_selected?
 
-          return continue_or_draft
-        elsif transaction_types_selected?
-          legal_aid_application.update!(no_credit_transaction_types_selected: false)
+          render :show
+        else
+          legal_aid_application.update!(no_credit_transaction_types_selected: none_selected?)
 
-          return continue_or_draft
+          continue_or_draft
         end
-
-        return continue_or_draft if draft_selected?
-
-        legal_aid_application.errors.add :transaction_type_ids, t(".none_selected")
-        render :show
       end
 
     private
+
+      def validate
+        legal_aid_application.errors.add :transaction_type_ids, t(".none_and_another_option_selected") if none_selected? && transaction_types_selected?
+        legal_aid_application.errors.add :transaction_type_ids, t(".none_selected") if [none_selected?, transaction_types_selected?].all?(false)
+      end
 
       def transaction_type_params
         params

--- a/app/controllers/providers/means/identify_types_of_incomes_controller.rb
+++ b/app/controllers/providers/means/identify_types_of_incomes_controller.rb
@@ -23,8 +23,16 @@ module Providers
     private
 
       def validate
-        legal_aid_application.errors.add :transaction_type_ids, t(".none_and_another_option_selected") if none_selected? && transaction_types_selected?
-        legal_aid_application.errors.add :transaction_type_ids, t(".none_selected") if [none_selected?, transaction_types_selected?].all?(false)
+        legal_aid_application.errors.add :transaction_type_ids, error_message_for_none_and_another_option_selected if none_selected? && transaction_types_selected?
+        legal_aid_application.errors.add :transaction_type_ids, error_message_for_none_selected if [none_selected?, transaction_types_selected?].all?(false)
+      end
+
+      def error_message_for_none_selected
+        I18n.t("providers.means.identify_types_of_incomes.transaction_type_ids.errors.none_selected")
+      end
+
+      def error_message_for_none_and_another_option_selected
+        I18n.t("providers.means.identify_types_of_incomes.transaction_type_ids.errors.none_and_another_option_selected")
       end
 
       def transaction_type_params

--- a/app/controllers/providers/means/identify_types_of_outgoings_controller.rb
+++ b/app/controllers/providers/means/identify_types_of_outgoings_controller.rb
@@ -23,8 +23,16 @@ module Providers
     private
 
       def validate
-        legal_aid_application.errors.add :transaction_type_ids, t(".none_and_another_option_selected") if none_selected? && transaction_types_selected?
-        legal_aid_application.errors.add :transaction_type_ids, t(".none_selected") if [none_selected?, transaction_types_selected?].all?(false)
+        legal_aid_application.errors.add :transaction_type_ids, error_message_for_none_and_another_option_selected if none_selected? && transaction_types_selected?
+        legal_aid_application.errors.add :transaction_type_ids, error_message_for_none_selected if [none_selected?, transaction_types_selected?].all?(false)
+      end
+
+      def error_message_for_none_selected
+        I18n.t("providers.means.identify_types_of_outgoings.transaction_type_ids.errors.none_selected")
+      end
+
+      def error_message_for_none_and_another_option_selected
+        I18n.t("providers.means.identify_types_of_outgoings.transaction_type_ids.errors.none_and_another_option_selected")
       end
 
       def legal_aid_application_params

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -163,7 +163,7 @@ en:
               inclusion: Select yes if your client has applied for civil legal aid before
             previous_reference:
               blank: Enter the reference number for any previous application
-              not_valid: Enter the reference number in the correct format 
+              not_valid: Enter the reference number in the correct format
         aggregated_cash_income:
           credits:
             attributes:
@@ -743,8 +743,6 @@ en:
               too_many_decimals: Enter a number with no more than 2 decimal places
             friends_or_family_frequency:
               inclusion: Select how often your client receives income from friends or family
-            transaction_type_ids:
-              blank: Select at least one of the options
             maintenance_in_amount:
               greater_than: Enter a number greater than 0
               not_a_number: Enter the amount of maintenance received
@@ -763,8 +761,11 @@ en:
               too_many_decimals: Enter a number with no more than 2 decimal places
             pension_frequency:
               inclusion: Select how often your client receives pension income
+            transaction_type_ids:
+              blank: Select at least one of the options
+              none_and_another_option_selected: If you select 'My client does not get any of these payments', you cannot select any of the other options
         providers/means/regular_outgoings_form:
-          attributes:
+          attributes: &regular_outgoings_attributes
             rent_or_mortgage_amount:
               greater_than: Enter a number greater than 0
               not_a_number: Enter the amount paid for housing
@@ -791,6 +792,7 @@ en:
               inclusion: Select how often your client makes legal aid payments
             transaction_type_ids:
               blank: Select at least one of the options
+              none_and_another_option_selected: If you select 'My client makes none of these payments', you cannot select any of the other options
         providers/partners/regular_income_form:
           attributes:
             <<: *regular_income_attributes
@@ -802,34 +804,22 @@ en:
               inclusion: Select how often the partner receives income from property or lodgers
             pension_frequency:
               inclusion: Select how often the partner receives pension income
+            transaction_type_ids:
+              none_and_another_option_selected: If you select 'The partner does not get any of these payments', you cannot select any of the other options
         providers/partners/regular_outgoings_form:
           attributes:
-            rent_or_mortgage_amount:
-              greater_than: Enter a number greater than 0
-              not_a_number: Enter the amount paid for housing
-              too_many_decimals: Enter a number with no more than 2 decimal places
+            <<: *regular_outgoings_attributes
             rent_or_mortgage_frequency:
-              inclusion: Select how often your client makes housing payments
-            child_care_amount:
-              greater_than: Enter a number greater than 0
-              not_a_number: Enter the amount paid for childcare
-              too_many_decimals: Enter a number with no more than 2 decimal places
+              inclusion: Select how often the partner makes housing payments
             child_care_frequency:
-              inclusion: Select how often your client makes childcare payments
-            maintenance_out_amount:
-              greater_than: Enter a number greater than 0
-              not_a_number: Enter the amount paid for maintenance
-              too_many_decimals: Enter a number with no more than 2 decimal places
+              inclusion: Select how often the partner makes childcare payments
             maintenance_out_frequency:
-              inclusion: Select how often your client makes maintenance payments
-            legal_aid_amount:
-              greater_than: Enter a number greater than 0
-              not_a_number: Enter the amount paid for legal aid
-              too_many_decimals: Enter a number with no more than 2 decimal places
+              inclusion: Select how often the partner makes maintenance payments
             legal_aid_frequency:
-              inclusion: Select how often your client makes legal aid payments
+              inclusion: Select how often the partner makes legal aid payments
             transaction_type_ids:
               blank: Select at least one of the options
+              none_and_another_option_selected: If you select 'The partner makes none of these payments', you cannot select any of the other options
         reports:
           application_type: Select if you want to search all cases or a particular type
           submitted_to_ccms: Select if you want to search cases submitted to CCMS only

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -805,6 +805,7 @@ en:
             pension_frequency:
               inclusion: Select how often the partner receives pension income
             transaction_type_ids:
+              blank: Select at least one of the options
               none_and_another_option_selected: If you select 'The partner does not get any of these payments', you cannot select any of the other options
         providers/partners/regular_outgoings_form:
           attributes:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -5,7 +5,7 @@ en:
       show:
         title: Has your client applied for civil legal aid before?
         heading: Has your client applied for civil legal aid before?
-        type_of_work_text: By this, we mean certificated and licensed work. You do not need to tell us about controlled work and family mediation. 
+        type_of_work_text: By this, we mean certificated and licensed work. You do not need to tell us about controlled work and family mediation.
         previous_records_text: We'll find any previous records to make sure any contributions we calculate are correct.
         ccms_ref_num: Give the CCMS reference number for any previous application
         ccms_ref_hint: For example, 300001234567. This is on any letter from the LAA (Legal aid agency).

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -963,9 +963,10 @@ en:
             benefits: For example, Child Benefit or tax credits.
             maintenance_in: This includes child maintenance.
             pension: This includes State, workplace and personal pensions.
-        update:
-          none_selected: Select if your client receives any types of income
-          none_and_another_option_selected: If you select 'My client does not get any of these payments', you cannot select any of the other options
+        transaction_type_ids:
+          errors:
+            none_selected: Select if your client receives any types of income
+            none_and_another_option_selected: If you select 'My client does not get any of these payments', you cannot select any of the other options
       cash_incomes:
         show:
           page_title: Select payments your client receives in cash
@@ -978,9 +979,10 @@ en:
             child_care: For example, to a childminder, nanny or nursery.
             maintenance_out: This includes child maintenance.
           none_of_these: My client makes none of these payments
-        update:
-          none_selected: Select if your client makes any regular payments
-          none_and_another_option_selected: If you select 'My client makes none of these payments', you cannot select any of the other options
+        transaction_type_ids:
+          errors:
+            none_selected: Select if your client makes any regular payments
+            none_and_another_option_selected: If you select 'My client makes none of these payments', you cannot select any of the other options
       cash_outgoings:
         show:
           page_heading: Select payments your client pays in cash

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -965,6 +965,7 @@ en:
             pension: This includes State, workplace and personal pensions.
         update:
           none_selected: Select if your client receives any types of income
+          none_and_another_option_selected: If you select 'My client does not get any of these payments', you cannot select any of the other options
       cash_incomes:
         show:
           page_title: Select payments your client receives in cash
@@ -979,6 +980,7 @@ en:
           none_of_these: My client makes none of these payments
         update:
           none_selected: Select if your client makes any regular payments
+          none_and_another_option_selected: If you select 'My client makes none of these payments', you cannot select any of the other options
       cash_outgoings:
         show:
           page_heading: Select payments your client pays in cash

--- a/spec/forms/providers/means/regular_income_form_spec.rb
+++ b/spec/forms/providers/means/regular_income_form_spec.rb
@@ -107,6 +107,22 @@ RSpec.describe Providers::Means::RegularIncomeForm do
       end
     end
 
+    context "when none plus one income type is selected" do
+      it "is invalid" do
+        maintenance_in = create(:transaction_type, :maintenance_in)
+        params = {
+          "transaction_type_ids" => ["", "none", maintenance_in.id],
+          legal_aid_application:,
+        }
+
+        form = described_class.new(params)
+
+        expect(form).not_to be_valid
+        expect(form.errors).to be_added(:transaction_type_ids, :none_and_another_option_selected)
+        expect(form.errors.messages[:transaction_type_ids]).to include("If you select 'My client does not get any of these payments', you cannot select any of the other options")
+      end
+    end
+
     context "when the correct attributes are provided" do
       it "is valid" do
         legal_aid_application = create(:legal_aid_application, :with_applicant)

--- a/spec/forms/providers/means/regular_outgoings_form_spec.rb
+++ b/spec/forms/providers/means/regular_outgoings_form_spec.rb
@@ -108,6 +108,22 @@ RSpec.describe Providers::Means::RegularOutgoingsForm do
       end
     end
 
+    context "when none plus one outgoings type is selected" do
+      it "is invalid" do
+        rent_or_mortgage = create(:transaction_type, :rent_or_mortgage)
+        params = {
+          "transaction_type_ids" => ["", "none", rent_or_mortgage.id],
+          legal_aid_application:,
+        }
+
+        form = described_class.new(params)
+
+        expect(form).not_to be_valid
+        expect(form.errors).to be_added(:transaction_type_ids, :none_and_another_option_selected)
+        expect(form.errors.messages[:transaction_type_ids]).to include("If you select 'My client makes none of these payments', you cannot select any of the other options")
+      end
+    end
+
     context "when the correct attributes are provided" do
       it "is valid" do
         legal_aid_application = create(:legal_aid_application, :with_applicant)

--- a/spec/forms/providers/partners/regular_income_form_spec.rb
+++ b/spec/forms/providers/partners/regular_income_form_spec.rb
@@ -1,0 +1,145 @@
+require "rails_helper"
+
+RSpec.describe Providers::Partners::RegularIncomeForm do
+  describe "#validate" do
+    let(:legal_aid_application) { build_stubbed(:legal_aid_application, :with_applicant_and_partner) }
+
+    context "when neither an outgoing type or none are selected" do
+      it "is invalid" do
+        params = {
+          "transaction_type_ids" => [""],
+          legal_aid_application:,
+        }
+
+        form = described_class.new(params)
+
+        expect(form).not_to be_valid
+        expect(form.errors).to be_added(:transaction_type_ids, :blank)
+      end
+    end
+
+    context "when at least one income type is selected, but an amount is missing" do
+      it "is invalid" do
+        maintenance_in = create(:transaction_type, :maintenance_in)
+        pension = create(:transaction_type, :pension)
+        params = {
+          "transaction_type_ids" => ["", maintenance_in.id, pension.id],
+          "maintenance_in_amount" => "",
+          "maintenance_in_frequency" => "weekly",
+          "pension_amount" => "100",
+          "pension_frequency" => "monthly",
+        }
+
+        form = described_class.new(params)
+
+        expect(form).not_to be_valid
+        expect(form.errors).to be_added(:maintenance_in_amount, :not_a_number, value: "")
+      end
+    end
+
+    context "when at least one income type is selected, but an invalid amount is given" do
+      it "is invalid" do
+        maintenance_in = create(:transaction_type, :maintenance_in)
+        pension = create(:transaction_type, :pension)
+        params = {
+          "transaction_type_ids" => ["", maintenance_in.id, pension.id],
+          "maintenance_in_amount" => "-1000",
+          "maintenance_in_frequency" => "weekly",
+          "pension_amount" => "100",
+          "pension_frequency" => "monthly",
+        }.merge(legal_aid_application:)
+
+        form = described_class.new(params)
+
+        expect(form).not_to be_valid
+        expect(form.errors).to be_added(:maintenance_in_amount, :greater_than, value: -1000, count: 0)
+      end
+    end
+
+    context "when at least one income type is selected, but a frequency is missing" do
+      it "is invalid" do
+        maintenance_in = create(:transaction_type, :maintenance_in)
+        pension = create(:transaction_type, :pension)
+        params = {
+          "transaction_type_ids" => ["", maintenance_in.id, pension.id],
+          "maintenance_in_amount" => "250",
+          "maintenance_in_frequency" => "",
+          "pension_amount" => "100",
+          "pension_frequency" => "monthly",
+        }.merge(legal_aid_application:)
+
+        form = described_class.new(params)
+
+        expect(form).not_to be_valid
+        expect(form.errors).to be_added(:maintenance_in_frequency, :inclusion, value: "")
+      end
+    end
+
+    context "when at least one income type is selected, but an invalid frequency is given" do
+      it "is invalid" do
+        maintenance_in = create(:transaction_type, :maintenance_in)
+        pension = create(:transaction_type, :pension)
+        params = {
+          "transaction_type_ids" => ["", maintenance_in.id, pension.id],
+          "maintenance_in_amount" => "250",
+          "maintenance_in_frequency" => "invalid",
+          "pension_amount" => "100",
+          "pension_frequency" => "monthly",
+        }.merge(legal_aid_application:)
+
+        form = described_class.new(params)
+
+        expect(form).not_to be_valid
+        expect(form.errors).to be_added(:maintenance_in_frequency, :inclusion, value: "invalid")
+      end
+    end
+
+    context "when none is selected" do
+      it "is valid" do
+        params = {
+          "transaction_type_ids" => ["", "none"],
+          legal_aid_application:,
+        }
+
+        form = described_class.new(params)
+
+        expect(form).to be_valid
+      end
+    end
+
+    context "when none plus one income type is selected" do
+      it "is invalid" do
+        maintenance_in = create(:transaction_type, :maintenance_in)
+        params = {
+          "transaction_type_ids" => ["", "none", maintenance_in.id],
+          legal_aid_application:,
+        }
+
+        form = described_class.new(params)
+
+        expect(form).not_to be_valid
+        expect(form.errors).to be_added(:transaction_type_ids, :none_and_another_option_selected)
+        expect(form.errors.messages[:transaction_type_ids]).to include("If you select 'The partner does not get any of these payments', you cannot select any of the other options")
+      end
+    end
+
+    context "when the correct attributes are provided" do
+      it "is valid" do
+        legal_aid_application = create(:legal_aid_application, :with_applicant_and_partner)
+        maintenance_in = create(:transaction_type, :maintenance_in)
+        pension = create(:transaction_type, :pension)
+        params = {
+          "transaction_type_ids" => ["", maintenance_in.id, pension.id],
+          "maintenance_in_amount" => "250",
+          "maintenance_in_frequency" => "weekly",
+          "pension_amount" => "100",
+          "pension_frequency" => "monthly",
+        }.merge(legal_aid_application:)
+
+        form = described_class.new(params)
+
+        expect(form).to be_valid
+      end
+    end
+  end
+end

--- a/spec/forms/providers/partners/regular_outgoings_form_spec.rb
+++ b/spec/forms/providers/partners/regular_outgoings_form_spec.rb
@@ -108,6 +108,22 @@ RSpec.describe Providers::Partners::RegularOutgoingsForm do
       end
     end
 
+    context "when none plus one outgoings type is selected" do
+      it "is invalid" do
+        rent_or_mortgage = create(:transaction_type, :rent_or_mortgage)
+        params = {
+          "transaction_type_ids" => ["", "none", rent_or_mortgage.id],
+          legal_aid_application:,
+        }
+
+        form = described_class.new(params)
+
+        expect(form).not_to be_valid
+        expect(form.errors).to be_added(:transaction_type_ids, :none_and_another_option_selected)
+        expect(form.errors.messages[:transaction_type_ids]).to include("If you select 'The partner makes none of these payments', you cannot select any of the other options")
+      end
+    end
+
     context "when the correct attributes are provided" do
       it "is valid" do
         legal_aid_application = create(:legal_aid_application, :with_applicant_and_partner)

--- a/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
       it "displays an error" do
         request
         expect(response.body).to match("govuk-error-summary")
-        expect(unescaped_response_body).to match(I18n.t("providers.means.identify_types_of_incomes.update.none_selected"))
+        expect(unescaped_response_body).to match("Select if your client receives any types of income")
         expect(unescaped_response_body).not_to include("translation missing")
       end
 

--- a/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
@@ -129,6 +129,23 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
       end
     end
 
+    context "when no option has been chosen" do
+      let(:params) { { legal_aid_application: { transaction_type_ids: [] } } }
+
+      it "displays an error" do
+        request
+        expect(page).to have_content("Select if your client receives any types of income")
+      end
+
+      it "does not add transaction types to the application" do
+        expect { request }.not_to change(LegalAidApplicationTransactionType, :count)
+      end
+
+      it "does not change no_credit_transaction_types_selected" do
+        expect { request }.not_to change { legal_aid_application.reload.no_credit_transaction_types_selected }
+      end
+    end
+
     context 'when "none selected" has been selected' do
       let(:params) { { legal_aid_application: { none_selected: "true" } } }
 
@@ -178,6 +195,30 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
         it "does not remove any debit cash transactions" do
           expect { request }.not_to change { legal_aid_application.cash_transactions.debits.present? }.from(true)
         end
+      end
+    end
+
+    context 'when "none selected" and another type has been selected' do
+      let(:params) do
+        {
+          legal_aid_application: {
+            none_selected: "true",
+            transaction_type_ids: income_types.map(&:id),
+          },
+        }
+      end
+
+      it "displays an error" do
+        request
+        expect(page).to have_content("If you select 'My client does not get any of these payments', you cannot select any of the other options")
+      end
+
+      it "synchronizes transaction types to the application" do
+        expect { request }.to change(LegalAidApplicationTransactionType, :count)
+      end
+
+      it "does not change no_credit_transaction_types_selected" do
+        expect { request }.not_to change { legal_aid_application.reload.no_credit_transaction_types_selected }
       end
     end
 
@@ -323,12 +364,12 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
       it_behaves_like "a provider not authenticated"
     end
 
-    context "when submitted with Save as draft" do
+    context "when form submitted with Save as draft button" do
       let(:params) do
         {
           draft_button: "Save as draft",
           legal_aid_application: {
-            none_selected: "true",
+            transaction_type_ids: [],
           },
         }
       end

--- a/spec/requests/providers/means/identify_types_of_outgoings_controller_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_outgoings_controller_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
       it "displays an error" do
         request
         expect(response.body).to match("govuk-error-summary")
-        expect(unescaped_response_body).to match(I18n.t("providers.means.identify_types_of_outgoings.update.none_selected"))
+        expect(unescaped_response_body).to match("Select if your client makes any regular payments")
         expect(unescaped_response_body).not_to include("translation missing")
       end
 


### PR DESCRIPTION
## What
Prevent none plus other checkbox selection when JS not enabled

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4707)

We rely on JS to deselect other regular income and outgoings checkboxes if the "none" checkbox option
is selected. Without JS, therefore, we need a validation that ensures "none" plus any other income/outgoing
cannot be saved.

This PR also ensures that selected checkboxes are re-rendered with user input when an error is encountered
and links the "none plus other" error to the checkbox list itself.

This change impacts the following forms:
- client regular income
- client regular outgoings 
- partner regular income
- partner regular outgoings (shown below)

Similar functionality applied to truelayer path  form equivalents - identify_types_of_income|outgoings

### After changes

![non_js_regular_transaction_with_none_plus_other_selected](https://github.com/user-attachments/assets/cfb808e3-a55c-48c8-a453-ff7bf49b1250)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
