### PR TITLE
AP-5335: Remove ability to add disregarded benefits

### DIFF
--- a/app/controllers/providers/means/housing_benefits_controller.rb
+++ b/app/controllers/providers/means/housing_benefits_controller.rb
@@ -28,7 +28,7 @@ module Providers
 
       def individual
         show_for_partner = legal_aid_application.housing_payments_for?("Partner")
-        show_for_client = legal_aid_application.housing_payments_for?("Applicant") && legal_aid_application.uploading_bank_statements?
+        show_for_client = legal_aid_application.housing_payments_for?("Applicant")
         if show_for_partner && show_for_client
           I18n.t("generic.client_or_partner")
         else

--- a/app/helpers/means_report_helper.rb
+++ b/app/helpers/means_report_helper.rb
@@ -1,9 +1,9 @@
 module MeansReportHelper
-  TransactionTypeItem = Struct.new(:name, :value_method, :scope, :suppress_border, :addendum)
+  TransactionTypeItem = Struct.new(:name, :value_method, :scope, :suppress_border)
 
-  def outgoings_detail_items(legal_aid_application)
+  def outgoings_detail_items
     [
-      TransactionTypeItem.new(:housing, :moe_housing, "outgoing", false, housing_payment_addendum(legal_aid_application)),
+      TransactionTypeItem.new(:housing, :moe_housing, "outgoing", false),
       TransactionTypeItem.new(:childcare, :moe_childcare, "outgoing", false),
       TransactionTypeItem.new(:maintenance_out, :moe_maintenance_out, "outgoing", false),
       TransactionTypeItem.new(:legal_aid, :moe_legal_aid, "outgoing", true),
@@ -47,9 +47,5 @@ private
       TransactionTypeItem.new(:student_loan, :mei_student_loan, "income", false),
       TransactionTypeItem.new(:pension, :mei_pension, "income", true),
     ]
-  end
-
-  def housing_payment_addendum(legal_aid_application)
-    t("shared.means_report.item.outgoing.housing_addendum") if legal_aid_application.uploading_bank_statements?
   end
 end

--- a/app/helpers/means_report_helper.rb
+++ b/app/helpers/means_report_helper.rb
@@ -19,7 +19,6 @@ module MeansReportHelper
   def deductions_detail_items(legal_aid_application)
     items = [TransactionTypeItem.new(:dependants_allowance, :dependants_allowance, "deductions", false)]
     items.append(TransactionTypeItem.new(:partner_allowance, :partner_allowance, "deductions", false)) if legal_aid_application.applicant.has_partner_with_no_contrary_interest?
-    items.append(TransactionTypeItem.new(:disregarded_state_benefits, :disregarded_state_benefits, "deductions", true)) unless legal_aid_application.uploading_bank_statements?
     items
   end
 

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -620,7 +620,7 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def housing_benefit_regular_transaction_applicable?
-    uploading_bank_statements? && housing_payments?
+    housing_payments?
   end
 
   def truelayer_path?

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -619,10 +619,6 @@ class LegalAidApplication < ApplicationRecord
     TransactionType.where(id: owners_transaction_types).for_outgoing_type?(:rent_or_mortgage)
   end
 
-  def housing_benefit_regular_transaction_applicable?
-    housing_payments?
-  end
-
   def truelayer_path?
     provider_received_citizen_consent == true
   end

--- a/app/services/cfe_civil/component_list.rb
+++ b/app/services/cfe_civil/component_list.rb
@@ -27,6 +27,7 @@ module CFECivil
       Components::OtherIncome,
       Components::IrregularIncomes,
       Components::Employments,
+      Components::RegularTransactions,
       Components::CashTransactions,
       Components::Partner,
     ].freeze

--- a/app/services/flow/steps/partner/cash_outgoings_step.rb
+++ b/app/services/flow/steps/partner/cash_outgoings_step.rb
@@ -4,20 +4,19 @@ module Flow
       CashOutgoingsStep = Step.new(
         path: ->(application) { Steps.urls.providers_legal_aid_application_partners_cash_outgoing_path(application) },
         forward: lambda do |application|
-                   # if the applicant did not use Truelayer and makes housing payments, or if the partner makes housing payments, then ask about housing benefit
-                   if (application.housing_payments_for?("Applicant") && application.uploading_bank_statements?) || application.housing_payments_for?("Partner")
-                     :housing_benefits
-                   else
-                     :has_dependants
-                   end
-                 end,
+          if application.housing_payments_for?("Applicant") || application.housing_payments_for?("Partner")
+            :housing_benefits
+          else
+            :has_dependants
+          end
+        end,
         check_answers: lambda do |application|
-                         if (application.housing_payments_for?("Applicant") && application.uploading_bank_statements?) || application.housing_payments_for?("Partner")
-                           :housing_benefits
-                         else
-                           :has_dependants
-                         end
-                       end,
+          if application.housing_payments_for?("Applicant") || application.housing_payments_for?("Partner")
+            :housing_benefits
+          else
+            :has_dependants
+          end
+        end,
       )
     end
   end

--- a/app/services/flow/steps/provider_income/cash_outgoings_step.rb
+++ b/app/services/flow/steps/provider_income/cash_outgoings_step.rb
@@ -11,9 +11,10 @@ module Flow
               return :outgoings_summary
             end
           end
+
           if application.applicant.has_partner_with_no_contrary_interest?
             :partner_about_financial_means
-          elsif application.uploading_bank_statements? && application.housing_payments_for?("Applicant")
+          elsif application.housing_payments_for?("Applicant")
             :housing_benefits
           else
             :has_dependants

--- a/app/services/flow/steps/provider_income/outgoings_summary_step.rb
+++ b/app/services/flow/steps/provider_income/outgoings_summary_step.rb
@@ -6,11 +6,15 @@ module Flow
         forward: lambda do |application|
           if application.applicant.has_partner_with_no_contrary_interest?
             :partner_about_financial_means
+          elsif application.housing_payments_for?("Applicant")
+            :housing_benefits
           else
             :has_dependants
           end
         end,
-        check_answers: :check_income_answers,
+        check_answers: lambda do |application|
+          application.housing_payments_for?("Applicant") ? :housing_benefits : :check_income_answers
+        end,
       )
     end
   end

--- a/app/services/populators/transaction_type_populator.rb
+++ b/app/services/populators/transaction_type_populator.rb
@@ -30,9 +30,21 @@ module Populators
       record
     end
 
+    # NOTE: while we could remove transaction types from the TransactionType::NAMES constant to achieve the
+    # "deactivation/archiving" this would mean the test environment and UAT branches would not reflect the
+    # real world data, as they would not be seeded with that transaction type at all. Archiving a type explicitly,
+    # aside from being clearer, therefore allows us identify test suite failures and manually test on UAT with
+    # like-real-world data as well as enable use to conditional logic for existing applications with that transaction
+    # tyoe that we may want to handle differently
+    #
+    # After a period of time and once we are confident the impact would be minimal we could then remove the transaction type
+    # from the TransactionType::NAMES constant AND possibly delete the old transaction type (and associated bank transactions??)
+    #
     def mark_old_as_archived
       TransactionType.active.where.not(name: TransactionType::NAMES.values.flatten).update!(archived_at: Time.current)
+
       TransactionType.active.find_by(name: "student_loan")&.update!(archived_at: Time.current)
+      TransactionType.active.find_by(name: "excluded_benefits")&.update!(archived_at: Time.current)
     end
 
     def update_other_income_types

--- a/app/views/providers/capital_income_assessment_results/_deductions.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_deductions.html.erb
@@ -22,12 +22,6 @@
             row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.partner_allowance))
           end
         end
-        unless @legal_aid_application.uploading_bank_statements?
-          body.with_row do |row|
-            row.with_cell(header: true, text: t(".excluded_benefits"))
-            row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.disregarded_state_benefits))
-          end
-        end
       end
 
       table.with_foot do |foot|

--- a/app/views/providers/means/check_income_answers/show.html.erb
+++ b/app/views/providers/means/check_income_answers/show.html.erb
@@ -10,7 +10,7 @@
 
   <%= render "providers/means/check_income_answers/partner_income_assessment" if @legal_aid_application.applicant.has_partner_with_no_contrary_interest? %>
 
-  <% if @legal_aid_application.housing_benefit_regular_transaction_applicable? %>
+  <% if @legal_aid_application.housing_payments? %>
     <%= render(
           "shared/check_answers/housing_benefit",
           read_only: false,

--- a/app/views/shared/check_answers/_outgoings_details.html.erb
+++ b/app/views/shared/check_answers/_outgoings_details.html.erb
@@ -1,9 +1,8 @@
 <section>
   <dl id="outgoings-details-questions" class="govuk-summary-list govuk-!-margin-bottom-9">
-    <% outgoings_detail_items(@legal_aid_application).each do |item| %>
+    <% outgoings_detail_items.each do |item| %>
       <%= render "shared/means_report/item", item.to_h %>
     <% end %>
     <%= render "shared/means_report/total", name: "total_outgoings", value_method: :total_monthly_outgoings %>
   </dl>
-
 </section>

--- a/app/views/shared/means_report/_item.html.erb
+++ b/app/views/shared/means_report/_item.html.erb
@@ -1,9 +1,8 @@
-<% addendum = local_assigns[:addendum] || nil %>
 <% suppress_border ||= false %>
 <% css_border_klass = suppress_border ? "govuk-summary-list__row--no-border" : "" %>
 <div class="govuk-summary-list__row  normal-word-break" id="<%= "means-merits-report__#{name}" %>">
   <dt class="govuk-summary-list__key govuk-!-width-one-half">
-    <%= t(".#{scope}.client.#{name}", addendum:) %>
+    <%= t(".#{scope}.client.#{name}") %>
   </dt>
   <!--  in-line styling due to issues around pdf generation in our production envs -->
   <dd class="govuk-summary-list__value govuk-!-text-align-right">
@@ -14,7 +13,7 @@
   <% unless partner_exclude_items.include?(value_method) %>
     <div class="<%= "govuk-summary-list__row  normal-word-break #{css_border_klass}" %>" id="<%= "means-merits-report__partner_#{name}" %>">
       <dt class="<%= "govuk-summary-list__key govuk-!-width-one-half" %>">
-        <%= t(".#{scope}.partner.#{name}", addendum:) %>
+        <%= t(".#{scope}.partner.#{name}") %>
       </dt>
       <!--  in-line styling due to issues around pdf generation in our production envs -->
       <dd class="govuk-summary-list__value govuk-!-text-align-right">

--- a/app/views/shared/review_application/_income_payments_and_assets.html.erb
+++ b/app/views/shared/review_application/_income_payments_and_assets.html.erb
@@ -55,6 +55,19 @@
     <% end %>
   </section>
 
+<!-- HOUSING BENEFIT -->
+
+  <section class="print-no-break govuk-!-padding-top-8">
+    <% if @legal_aid_application.housing_payments? %>
+      <% individual = @legal_aid_application.applicant.has_partner_with_no_contrary_interest? ? t("generic.client_or_partner") : t("generic.client") %>
+      <%= render(
+            "shared/check_answers/housing_benefit",
+            read_only: true,
+            individual:,
+          ) %>
+    <% end %>
+  </section>
+
 <!--  PARTNER INCOME -->
 
   <% if @legal_aid_application.applicant.has_partner_with_no_contrary_interest? && !@legal_aid_application.applicant_receives_benefit? %>
@@ -66,7 +79,7 @@
 
 <!-- CAPITAL -->
 
-  <section class="print-no-break govuk-!-padding-top-8">
+  <section class="print-no-break">
     <% individual = @legal_aid_application.applicant.has_partner_with_no_contrary_interest? ? "_with_partner" : nil %>
     <%= render "shared/check_answers/assets", read_only: true, individual: %>
   </section>

--- a/app/views/shared/review_application/_income_payments_and_assets_for_bank_statement_upload.html.erb
+++ b/app/views/shared/review_application/_income_payments_and_assets_for_bank_statement_upload.html.erb
@@ -106,7 +106,7 @@
 <!-- HOUSING BENEFIT -->
 
   <section class="print-no-break">
-    <% if @legal_aid_application.housing_benefit_regular_transaction_applicable? %>
+    <% if @legal_aid_application.housing_payments? %>
       <% individual = @legal_aid_application.applicant.has_partner_with_no_contrary_interest? ? t("generic.client_or_partner") : t("generic.client") %>
       <%= render(
             "shared/check_answers/housing_benefit",

--- a/config/locales/cy/shared.yml
+++ b/config/locales/cy/shared.yml
@@ -99,7 +99,6 @@ cy:
       item:
         deductions:
           dependants_allowance: ecnawolla stnadnepeD
-          disregarded_state_benefits: noitaluclac morf dedulcxe stifeneb morf emocnI
         income:
           benefits: stifeneB
           family_help: ylimaf ro sdneirf morf pleh laicnaniF

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -111,7 +111,6 @@ en:
         title: Deductions
         dependants_allowance: Dependants allowance
         partner_allowance: Partner allowance
-        excluded_benefits: Income from benefits excluded from calculation
         total_deductions: Total deductions
         table_caption: Deductions
         type_of_deduction: Type of deductions

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -306,20 +306,17 @@ en:
             student_loan: Partner student loan or grant
             pension: Partner pension
         outgoing:
-          housing: "Housing payments%{addendum}"
-          housing_addendum: " (any declared housing benefits have been deducted from this total)"
+          housing: "Housing payments (any declared housing benefits have been deducted from this total)"
           childcare: Childcare payments
           maintenance_out: Maintenance payments to a former partner
           legal_aid: Payments towards legal aid in a criminal case
           client:
-            housing: "Client housing payments%{addendum}"
-            housing_addendum: " (any declared housing benefits have been deducted from this total)"
+            housing: "Client housing payments (any declared housing benefits have been deducted from this total)"
             childcare: Client childcare payments
             maintenance_out: Client maintenance payments to a former partner
             legal_aid: Client payments towards legal aid in a criminal case
           partner:
-            housing: "Partner housing payments%{addendum}"
-            housing_addendum: " (any declared housing benefits have been deducted from this total)"
+            housing: "Partner housing payments (any declared housing benefits have been deducted from this total)"
             childcare: Partner childcare payments
             maintenance_out: Partner maintenance payments to a former partner
             legal_aid: Partner payments towards legal aid in a criminal case

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -264,14 +264,10 @@ en:
       item:
         deductions:
           dependants_allowance: Dependants allowance
-          disregarded_state_benefits: Income from benefits excluded from calculation
           partner_allowance: Partner allowance
           client:
             dependants_allowance: Dependants allowance
-            disregarded_state_benefits: Client income from benefits excluded from calculation
             partner_allowance: Partner allowance
-          partner:
-            disregarded_state_benefits: Partner income from benefits excluded from calculation
         income:
           benefits: Benefits
           employment: Gross employment income

--- a/features/providers/check_multiple_employment.feature
+++ b/features/providers/check_multiple_employment.feature
@@ -29,7 +29,7 @@ Feature: Check multiple employment
     And I click 'Save and continue'
     Then I should be on a page showing "Which of these payments does your client pay?"
 
-    When I select 'Housing payments'
+    When I select 'Childcare'
     And I click 'Save and continue'
     Then I should be on a page showing "Select payments your client pays in cash"
 
@@ -46,7 +46,7 @@ Feature: Check multiple employment
     Then I should be on the 'outgoings_summary' page showing "Sort your client's regular payments into categories"
 
     Then I click the first link 'View statements and add transactions'
-    Then I should be on a page showing 'Select housing payments'
+    Then I should be on a page showing 'Select childcare payments'
 
     Then I select the first checkbox
     And I click 'Save and continue'

--- a/features/providers/check_pending_employment.feature
+++ b/features/providers/check_pending_employment.feature
@@ -28,7 +28,7 @@ Feature: Check pending employment
     And I click 'Save and continue'
     Then I should be on the 'identify_types_of_outgoing' page showing "Which of these payments does your client pay?"
 
-    When I select 'Housing'
+    When I select 'Childcare'
     And I click 'Save and continue'
     Then I should be on a page showing "Select payments your client pays in cash"
 
@@ -45,7 +45,7 @@ Feature: Check pending employment
     Then I should be on the 'outgoings_summary' page showing "Sort your client's regular payments into categories"
 
     When I click the first link 'View statements and add transactions'
-    Then I should be on a page showing 'Select housing payments'
+    Then I should be on a page showing 'Select childcare payments'
     When I select the first checkbox
     And I click 'Save and continue'
     And I click 'Save and continue'

--- a/features/providers/check_single_employment.feature
+++ b/features/providers/check_single_employment.feature
@@ -29,7 +29,7 @@ Feature: Check single employment
     And I click 'Save and continue'
     Then I should be on the 'identify_types_of_outgoing' page showing "Which of these payments does your client pay?"
 
-    When I select 'Housing'
+    When I select 'Childcare'
     And I click 'Save and continue'
     Then I should be on a page showing "Select payments your client pays in cash"
 
@@ -46,7 +46,7 @@ Feature: Check single employment
     Then I should be on the 'outgoings_summary' page showing "Sort your client's regular payments into categories"
 
     When I click the first link 'View statements and add transactions'
-    Then I should be on a page showing 'Select housing payments'
+    Then I should be on a page showing 'Select childcare payments'
     When I select the first checkbox
     And I click 'Save and continue'
     And I click 'Save and continue'

--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -325,7 +325,6 @@ Feature: Checking answers backwards and forwards
     And the "Payments your client receives" section's questions and answers should match:
       | question | answer |
       | Benefits | £666.00 |
-      | Disregarded benefits | None |
       | Financial help from friends or family | None |
       | Maintenance payments from a former partner | Yes, but none specified |
       | Income from a property or lodger | None |

--- a/features/providers/means_report.feature
+++ b/features/providers/means_report.feature
@@ -96,10 +96,6 @@ Feature: Means report
       | Dependants allowance |
       | Total deductions |
 
-    And the Deductions questions should not exist:
-      | question |
-      | Income from benefits excluded from calculation |
-
     And the Caseworker review section should contain:
       | question | answer |
       | Caseworker review required? | Yes |
@@ -266,7 +262,6 @@ Feature: Means report
     And the Deductions questions should exist:
       | question |
       | Dependants allowance |
-      | Client income from benefits excluded from calculation |
       | Total deductions |
 
     And the Caseworker review questions should exist:

--- a/features/providers/means_report.feature
+++ b/features/providers/means_report.feature
@@ -256,7 +256,7 @@ Feature: Means report
 
     And the Outgoings questions and answers should match:
       | question | answer |
-      | Client housing payments | £125 |
+      | Client housing payments (any declared housing benefits have been deducted from this total) | £125 |
       | Client childcare payments | £0 |
       | Client maintenance payments to a former partner | £0 |
       | Client payments towards legal aid in a criminal case | £100 |

--- a/features/providers/non_passported_journey/with_bank_transactions.feature
+++ b/features/providers/non_passported_journey/with_bank_transactions.feature
@@ -1,16 +1,20 @@
 Feature: non_passported_journey with bank transactions
   @javascript @vcr
   Scenario: Selects and categorises bank transactions into transaction types
-    Given I start the merits application with bank transactions with no transaction type category
+    Given I start the means application with bank transactions with no transaction type category
     Then I should be on the 'client_completed_means' page showing 'Your client has shared their financial information'
     Then I click 'Continue'
 
     Then I should be on the 'identify_types_of_income' page showing "Which of these payments does your client get?"
     Then I select 'Pension'
     And I select 'Financial help from friends or family'
+    And I select 'Benefits'
     And I click 'Save and continue'
 
     Then I should be on a page with title "Select payments your client receives in cash"
+    And I should see "Benefits"
+    And I should see "Financial help from friends or family"
+    And I should see "Pension"
     When I select 'My client receives none of these payments in cash'
     And I click 'Save and continue'
 
@@ -23,15 +27,18 @@ Feature: non_passported_journey with bank transactions
     And I click 'Save and continue'
 
     Then I should be on a page with title "Select payments your client pays in cash"
+    And I should see 'Housing'
     When I select 'None of the above'
     And I click 'Save and continue'
 
     Then I should be on the 'income_summary' page showing "Sort your client's income into categories"
     And the following sections should exist:
       | tag | section |
-      | h2  | 1. Financial help from friends or family |
-      | h2  | 2. Pension |
+      | h2  | 1. Benefits |
+      | h2  | 2. Financial help from friends or family |
+      | h2  | 3. Pension |
 
+    And I should not see "Disregarded benefits"
     And I should not see "Housing benefit"
 
     Then I click the first link 'View statements and add transactions'
@@ -39,15 +46,21 @@ Feature: non_passported_journey with bank transactions
     And I click 'Save and continue'
 
     Then I click the '2nd' link 'View statements and add transactions'
-    And I should see govuk-tag "Financial help"
+    And I should see govuk-tag "Benefits"
     Then I select the first checkbox
     And I click 'Save and continue'
 
     Then I click the '2nd' link 'View statements and add transactions'
+    And I should see govuk-tag "Benefits"
     And I should see govuk-tag "Financial help"
-    And I should see govuk-tag "Pension"
     Then I click 'Save and continue'
 
+    When I click 'Save and continue'
+    Then I should see govuk error summary "Add transactions to this category"
+
+    When I click the '3rd' link 'View statements and add transactions'
+    Then I select the first checkbox
+    Then I click 'Save and continue'
     Then I click 'Save and continue'
 
     Then I should be on the 'outgoings_summary' page showing "Sort your client's regular payments into categories"

--- a/features/providers/non_passported_journey/with_bank_transactions.feature
+++ b/features/providers/non_passported_journey/with_bank_transactions.feature
@@ -60,13 +60,36 @@ Feature: non_passported_journey with bank transactions
 
     When I click the '3rd' link 'View statements and add transactions'
     Then I select the first checkbox
-    Then I click 'Save and continue'
-    Then I click 'Save and continue'
+    And I click 'Save and continue'
 
+    When I click 'Save and continue'
     Then I should be on the 'outgoings_summary' page showing "Sort your client's regular payments into categories"
     Then I click the first link 'View statements and add transactions'
     Then I select the first checkbox
     And I click 'Save and continue'
 
-    Then I click 'Save and continue'
+    When I click 'Save and continue'
+    Then I should be on the 'housing_benefits' page showing "Does your client get Housing Benefit?"
+
+    When I choose 'Yes'
+    And I fill "providers-means-housing-benefit-form-housing-benefit-amount-field" with "101"
+    And I choose 'Every week'
+    And I click 'Save and continue'
     Then I should be on the 'has_dependants' page showing "Does your client have any dependants?"
+
+    When I choose 'No'
+    And I click 'Save and continue'
+    Then I should be on the 'check_income_answers' page showing "Check your answers"
+
+    And the following sections within "applicant" should exist:
+      | tag | section |
+      | h2  | Your client's income |
+      | h3  | Payments your client receives |
+      | h3  | Student finance |
+      | h2  | Your client's outgoings |
+      | h3  | Payments your client makes |
+
+    And the following sections should exist:
+      | tag | section |
+      | h3  | Housing Benefit |
+      | h2  | Dependants |

--- a/features/providers/non_passported_journey/with_means.feature
+++ b/features/providers/non_passported_journey/with_means.feature
@@ -57,6 +57,10 @@ Feature: non_passported_journey with means
     Then I should be on a page with title "Sort your client's regular payments into categories"
 
     When I click 'Save and continue'
+    Then I should be on the 'housing_benefits' page showing "Does your client get Housing Benefit?"
+
+    When I choose 'No'
+    And I click 'Save and continue'
     Then I should be on the 'has_dependants' page showing "Does your client have any dependants?"
 
     When I choose "No"

--- a/features/providers/partner_means_assessment/means_report.feature
+++ b/features/providers/partner_means_assessment/means_report.feature
@@ -113,10 +113,6 @@ Feature: Means report when partner is present
       | Dependants allowance |
       | Total deductions |
 
-    And the Deductions questions should not exist:
-      | question |
-      | Income from benefits excluded from calculation |
-
     And the Caseworker review section should contain:
       | question | answer |
       | Caseworker review required? | Yes |

--- a/features/providers/review_and_print.feature
+++ b/features/providers/review_and_print.feature
@@ -86,7 +86,6 @@ Feature: Review and print your application
     And the "Income, regular payments and assets" review section should contain:
       | question |
       | Benefits total |
-      | Disregarded benefits total |
       | Financial help from friends or family total |
       | Maintenance payments from a former partner total |
       | Income from a property or lodger total |

--- a/features/step_definitions/check_your_answers_steps.rb
+++ b/features/step_definitions/check_your_answers_steps.rb
@@ -100,7 +100,7 @@ def expect_matching_questions_and_answers(actual_selector:, expected_table:)
   expected = expected_table.hashes.map(&:symbolize_keys)
   actual = actual_questions_and_answers_in(selector: actual_selector)
 
-  expect(actual).to match_array(expected)
+  expect(actual).to match_array(expected), SuperDiff.diff(expected, actual)
 end
 
 def actual_questions_and_answers_in(selector:)

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -280,13 +280,13 @@ Given("I start the means application") do
   )
 end
 
-Given("I start the merits application with bank transactions with no transaction type category") do
+Given("I start the means application with bank transactions with no transaction type category") do
   @legal_aid_application = create(
     :application,
     :with_applicant,
     :with_proceedings,
     :with_non_passported_state_machine,
-    :provider_entering_merits,
+    :provider_assessing_means,
     :with_transaction_period,
     :with_uncategorised_credit_transactions,
     :with_uncategorised_debit_transactions,

--- a/spec/helpers/means_report_helper_spec.rb
+++ b/spec/helpers/means_report_helper_spec.rb
@@ -9,36 +9,12 @@ RSpec.describe MeansReportHelper do
   end
 
   describe "#outgoings_detail_items" do
-    subject(:items) { outgoings_detail_items(legal_aid_application) }
+    subject(:items) { outgoings_detail_items }
 
     it_behaves_like "transaction type item list"
 
     it "has expected items" do
       expect(items.map(&:name)).to eq(%i[housing childcare maintenance_out legal_aid])
-    end
-
-    context "with housing item" do
-      subject(:housing_item) { items.first }
-
-      context "when an application is uploading_bank_statements?" do
-        before do
-          allow(legal_aid_application).to receive(:uploading_bank_statements?).and_return(true)
-        end
-
-        it "addendum matches expected text" do
-          expect(housing_item.addendum).to eq(" (any declared housing benefits have been deducted from this total)")
-        end
-      end
-
-      context "when an application is not uploading_bank_statements?" do
-        before do
-          allow(legal_aid_application).to receive(:uploading_bank_statements?).and_return(false)
-        end
-
-        it "addendum is nil" do
-          expect(housing_item.addendum).to be_nil
-        end
-      end
     end
   end
 
@@ -82,19 +58,17 @@ RSpec.describe MeansReportHelper do
 
     it_behaves_like "transaction type item list"
 
-    context "when application is not uploading_bank_statements?" do
-      before { allow(legal_aid_application).to receive(:uploading_bank_statements?).and_return(false) }
-
-      it "has expected items" do
-        expect(items.map(&:name)).to eql(%i[dependants_allowance disregarded_state_benefits])
-      end
+    it "has expected items" do
+      expect(items.map(&:name)).to eql(%i[dependants_allowance])
     end
 
-    context "when application is uploading_bank_statements?" do
-      before { allow(legal_aid_application).to receive(:uploading_bank_statements?).and_return(true) }
+    context "when application has partner with no contrary interest" do
+      before do
+        allow(applicant).to receive(:has_partner_with_no_contrary_interest?).and_return(true)
+      end
 
       it "has expected items" do
-        expect(items.map(&:name)).to eql(%i[dependants_allowance])
+        expect(items.map(&:name)).to eql(%i[dependants_allowance partner_allowance])
       end
     end
   end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -488,7 +488,7 @@ RSpec.describe LegalAidApplication do
       let(:legal_aid_application) { create(:legal_aid_application, applicant:, transaction_types: [transaction_type]) }
 
       context "with income transactions" do
-        let(:transaction_type) { create(:transaction_type, :credit, name: "salary") }
+        let(:transaction_type) { create(:transaction_type, :credit) }
 
         it "returns false" do
           create(:bank_transaction, :credit, transaction_type:, bank_account:)
@@ -510,7 +510,7 @@ RSpec.describe LegalAidApplication do
       let(:legal_aid_application) { create(:legal_aid_application, applicant:, transaction_types: [transaction_type]) }
 
       context "with income transactions" do
-        let(:transaction_type) { create(:transaction_type, :credit, name: "salary") }
+        let(:transaction_type) { create(:transaction_type, :credit) }
 
         it "returns true" do
           create(:bank_transaction, :credit, transaction_type: nil, bank_account:)

--- a/spec/models/transaction_type_spec.rb
+++ b/spec/models/transaction_type_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe TransactionType do
     describe "#child?" do
       context "when is a child" do
         it "returns true" do
-          expect(excluded_benefits.child?).to be true
+          expect(housing_benefit.child?).to be true
         end
       end
 
@@ -158,7 +158,7 @@ RSpec.describe TransactionType do
 
       context "when is a child" do
         it "returns parent" do
-          expect(excluded_benefits.parent_or_self).to eq benefits
+          expect(housing_benefit.parent_or_self).to eq benefits
         end
       end
     end
@@ -167,6 +167,7 @@ RSpec.describe TransactionType do
       context "when a disregarded benefit type" do
         it "returns true" do
           expect(excluded_benefits.disregarded_benefit?).to be true
+          expect(housing_benefit.disregarded_benefit?).to be true
         end
       end
 

--- a/spec/services/cfe_civil/component_list_spec.rb
+++ b/spec/services/cfe_civil/component_list_spec.rb
@@ -40,6 +40,7 @@ module CFECivil
             Components::OtherIncome,
             Components::IrregularIncomes,
             Components::Employments,
+            Components::RegularTransactions,
             Components::CashTransactions,
             Components::Partner,
           ])

--- a/spec/services/flow/steps/partner/cash_outgoings_step_spec.rb
+++ b/spec/services/flow/steps/partner/cash_outgoings_step_spec.rb
@@ -2,15 +2,6 @@ require "rails_helper"
 
 RSpec.describe Flow::Steps::Partner::CashOutgoingsStep, type: :request do
   let(:legal_aid_application) { create(:legal_aid_application) }
-  let(:applicant_housing_payments?) { true }
-  let(:partner_housing_payments?) { false }
-  let(:bank_statements?) { true }
-
-  before do
-    allow(legal_aid_application).to receive(:housing_payments_for?).with("Applicant").and_return(applicant_housing_payments?)
-    allow(legal_aid_application).to receive(:housing_payments_for?).with("Partner").and_return(partner_housing_payments?)
-    allow(legal_aid_application).to receive(:uploading_bank_statements?).and_return(bank_statements?)
-  end
 
   describe "#path" do
     subject { described_class.path.call(legal_aid_application) }
@@ -21,12 +12,27 @@ RSpec.describe Flow::Steps::Partner::CashOutgoingsStep, type: :request do
   describe "#forward" do
     subject { described_class.forward.call(legal_aid_application) }
 
-    context "when the applicant has housing payments and is uploading bank statements" do
+    before do
+      allow(legal_aid_application).to receive(:housing_payments_for?).with("Applicant").and_return(applicant_housing_payments?)
+      allow(legal_aid_application).to receive(:housing_payments_for?).with("Partner").and_return(partner_housing_payments?)
+    end
+
+    context "when only the applicant has housing payments" do
+      let(:applicant_housing_payments?) { true }
+      let(:partner_housing_payments?) { false }
+
       it { is_expected.to be :housing_benefits }
     end
 
-    context "when the partner has housing payments" do
+    context "when only the partner has housing payments" do
       let(:applicant_housing_payments?) { false }
+      let(:partner_housing_payments?) { true }
+
+      it { is_expected.to be :housing_benefits }
+    end
+
+    context "when both the applicant and partner have housing payments" do
+      let(:applicant_housing_payments?) { true }
       let(:partner_housing_payments?) { true }
 
       it { is_expected.to be :housing_benefits }
@@ -34,6 +40,7 @@ RSpec.describe Flow::Steps::Partner::CashOutgoingsStep, type: :request do
 
     context "when there are no housing payments" do
       let(:applicant_housing_payments?) { false }
+      let(:partner_housing_payments?) { false }
 
       it { is_expected.to be :has_dependants }
     end
@@ -42,12 +49,27 @@ RSpec.describe Flow::Steps::Partner::CashOutgoingsStep, type: :request do
   describe "#check_answers" do
     subject { described_class.check_answers.call(legal_aid_application) }
 
-    context "when the applicant has housing payments and is uploading bank statements" do
+    before do
+      allow(legal_aid_application).to receive(:housing_payments_for?).with("Applicant").and_return(applicant_housing_payments?)
+      allow(legal_aid_application).to receive(:housing_payments_for?).with("Partner").and_return(partner_housing_payments?)
+    end
+
+    context "when only the applicant has housing payments" do
+      let(:applicant_housing_payments?) { true }
+      let(:partner_housing_payments?) { false }
+
       it { is_expected.to be :housing_benefits }
     end
 
-    context "when the partner has housing payments" do
+    context "when only the partner has housing payments" do
       let(:applicant_housing_payments?) { false }
+      let(:partner_housing_payments?) { true }
+
+      it { is_expected.to be :housing_benefits }
+    end
+
+    context "when both the applicant and partner have housing payments" do
+      let(:applicant_housing_payments?) { true }
       let(:partner_housing_payments?) { true }
 
       it { is_expected.to be :housing_benefits }
@@ -55,6 +77,7 @@ RSpec.describe Flow::Steps::Partner::CashOutgoingsStep, type: :request do
 
     context "when there are no housing payments" do
       let(:applicant_housing_payments?) { false }
+      let(:partner_housing_payments?) { false }
 
       it { is_expected.to be :has_dependants }
     end

--- a/spec/services/flow/steps/provider_income/cash_outgoings_step_spec.rb
+++ b/spec/services/flow/steps/provider_income/cash_outgoings_step_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe Flow::Steps::ProviderIncome::CashOutgoingsStep, type: :request do
 
       before do
         allow(application).to receive(:housing_payments_for?).with("Applicant").and_return(true)
-        allow(application).to receive(:uploading_bank_statements?).and_return(true)
       end
 
       it { is_expected.to eq :housing_benefits }
@@ -49,7 +48,6 @@ RSpec.describe Flow::Steps::ProviderIncome::CashOutgoingsStep, type: :request do
 
       before do
         allow(application).to receive(:housing_payments_for?).with("Applicant").and_return(false)
-        allow(application).to receive(:uploading_bank_statements?).and_return(true)
       end
 
       it { is_expected.to eq :has_dependants }
@@ -62,7 +60,7 @@ RSpec.describe Flow::Steps::ProviderIncome::CashOutgoingsStep, type: :request do
     context "when uploading bank statements" do
       before { allow(application).to receive(:uploading_bank_statements?).and_return(true) }
 
-      context "when there are housing payments for applicant" do
+      context "with housing payments for applicant" do
         let(:applicant) { create(:applicant, has_partner: false) }
 
         before do
@@ -72,7 +70,7 @@ RSpec.describe Flow::Steps::ProviderIncome::CashOutgoingsStep, type: :request do
         it { is_expected.to eq :housing_benefits }
       end
 
-      context "when there are no housing payments for applicant" do
+      context "with no housing payments for applicant" do
         let(:applicant) { create(:applicant, has_partner: false) }
 
         before do

--- a/spec/services/flow/steps/provider_income/outgoings_summary_step_spec.rb
+++ b/spec/services/flow/steps/provider_income/outgoings_summary_step_spec.rb
@@ -18,14 +18,42 @@ RSpec.describe Flow::Steps::ProviderIncome::OutgoingsSummaryStep, type: :request
       it { is_expected.to eq :partner_about_financial_means }
     end
 
+    context "when there are housing payments for applicant" do
+      let(:applicant) { create(:applicant, has_partner: false) }
+
+      before do
+        allow(application).to receive(:housing_payments_for?).with("Applicant").and_return(true)
+      end
+
+      it { is_expected.to eq :housing_benefits }
+    end
+
     context "when none of those are true" do
       it { is_expected.to eq :has_dependants }
     end
   end
 
   describe "#check_answers" do
-    subject { described_class.check_answers }
+    subject { described_class.check_answers.call(application) }
 
-    it { is_expected.to eq :check_income_answers }
+    context "when there are housing payments for applicant" do
+      let(:applicant) { create(:applicant, has_partner: false) }
+
+      before do
+        allow(application).to receive(:housing_payments_for?).with("Applicant").and_return(true)
+      end
+
+      it { is_expected.to eq :housing_benefits }
+    end
+
+    context "when there are no housing payments for applicant" do
+      let(:applicant) { create(:applicant, has_partner: false) }
+
+      before do
+        allow(application).to receive(:housing_payments_for?).with("Applicant").and_return(false)
+      end
+
+      it { is_expected.to eq :check_income_answers }
+    end
   end
 end


### PR DESCRIPTION
## What
Remove ability to add disregarded benefits on open banking (truelayer) journey

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5335)

The BA has identified that the caseworkers do not find the addition of transactions pertaining to disregarded benefits, via the clients truelayer journey, helpful when assessing means. The option to add transactions that are “disregarded benefits” should therefore be removed.

- [X] check mid-flow and historical data consequences ok
_agreed with BA that we can ignore the impact on the few applications that will be impacted_
- [x] add housing benefits question to truelayer path
_this came out of discussion with BA. Existing system has a bug in this regard as HB needs to be discounted from housing payments to reach an actual housing payment amount. Further, since we are removing disregards we need to ask the provider for HB amounts and send the respetive value to CFE just as for the bank statement upload flow._

## Note on approach and impact
The disregarded benefits type, `excluded_benefits` was explicitly archived by setting its 
`archived_at` value. This means `excluded_benefits` transaction type continues
to exist but is not used. 

1. excluded_benefits transaction_type will exist but be inactive
2. tests will run with production like data in this respect
2. fresh UAT branches will have production like data in this respect

NOTE: Removing the transaction type from the NAMES constant was _not_ done
because it will cause tests and fresh UAT branches to NOT have the
excluded_benefits transaction type at all - i.e. non-production like data

Having excluded_benefits be inactive will make

- the option to selected disregarded benefits disappear from the
  transaction select page (/income_summary) - mid flow
- the disregarded benefits output to disappear from CYA means page (/check_income_answers) - mid flow
- the disregarded benefits output to disappear from review and print page (/review_and_print_application) - mid-flow
- the disregarded benefits output to disappear from submitted_applications review and print page (/submitted_application) - post submission
- means report has a deductions which may also need removing

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
