### PR TITLE
AP-5407: Add housing benefits into partner flow for outgoings

### DIFF
--- a/app/services/flow/steps/partner/cash_outgoings_step.rb
+++ b/app/services/flow/steps/partner/cash_outgoings_step.rb
@@ -4,20 +4,19 @@ module Flow
       CashOutgoingsStep = Step.new(
         path: ->(application) { Steps.urls.providers_legal_aid_application_partners_cash_outgoing_path(application) },
         forward: lambda do |application|
-                   # if the applicant did not use Truelayer and makes housing payments, or if the partner makes housing payments, then ask about housing benefit
-                   if (application.housing_payments_for?("Applicant") && application.uploading_bank_statements?) || application.housing_payments_for?("Partner")
-                     :housing_benefits
-                   else
-                     :has_dependants
-                   end
-                 end,
+          if (application.housing_payments_for?("Applicant") && application.uploading_bank_statements?) || application.housing_payments_for?("Partner")
+            :housing_benefits
+          else
+            :has_dependants
+          end
+        end,
         check_answers: lambda do |application|
-                         if (application.housing_payments_for?("Applicant") && application.uploading_bank_statements?) || application.housing_payments_for?("Partner")
-                           :housing_benefits
-                         else
-                           :has_dependants
-                         end
-                       end,
+          if (application.housing_payments_for?("Applicant") && application.uploading_bank_statements?) || application.housing_payments_for?("Partner")
+            :housing_benefits
+          else
+            :has_dependants
+          end
+        end,
       )
     end
   end

--- a/app/services/flow/steps/partner/regular_outgoings_step.rb
+++ b/app/services/flow/steps/partner/regular_outgoings_step.rb
@@ -6,6 +6,8 @@ module Flow
         forward: lambda do |application|
           if application.partner_outgoing_types?
             :partner_cash_outgoings
+          elsif (application.housing_payments_for?("Applicant") && application.uploading_bank_statements?) || application.housing_payments_for?("Partner")
+            :housing_benefits
           else
             :has_dependants
           end
@@ -13,6 +15,8 @@ module Flow
         check_answers: lambda do |application|
           if application.partner_outgoing_types?
             :partner_cash_outgoings
+          elsif (application.housing_payments_for?("Applicant") && application.uploading_bank_statements?) || application.housing_payments_for?("Partner")
+            :housing_benefits
           else
             :check_income_answers
           end


### PR DESCRIPTION
## What
Add housing benefits into partner flow for outgoings (if client has housing payments)

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5407)

This was missing because if client has housing payments and
partner has no outgoings it was not considering whether
client had them and jumping straight to next "section" (has_dependants).


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
