### PR TITLE
AP-5336: Remove automatic categorisation of transactions matching excluded benefits

### DIFF
--- a/app/services/banking/state_benefits_loader.rb
+++ b/app/services/banking/state_benefits_loader.rb
@@ -1,0 +1,39 @@
+module Banking
+  Struct.new("Benefit", :code, :label, :name, :excluded?)
+
+  class StateBenefitsLoader
+    attr_accessor :state_benefit_codes
+
+    def self.call
+      new.call
+    end
+
+    def initialize
+      @state_benefit_codes = {}
+    end
+
+    def call
+      load_state_benefit_types
+      state_benefit_codes
+    end
+
+  private
+
+    def load_state_benefit_types
+      state_benefit_list.each do |state_benefit|
+        next if state_benefit["dwp_code"].nil?
+
+        store_benefit(state_benefit)
+      end
+    end
+
+    def state_benefit_list
+      CFECivil::ObtainStateBenefitTypesService.call
+    end
+
+    def store_benefit(state_benefit)
+      benefit = Struct::Benefit.new(state_benefit["dwp_code"], state_benefit["label"], state_benefit["name"], state_benefit["exclude_from_gross_income"])
+      state_benefit_codes[benefit.code] = benefit
+    end
+  end
+end


### PR DESCRIPTION
## What
Remove automatic categorisation of transactions matching excluded benefits

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5336)

We will be removing the ability to add disregarded benefits entirely
in the near future ([Related ticket](https://dsdmoj.atlassian.net/browse/AP-5335)), but for now the BA has approved the removal of 
automatic categorisation of transactions from truelayer as being disregarded types, even 
when they match. This is because caseworkers have fed back that it is inaccurate, 
confusing and unhelpful.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
