### PR TITLE
Fix: Add on delete cascade to benefit_check_result fk

### DIFF
--- a/db/migrate/20241018070508_alter_foreign_key_on_benefit_check_result.rb
+++ b/db/migrate/20241018070508_alter_foreign_key_on_benefit_check_result.rb
@@ -1,0 +1,6 @@
+class AlterForeignKeyOnBenefitCheckResult < ActiveRecord::Migration[7.2]
+  def change
+    remove_foreign_key :benefit_check_results, :legal_aid_applications
+    add_foreign_key :benefit_check_results, :legal_aid_applications, on_delete: :cascade, validate: false
+  end
+end

--- a/db/migrate/20241018071246_validate_foreign_key_on_benefit_check_result.rb
+++ b/db/migrate/20241018071246_validate_foreign_key_on_benefit_check_result.rb
@@ -1,0 +1,5 @@
+class ValidateForeignKeyOnBenefitCheckResult < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :benefit_check_results, :legal_aid_applications
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_01_081701) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_18_071246) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -1102,7 +1102,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_01_081701) do
   add_foreign_key "bank_errors", "applicants"
   add_foreign_key "bank_providers", "applicants"
   add_foreign_key "bank_transactions", "bank_accounts"
-  add_foreign_key "benefit_check_results", "legal_aid_applications"
+  add_foreign_key "benefit_check_results", "legal_aid_applications", on_delete: :cascade
   add_foreign_key "ccms_submission_documents", "ccms_submissions", column: "submission_id"
   add_foreign_key "ccms_submission_histories", "ccms_submissions", column: "submission_id"
   add_foreign_key "ccms_submissions", "legal_aid_applications", on_delete: :cascade


### PR DESCRIPTION
## What
Add on delete cascade to benefit_check_result foreign key constraint

Was causing a database error when purging the application

```
ActiveRecord::InvalidForeignKey: PG::ForeignKeyViolation: ERROR:  update or delete on table "legal_aid_applications" violates foreign key constraint "fk_rails_d026359e92" on table "benefit_check_results" (ActiveRecord::InvalidForeignKey)
DETAIL:  Key (id)=(4166cd72-5ae3-4c30-ac85-69f7694fc73c) is still referenced from table "benefit_check_results".
```
## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
