### PR TITLE
AP-3985: Clear employment if citizen does not complete truelayer

### DIFF
--- a/app/controllers/citizens/consents_controller.rb
+++ b/app/controllers/citizens/consents_controller.rb
@@ -18,7 +18,15 @@ module Citizens
   private
 
     def change_application_state
-      legal_aid_application.use_ccms!(:no_applicant_consent) if @form.open_banking_consent != "true"
+      if @form.open_banking_consent != "true"
+        legal_aid_application.use_ccms!(:no_applicant_consent)
+        clear_employment_status
+      end
+    end
+
+    def clear_employment_status
+      legal_aid_application.applicant.employed = nil
+      legal_aid_application.applicant.save!
     end
 
     def form_params

--- a/app/views/shared/check_answers/_full_employment_details.html.erb
+++ b/app/views/shared/check_answers/_full_employment_details.html.erb
@@ -23,7 +23,7 @@
 
 <%= govuk_summary_list(actions: false, classes: "govuk-!-margin-bottom-9", html_attributes: { id: "employment-income-questions" }) do |summary_list| %>
   <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__full_employment_details" }) do |row| %>
-    <%= row.with_key(text: t(".details", individual_with_determiner:), classes: "govuk-!-width-one-half") %>
+    <%= row.with_key(text: t(".details", individual_with_determiner:).upcase_first, classes: "govuk-!-width-one-half") %>
     <%= row.with_value { content.presence || "-" } %>
   <% end %>
 <% end %>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3985)

Delete employment answer if citizen does not complete truelayer, so that this information is not displayed before the provider answers the question. The question is asked twice in this scenario - this is a quirk of the sequencing of the questions
## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
