### PR TITLE
AP-5329: Add previous_reference to admin report

### DIFF
--- a/app/services/reports/mis/application_detail_csv_line.rb
+++ b/app/services/reports/mis/application_detail_csv_line.rb
@@ -172,6 +172,7 @@ module Reports
           "Legal link lead?",
           "Number of legal links",
           "No fixed address",
+          "Previous CCMS ref?",
         ]
       end
 
@@ -207,6 +208,7 @@ module Reports
         partner
         linked_applications
         home_address
+        previous_ccms_ref
         sanitise
       end
 
@@ -446,6 +448,10 @@ module Reports
 
       def home_address
         @line << yesno(laa.applicant.no_fixed_residence?)
+      end
+
+      def previous_ccms_ref
+        @line << yesno(laa.applicant.previous_reference.present?)
       end
 
       def yesno(value)

--- a/spec/services/reports/mis/application_detail_csv_line_spec.rb
+++ b/spec/services/reports/mis/application_detail_csv_line_spec.rb
@@ -892,6 +892,24 @@ module Reports
             end
           end
         end
+
+        describe "previous reference" do
+          context "when the provider has entered a previous reference" do
+            let(:applicant) { create(:applicant, previous_reference: "30000123456") }
+
+            it "sets no_fixed_address to true" do
+              expect(value_for("Previous CCMS ref?")).to eq "Yes"
+            end
+          end
+
+          context "when the provider has not entered a previous reference" do
+            let(:applicant) { create(:applicant, previous_reference: nil) }
+
+            it "sets no_fixed_address to false" do
+              expect(value_for("Previous CCMS ref?")).to eq "No"
+            end
+          end
+        end
       end
 
       def value_for(name)


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5329)

Add a true/false display to the admin report that shows whether the provider has recorded a previous CCMS reference to an application.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
