### PR TITLE
Stop updating student_loan `archived_at` date

### DIFF
--- a/app/services/populators/transaction_type_populator.rb
+++ b/app/services/populators/transaction_type_populator.rb
@@ -32,7 +32,7 @@ module Populators
 
     def mark_old_as_archived
       TransactionType.active.where.not(name: TransactionType::NAMES.values.flatten).update!(archived_at: Time.current)
-      TransactionType.find_by(name: "student_loan").update!(archived_at: Time.current)
+      TransactionType.active.find_by(name: "student_loan")&.update!(archived_at: Time.current)
     end
 
     def update_other_income_types


### PR DESCRIPTION
## What
Stop updating student_loan `archived_at` date

[Came out of looking at story](https://dsdmoj.atlassian.net/browse/AP-5346)

This was causing the archived_at date to be updated with the current
date time everytime it is deployed.

Arguably we could/should remove this line entirely?!

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
