### PR TITLE
FIX: fix truelayer category display

### DIFF
--- a/app/views/providers/transactions/show.html.erb
+++ b/app/views/providers/transactions/show.html.erb
@@ -98,7 +98,7 @@
                   end
                 else
                   row.with_cell(html_attributes: { class: "sortable-cell", "data-sort-value": t("activemodel.attributes.transaction_types.name.#{@transaction_type.name}"), id: "Category-#{builder.object.id}" }) do
-                    concat govuk_tag(text: t("activemodel.attributes.transaction_types.name.#{@transaction_type.name}"))
+                    concat govuk_tag(text: t("activemodel.attributes.transaction_types.name.#{builder.object.transaction_type.name}"))
                   end
                 end
               end

--- a/features/providers/non_passported_journey/with_bank_transactions.feature
+++ b/features/providers/non_passported_journey/with_bank_transactions.feature
@@ -39,8 +39,14 @@ Feature: non_passported_journey with bank transactions
     And I click 'Save and continue'
 
     Then I click the '2nd' link 'View statements and add transactions'
+    And I should see govuk-tag "Financial help"
     Then I select the first checkbox
     And I click 'Save and continue'
+
+    Then I click the '2nd' link 'View statements and add transactions'
+    And I should see govuk-tag "Financial help"
+    And I should see govuk-tag "Pension"
+    Then I click 'Save and continue'
 
     Then I click 'Save and continue'
 

--- a/features/step_definitions/generic_steps.rb
+++ b/features/step_definitions/generic_steps.rb
@@ -20,6 +20,10 @@ Then("I should see govuk-details {string}") do |text|
   expect(page).to have_css(".govuk-details", text:)
 end
 
+Then("I should see govuk-tag {string}") do |text|
+  expect(page).to have_css(".govuk-tag", text:)
+end
+
 And(/^I should (see|not see) a ['|"](.*?)['|"] button$/) do |visibility, text|
   if visibility == "see"
     expect(page).to have_button(text:)


### PR DESCRIPTION
## What
Fix truelayer category display

[Came out of](https://dsdmoj.atlassian.net/browse/AP-5336)

For already selected/categorised transactions the current app is
displaying the category of whatever transaction type (Benefits, Disregards,
Maintenance) you happen to be on the page for selecting, rather than the
actual category that it has already been categorised as.

## Before
On the select maintenance payments page already selected transactions appear as maintenance (same applies to any transaction type page you are on though)

![Screenshot 2024-10-09 at 16 48 53](https://github.com/user-attachments/assets/8d129321-4275-418e-80b7-e404cb402cf4)


## After
With fix in place pre categorised transactions appear as what they were categorised as

![Screenshot 2024-10-09 at 16 51 51](https://github.com/user-attachments/assets/2109144b-986a-4d5d-acdb-96fc965df922)



## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
