### PR TITLE
AP-5346: Remove mandatory benefit disregards

### DIFF
--- a/app/views/providers/transactions/show.html.erb
+++ b/app/views/providers/transactions/show.html.erb
@@ -1,7 +1,13 @@
 <%= page_template page_title: t("transaction_types.page_titles.#{@transaction_type.name}"),
                   caption: t("generic.client_means_caption"), column_width: "full", template: :default do %>
 
-  <div class="govuk-body"><%= t("transaction_types.#{@transaction_type.name}.inset_text") %></div>
+  <% if I18n.exists?("transaction_types.#{@transaction_type.name}.inset_paras") %>
+    <% t("transaction_types.#{@transaction_type.name}.inset_paras").each_line do |para| %>
+      <p class="govuk-body"><%= para %></p>
+    <% end %>
+  <% else %>
+    <div class="govuk-body"><%= t("transaction_types.#{@transaction_type.name}.inset_text") %></div>
+  <% end %>
 
   <% if %w[benefits excluded_benefits].include?(@transaction_type.name) %>
     <%= render "shared/means/cost_of_living_and_disregarded_benefits" %>

--- a/config/locales/cy/transaction_types.yml
+++ b/config/locales/cy/transaction_types.yml
@@ -55,8 +55,9 @@ cy:
       student_loan: stnemyap tnarg ro naol tneduts tceleS
       excluded_benefits: stnemyap stifeneb dedragersid tceleS
     benefits:
-      inset_text: ".shtnom 3 tsap eht ni deviecer tneilc ruoy tnemyap stifeneb yreve
-        tceleS"
+      inset_paras: |
+        shtnom 3 tsal eht ni deviecer esoht edulcnI
+        .shtnom 3 tsap eht ni deviecer tneilc ruoy tnemyap stifeneb yreve tceleS
     child_care:
       inset_text: ".shtnom 3 tsap eht ni edam tneilc ruoy tnemyap eracdlihc yreve
         tceleS"

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -163,7 +163,7 @@ en:
               inclusion: Select yes if your client has applied for civil legal aid before
             previous_reference:
               blank: Enter the reference number for any previous application
-              not_valid: Enter the reference number in the correct format 
+              not_valid: Enter the reference number in the correct format
         aggregated_cash_income:
           credits:
             attributes:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -5,7 +5,7 @@ en:
       show:
         title: Has your client applied for civil legal aid before?
         heading: Has your client applied for civil legal aid before?
-        type_of_work_text: By this, we mean certificated and licensed work. You do not need to tell us about controlled work and family mediation. 
+        type_of_work_text: By this, we mean certificated and licensed work. You do not need to tell us about controlled work and family mediation.
         previous_records_text: We'll find any previous records to make sure any contributions we calculate are correct.
         ccms_ref_num: Give the CCMS reference number for any previous application
         ccms_ref_hint: For example, 300001234567. This is on any letter from the LAA (Legal aid agency).
@@ -130,7 +130,7 @@ en:
       other_income:
         title: "%{individual} other income"
         income: "%{individual} income"
-        benefits: Benefits
+        benefits: Benefits, charitable or government payments
         friends_or_family: Financial help from friends or family
         maintenance: Maintenance payments from a former partner
         property_or_lodger: Income from property or lodger

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -216,7 +216,7 @@ en:
         line_3: You still need to provide details of the case before we can grant legal aid.
     cost_of_living_and_disregarded_benefits:
       title:
-        Government Cost of Living Payments and disregarded benefits
+        What not to include
     cost_of_living:
       header: Government Cost of Living Payments
       text: "Government Cost of Living Payments are disregarded from the financial eligibility calculation, for example:"
@@ -249,23 +249,27 @@ en:
       low_income:
         heading: Low income benefits
         list:
-        - Benefit Transfer Advance (Universal Credit)
         - Budgeting Advance
-        - Council Tax Reduction
-        - Earnings Top-up (ETU)
         - Housing Benefit
         - Social Fund Funeral Payment
         - Social Fund payments
+        - Universal Credit advance payments
       other:
         heading: Other benefits
         list:
         - Armed Forces Independence Payment
+        - Compensation for miscarriage of justice
         - Foster Carers Allowance
         - Grenfell Tower Residents' Discretionary Fund
         - Grenfell Tower fire victims payments
+        - Infected Blood Support Scheme, which includes Infected Blood
+        - Interim Compensation Payment Scheme, Infected Blodd Further
+        - Interim Compensation Payment Schem, Infected Blood
+        - Compensation Scheme or ealier support schemes
+        - Modern Slavery Victim Care Contract (MSVCC) payments
+        - Scotland and Northen Ireland Redress Schemes for historical child abuse payments
         - War Pensions Scheme payments
         - War Widow(er) Pension
-        - Widow's Pension lump sum payments
         - Windrush Compensation Scheme Payments
     means_report:
       item:

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -25,7 +25,7 @@ en:
         providers:
           means: &revealing_checkbox_labels
             cash_incomes:
-              check_box_benefits: Benefits
+              check_box_benefits: Benefits, charitable or government payments
               check_box_friends_or_family: Financial help from friends or family
               check_box_maintenance_in: Maintenance payments from a former partner
               check_box_property_or_lodger: Income from a property or lodger

--- a/config/locales/en/transaction_types.yml
+++ b/config/locales/en/transaction_types.yml
@@ -4,7 +4,7 @@ en:
       # TODO: remove this as we don't actually show transaction categories to citizens anymore, however these categories are still
       # being used in a few places, and have tests and helper methods which will also need to be updated/removed
       citizens:
-        benefits: Benefits
+        benefits: Benefits, charitable or government payments
         child_care: Childcare payments
         excluded_benefits: Disregarded benefits
         friends_or_family: Financial help from friends or family
@@ -18,7 +18,7 @@ en:
         salary: Salary or wages
         student_loan: Student loan or grant
       providers:
-        benefits: Benefits
+        benefits: Benefits, charitable or government payments
         child_care: Childcare payments
         excluded_benefits: Disregarded benefits
         friends_or_family: Financial help from friends or family
@@ -61,7 +61,7 @@ en:
       salary: Salary
       student_loan: Student loan
     page_titles:
-      benefits: Select any benefits your client got in the last 3 months
+      benefits: Select any benefits, charitable or government payments
       child_care: Select childcare payments
       friends_or_family: Select payments from friends or family
       legal_aid: Select legal aid payments
@@ -74,7 +74,9 @@ en:
       student_loan: Select student loan or grant payments
       excluded_benefits: Select government Cost of Living Payments and disregarded benefits
     benefits:
-      inset_text: Do not include Housing Benefit, government Cost of Living Payments or any other disregarded benefits.
+      inset_paras: |
+        Include those received in the last 3 months
+        Do not include Housing Benefit, Government Cost of Living Payments or any other disregarded benefits and payments.
     child_care:
       inset_text: Select every childcare payment your client made in the past 3 months.
     excluded_benefits:

--- a/features/providers/bank_statement_upload/happy_path_journey.feature
+++ b/features/providers/bank_statement_upload/happy_path_journey.feature
@@ -25,9 +25,9 @@ Feature: Bank statement upload journey happy path
 
     When I click "Save and continue"
     Then I should be on the "regular_incomes" page showing "Which of these payments does your client get?"
-    And I should see govuk-details 'Government Cost of Living Payments and disregarded benefits'
+    And I should see govuk-details 'What not to include'
 
-    When I open the section 'Government Cost of Living Payments and disregarded benefits'
+    When I open the section 'What not to include'
     Then the following sections should exist:
       | tag | section |
       | h2  | Government Cost of Living Payments |
@@ -100,9 +100,9 @@ Feature: Bank statement upload journey happy path
 
     When I click "Save and continue"
     Then I should be on the "regular_incomes" page showing "Which of these payments does your client get?"
-    And I should see govuk-details 'Government Cost of Living Payments and disregarded benefits'
+    And I should see govuk-details 'What not to include'
 
-    When I open the section 'Government Cost of Living Payments and disregarded benefits'
+    When I open the section 'What not to include'
     Then the following sections should exist:
       | tag | section |
       | h2  | Government Cost of Living Payments |

--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -323,7 +323,7 @@ Feature: Checking answers backwards and forwards
 
     And the "Payments your client receives" section's questions and answers should match:
       | question | answer |
-      | Benefits | £666.00 |
+      | Benefits, charitable or government payments | £666.00 |
       | Disregarded benefits | None |
       | Financial help from friends or family | None |
       | Maintenance payments from a former partner | Yes, but none specified |

--- a/features/providers/non_passported_journey/with_means.feature
+++ b/features/providers/non_passported_journey/with_means.feature
@@ -74,7 +74,7 @@ Feature: non_passported_journey with means
 
     When I click 'Save and continue'
     Then I should be on the 'check_income_answers' page showing 'Check your answers'
-    And I should see "Benefits None"
+    And I should see "Benefits, charitable or government payments None"
 
     When I click 'Save and continue'
     Then I should be on a page with title "What you need to do"

--- a/features/providers/review_and_print.feature
+++ b/features/providers/review_and_print.feature
@@ -85,7 +85,7 @@ Feature: Review and print your application
 
     And the "Income, regular payments and assets" review section should contain:
       | question |
-      | Benefits total |
+      | Benefits, charitable or government payments total |
       | Disregarded benefits total |
       | Financial help from friends or family total |
       | Maintenance payments from a former partner total |
@@ -145,7 +145,7 @@ Feature: Review and print your application
       | h2  | Your client's capital |
 
     And I should see "Passported"
-    And I should not see "Benefits total"
+    And I should not see "Benefits, charitable or government payments total"
     And I should not see "Housing benefit total"
     And I should not see "Disregarded benefits total"
     And I should not see "Financial help from friends or family total"


### PR DESCRIPTION


## What
Remove mandatory disregards [from truelayer]

[Content/design ticket](https://dsdmoj.atlassian.net/browse/AP-5436)
[Remove disregards backend](https://dsdmoj.atlassian.net/browse/AP-5335)
[Remove disregards auto categorisation](https://dsdmoj.atlassian.net/browse/AP-5336)

Remove the mandatory disregards from the True layer journey as Caseworkers do not need this information
and to bring it in line with the non-True layer journey.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
