### PR TITLE
Chore: Update gemfile-lock with new darwin osx version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,6 +274,7 @@ GEM
     faraday-net_http (3.3.0)
       net-http
     ffi (1.17.0)
+    ffi (1.17.0-x86_64-darwin)
     formatador (1.1.0)
     geckoboard-ruby (0.4.0)
     globalid (1.2.1)
@@ -420,6 +421,8 @@ GEM
     nio4r (2.7.3)
     nokogiri (1.16.7)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.16.7-x86_64-darwin)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -652,6 +655,7 @@ GEM
       nokogiri (>= 1.13.10)
       rexml
     rubyzip (2.3.2)
+    securerandom (0.3.1)
     selenium-webdriver (4.25.0)
       base64 (~> 0.2)
       logger (~> 1.4)
@@ -752,6 +756,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin
 
 DEPENDENCIES
   aasm (~> 5.5.0)


### PR DESCRIPTION
## What

ran `bundle lock --add-platform ruby` and `bundle lock --add-platform x86_64-darwin` to ensure the gems needed by development osx machines and deployed linux containers are explicitly included

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
