### PR TITLE
AP-5365: Fix vehicle not found error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
 private
 
   def page_not_found(exception)
+    # TODO: alerting and logging added to handle bug AP-5365 but could keep in?!
     AlertManager.capture_exception(exception)
     Rails.logger.error(exception.message)
     update_locale

--- a/app/controllers/concerns/providers/application_dependable.rb
+++ b/app/controllers/concerns/providers/application_dependable.rb
@@ -31,8 +31,6 @@ module Providers
       end
 
       def process_invalid_application
-        AlertManager.capture_exception("#{self.class}##{__method__} called for legal aid application id of #{params[:legal_aid_application_id] || 'nil'}")
-        Rails.logger.error("#{self.class}##{__method__} called for legal aid application id of #{params[:legal_aid_application_id] || 'nil'}")
         redirect_to error_path(:page_not_found)
       end
 

--- a/app/services/flow/steps/provider_capital/vehicle_details_step.rb
+++ b/app/services/flow/steps/provider_capital/vehicle_details_step.rb
@@ -3,8 +3,9 @@ module Flow
     module ProviderCapital
       VehicleDetailsStep = Step.new(
         path: lambda do |application|
-          if application.provider_step_params["id"]
-            vehicle = application.vehicles.find(application.provider_step_params["id"])
+          vehicle = application.vehicles.find_by_id(application.provider_step_params["id"])
+
+          if vehicle
             Steps.urls.providers_legal_aid_application_means_vehicle_detail_path(application, vehicle)
           else
             Steps.urls.new_providers_legal_aid_application_means_vehicle_detail_path(application)

--- a/spec/services/flow/steps/provider_capital/vehicle_details_step_spec.rb
+++ b/spec/services/flow/steps/provider_capital/vehicle_details_step_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe Flow::Steps::ProviderCapital::VehicleDetailsStep, type: :request 
 
       it { is_expected.to eq providers_legal_aid_application_means_vehicle_detail_path(legal_aid_application, vehicle) }
     end
+
+    context "when a user has somehow stored an invalid vehicle id (BUG AP-5365)" do
+      let(:provider_step_params) { { id: "new" } }
+
+      it { is_expected.to eq new_providers_legal_aid_application_means_vehicle_detail_path(legal_aid_application) }
+    end
   end
 
   describe "#forward" do


### PR DESCRIPTION
## What
Fix vehicle not found error

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5365)

This was causing the application list/index for national legal service’s firm to
redirect to page not found as vehicle id had been stored with the value 'new' for
one of their firms applications. This resulted in an ActiveRecord::NotFound error
which is rescued at application controller level and redirected to the page_not_found.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
