### PR TITLE
AP-5404: Improve document naming

### DIFF
--- a/app/services/ccms/requestors/document_id_requestor.rb
+++ b/app/services/ccms/requestors/document_id_requestor.rb
@@ -35,6 +35,7 @@ module CCMS
         document_category = DocumentCategory.find_by(name: @document_type)
         if document_category.present?
           xml.__send__(:"casebio:DocumentType", document_category.ccms_document_type)
+          xml.__send__(:"casebio:Text", document_category.description)
         else
           xml.__send__(:"casebio:DocumentType", "ADMIN1")
         end

--- a/app/services/ccms/requestors/document_id_requestor.rb
+++ b/app/services/ccms/requestors/document_id_requestor.rb
@@ -32,19 +32,9 @@ module CCMS
       end
 
       def document_type(xml)
-        case @document_type
-        when "bank_statement_evidence_pdf", "part_bank_state_evidence_pdf", "bank_transaction_report"
-          xml.__send__(:"casebio:DocumentType", "BSTMT")
-        when "client_employment_evidence_pdf", "part_employ_evidence_pdf", "employment_evidence_pdf"
-          xml.__send__(:"casebio:DocumentType", "PAYSLIP")
-        when "court_order_pdf", "court_application_or_order_pdf", "court_application_pdf"
-          xml.__send__(:"casebio:DocumentType", "COURT_ORD")
-        when "expert_report_pdf", "gateway_evidence_pdf"
-          xml.__send__(:"casebio:DocumentType", "EX_RPT")
-        when "benefit_evidence_pdf"
-          xml.__send__(:"casebio:DocumentType", "BEN_LTR")
-        when "statement_of_case_pdf"
-          xml.__send__(:"casebio:DocumentType", "STATE")
+        document_category = DocumentCategory.find_by(name: @document_type)
+        if document_category.present?
+          xml.__send__(:"casebio:DocumentType", document_category.ccms_document_type)
         else
           xml.__send__(:"casebio:DocumentType", "ADMIN1")
         end

--- a/app/services/ccms/requestors/document_upload_requestor.rb
+++ b/app/services/ccms/requestors/document_upload_requestor.rb
@@ -41,28 +41,11 @@ module CCMS
       end
 
       def document_type(xml)
-        case @document_type
-        when "bank_transaction_report"
-          xml.__send__(:"casebio:DocumentType", "BSTMT")
-          xml.__send__(:"casebio:FileExtension", "csv")
-        when "bank_statement_evidence_pdf", "part_bank_state_evidence_pdf"
-          xml.__send__(:"casebio:DocumentType", "BSTMT")
-          xml.__send__(:"casebio:FileExtension", "pdf")
-        when "client_employment_evidence_pdf", "part_employ_evidence_pdf", "employment_evidence_pdf"
-          xml.__send__(:"casebio:DocumentType", "PAYSLIP")
-          xml.__send__(:"casebio:FileExtension", "pdf")
-        when "court_order_pdf", "court_application_or_order_pdf", "court_application_pdf"
-          xml.__send__(:"casebio:DocumentType", "COURT_ORD")
-          xml.__send__(:"casebio:FileExtension", "pdf")
-        when "expert_report_pdf", "gateway_evidence_pdf"
-          xml.__send__(:"casebio:DocumentType", "EX_RPT")
-          xml.__send__(:"casebio:FileExtension", "pdf")
-        when "benefit_evidence_pdf"
-          xml.__send__(:"casebio:DocumentType", "BEN_LTR")
-          xml.__send__(:"casebio:FileExtension", "pdf")
-        when "statement_of_case_pdf"
-          xml.__send__(:"casebio:DocumentType", "STATE")
-          xml.__send__(:"casebio:FileExtension", "pdf")
+        document_category = DocumentCategory.find_by(name: @document_type)
+        if document_category.present?
+          xml.__send__(:"casebio:DocumentType", document_category.ccms_document_type)
+          xml.__send__(:"casebio:FileExtension", document_category.file_extension)
+          xml.__send__(:"casebio:Text", document_category.description)
         else
           xml.__send__(:"casebio:DocumentType", "ADMIN1")
           xml.__send__(:"casebio:FileExtension", "pdf")

--- a/db/migrate/20241018081039_update_document_categories.rb
+++ b/db/migrate/20241018081039_update_document_categories.rb
@@ -1,0 +1,6 @@
+class UpdateDocumentCategories < ActiveRecord::Migration[7.2]
+  def change
+    add_column :document_categories, :file_extension, :string
+    add_column :document_categories, :description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_18_071246) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_18_081039) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -435,6 +435,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_18_071246) do
     t.boolean "mandatory", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "file_extension"
+    t.string "description"
   end
 
   create_table "domestic_abuse_summaries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/seeds/document_categories.csv
+++ b/db/seeds/document_categories.csv
@@ -1,28 +1,28 @@
-name,submit_to_ccms,ccms_document_type,display_on_evidence_upload,mandatory
-bank_transaction_report,TRUE,BSTMT,FALSE,FALSE
+name,submit_to_ccms,ccms_document_type,display_on_evidence_upload,mandatory,file_extension,description
+bank_transaction_report,TRUE,BSTMT,FALSE,FALSE,csv,Open Banking Report
 benefit_evidence,FALSE,,TRUE,TRUE
-benefit_evidence_pdf,TRUE,ADMIN1,FALSE,FALSE
+benefit_evidence_pdf,TRUE,BEN_LTR,FALSE,FALSE,pdf,Passporting Evidence
 client_employment_evidence,FALSE,,TRUE,TRUE
-client_employment_evidence_pdf,TRUE,ADMIN1,FALSE,FALSE
+client_employment_evidence_pdf,TRUE,PAYSLIP,FALSE,FALSE,pdf,Client Employment
 part_employ_evidence,FALSE,,TRUE,TRUE
-part_employ_evidence_pdf,TRUE,ADMIN1,FALSE,FALSE
+part_employ_evidence_pdf,TRUE,PAYSLIP,FALSE,FALSE,pdf,Partner Employment
 gateway_evidence,FALSE,,TRUE,FALSE
-gateway_evidence_pdf,TRUE,STATE,FALSE,FALSE
-means_report,TRUE,ADMIN1,FALSE,FALSE
-merits_report,TRUE,ADMIN1,FALSE,FALSE
+gateway_evidence_pdf,TRUE,EX_RPT,FALSE,FALSE,pdf,Gateway Evidence
+means_report,TRUE,REPORT,FALSE,FALSE,pdf,Means Report
+merits_report,TRUE,REPORT,FALSE,FALSE,pdf,Merits Report
 statement_of_case,FALSE,,FALSE,FALSE
-statement_of_case_pdf,TRUE,ADMIN1,FALSE,FALSE
+statement_of_case_pdf,TRUE,STATE,FALSE,FALSE,pdf,Statement of Case
 bank_statement_evidence,FALSE,,FALSE,FALSE
-bank_statement_evidence_pdf,TRUE,BSTMT,FALSE,FALSE
+bank_statement_evidence_pdf,TRUE,BSTMT,FALSE,FALSE,pdf,Client Statement
 court_application,FALSE,,TRUE,FALSE
-court_application_pdf,TRUE,ADMIN1,FALSE,FALSE
+court_application_pdf,TRUE,COURT_ORD,FALSE,FALSE,pdf,Court Application
 court_order,FALSE,,TRUE,TRUE
-court_order_pdf,TRUE,ADMIN1,FALSE,FALSE
+court_order_pdf,TRUE,COURT_ORD,FALSE,FALSE,pdf,Court Order
 expert_report,FALSE,,TRUE,FALSE
-expert_report_pdf,TRUE,ADMIN1,FALSE,FALSE
+expert_report_pdf,TRUE,EX_RPT,FALSE,FALSE,pdf,Expert Report
 court_application_or_order,FALSE,,TRUE,TRUE
-court_application_or_order_pdf,TRUE,ADMIN1,FALSE,FALSE
+court_application_or_order_pdf,TRUE,COURT_ORD,FALSE,FALSE,pdf,Court Order or Application
 part_bank_state_evidence,FALSE,,FALSE,FALSE
-part_bank_state_evidence_pdf,TRUE,BSTMT,FALSE,FALSE
+part_bank_state_evidence_pdf,TRUE,BSTMT,FALSE,FALSE,pdf,Partner Statement
 parental_responsibility,FALSE,,TRUE,TRUE
-parental_responsibility_pdf,TRUE,EX_RPT,FALSE,FALSE
+parental_responsibility_pdf,TRUE,COURT_ORD,FALSE,FALSE,pdf,PR Evidence

--- a/spec/services/ccms/requestors/document_id_requestor_spec.rb
+++ b/spec/services/ccms/requestors/document_id_requestor_spec.rb
@@ -22,9 +22,10 @@ module CCMS
             expect(requestor.formatted_xml).to be_soap_envelope_with(
               command: "casebim:DocumentUploadRQ",
               transaction_id: expected_tx_id,
-              matching: %w[
-                <casebio:DocumentType>REPORT</casebio:DocumentType>
-                <casebio:Channel>E</casebio:Channel>
+              matching: [
+                "<casebio:DocumentType>REPORT</casebio:DocumentType>",
+                "<casebio:Text>Means Report</casebio:Text>",
+                "<casebio:Channel>E</casebio:Channel>",
               ],
             )
           end
@@ -40,9 +41,10 @@ module CCMS
             expect(requestor.formatted_xml).to be_soap_envelope_with(
               command: "casebim:DocumentUploadRQ",
               transaction_id: expected_tx_id,
-              matching: %w[
-                <casebio:DocumentType>BSTMT</casebio:DocumentType>
-                <casebio:Channel>E</casebio:Channel>
+              matching: [
+                "<casebio:DocumentType>BSTMT</casebio:DocumentType>",
+                "<casebio:Text>Open Banking Report</casebio:Text>",
+                "<casebio:Channel>E</casebio:Channel>",
               ],
             )
           end
@@ -58,9 +60,10 @@ module CCMS
             expect(requestor.formatted_xml).to be_soap_envelope_with(
               command: "casebim:DocumentUploadRQ",
               transaction_id: expected_tx_id,
-              matching: %w[
-                <casebio:DocumentType>BSTMT</casebio:DocumentType>
-                <casebio:Channel>E</casebio:Channel>
+              matching: [
+                "<casebio:DocumentType>BSTMT</casebio:DocumentType>",
+                "<casebio:Text>Client Statement</casebio:Text>",
+                "<casebio:Channel>E</casebio:Channel>",
               ],
             )
           end
@@ -76,9 +79,10 @@ module CCMS
             expect(requestor.formatted_xml).to be_soap_envelope_with(
               command: "casebim:DocumentUploadRQ",
               transaction_id: expected_tx_id,
-              matching: %w[
-                <casebio:DocumentType>EX_RPT</casebio:DocumentType>
-                <casebio:Channel>E</casebio:Channel>
+              matching: [
+                "<casebio:DocumentType>EX_RPT</casebio:DocumentType>",
+                "<casebio:Text>Gateway Evidence</casebio:Text>",
+                "<casebio:Channel>E</casebio:Channel>",
               ],
             )
           end
@@ -94,9 +98,10 @@ module CCMS
             expect(requestor.formatted_xml).to be_soap_envelope_with(
               command: "casebim:DocumentUploadRQ",
               transaction_id: expected_tx_id,
-              matching: %w[
-                <casebio:DocumentType>PAYSLIP</casebio:DocumentType>
-                <casebio:Channel>E</casebio:Channel>
+              matching: [
+                "<casebio:DocumentType>PAYSLIP</casebio:DocumentType>",
+                "<casebio:Text>Client Employment</casebio:Text>",
+                "<casebio:Channel>E</casebio:Channel>",
               ],
             )
           end
@@ -112,9 +117,10 @@ module CCMS
             expect(requestor.formatted_xml).to be_soap_envelope_with(
               command: "casebim:DocumentUploadRQ",
               transaction_id: expected_tx_id,
-              matching: %w[
-                <casebio:DocumentType>COURT_ORD</casebio:DocumentType>
-                <casebio:Channel>E</casebio:Channel>
+              matching: [
+                "<casebio:DocumentType>COURT_ORD</casebio:DocumentType>",
+                "<casebio:Text>Court Order or Application</casebio:Text>",
+                "<casebio:Channel>E</casebio:Channel>",
               ],
             )
           end
@@ -130,9 +136,10 @@ module CCMS
             expect(requestor.formatted_xml).to be_soap_envelope_with(
               command: "casebim:DocumentUploadRQ",
               transaction_id: expected_tx_id,
-              matching: %w[
-                <casebio:DocumentType>BEN_LTR</casebio:DocumentType>
-                <casebio:Channel>E</casebio:Channel>
+              matching: [
+                "<casebio:DocumentType>BEN_LTR</casebio:DocumentType>",
+                "<casebio:Text>Passporting Evidence</casebio:Text>",
+                "<casebio:Channel>E</casebio:Channel>",
               ],
             )
           end

--- a/spec/services/ccms/requestors/document_id_requestor_spec.rb
+++ b/spec/services/ccms/requestors/document_id_requestor_spec.rb
@@ -9,6 +9,8 @@ module CCMS
       let(:requestor) { described_class.new(case_ccms_reference, "my_login", type) }
       let(:type) { "means_report" }
 
+      before { DocumentCategoryPopulator.call }
+
       describe "XML request" do
         context "when the attachment is a means report" do
           let(:type) { "means_report" }
@@ -21,7 +23,7 @@ module CCMS
               command: "casebim:DocumentUploadRQ",
               transaction_id: expected_tx_id,
               matching: %w[
-                <casebio:DocumentType>ADMIN1</casebio:DocumentType>
+                <casebio:DocumentType>REPORT</casebio:DocumentType>
                 <casebio:Channel>E</casebio:Channel>
               ],
             )
@@ -130,6 +132,24 @@ module CCMS
               transaction_id: expected_tx_id,
               matching: %w[
                 <casebio:DocumentType>BEN_LTR</casebio:DocumentType>
+                <casebio:Channel>E</casebio:Channel>
+              ],
+            )
+          end
+        end
+
+        context "when sent a legacy document" do
+          let(:type) { "employment_evidence_pdf" }
+
+          include_context "with ccms soa configuration"
+
+          it "generates the expected XML" do
+            allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
+            expect(requestor.formatted_xml).to be_soap_envelope_with(
+              command: "casebim:DocumentUploadRQ",
+              transaction_id: expected_tx_id,
+              matching: %w[
+                <casebio:DocumentType>ADMIN1</casebio:DocumentType>
                 <casebio:Channel>E</casebio:Channel>
               ],
             )

--- a/spec/services/ccms/requestors/document_upload_requestor_spec.rb
+++ b/spec/services/ccms/requestors/document_upload_requestor_spec.rb
@@ -10,6 +10,8 @@ module CCMS
       let(:document_encoded_base64) { "JVBERi0xLjUNCiW1tbW1DQoxIDAgb2JqDQo8PC9UeXBlL0NhdGFsb2cvUGFnZXMgMiA" }
       let(:requestor) { described_class.new(case_ccms_reference, document_id, document_encoded_base64, "my_login") }
 
+      before { DocumentCategoryPopulator.call }
+
       describe "XML request" do
         context "when sent a normal document" do
           include_context "with ccms soa configuration"
@@ -37,9 +39,10 @@ module CCMS
             expect(requestor.formatted_xml).to be_soap_envelope_with(
               command: "casebim:DocumentUploadRQ",
               transaction_id: expected_tx_id,
-              matching: %w[
-                <casebio:DocumentType>EX_RPT</casebio:DocumentType>
-                <casebio:FileExtension>pdf</casebio:FileExtension>
+              matching: [
+                "<casebio:DocumentType>EX_RPT</casebio:DocumentType>",
+                "<casebio:FileExtension>pdf</casebio:FileExtension>",
+                "<casebio:Text>Gateway Evidence</casebio:Text>",
               ],
             )
           end
@@ -55,9 +58,10 @@ module CCMS
             expect(requestor.formatted_xml).to be_soap_envelope_with(
               command: "casebim:DocumentUploadRQ",
               transaction_id: expected_tx_id,
-              matching: %w[
-                <casebio:DocumentType>BSTMT</casebio:DocumentType>
-                <casebio:FileExtension>csv</casebio:FileExtension>
+              matching: [
+                "<casebio:DocumentType>BSTMT</casebio:DocumentType>",
+                "<casebio:FileExtension>csv</casebio:FileExtension>",
+                "<casebio:Text>Open Banking Report</casebio:Text>",
               ],
             )
           end
@@ -73,9 +77,10 @@ module CCMS
             expect(requestor.formatted_xml).to be_soap_envelope_with(
               command: "casebim:DocumentUploadRQ",
               transaction_id: expected_tx_id,
-              matching: %w[
-                <casebio:DocumentType>BSTMT</casebio:DocumentType>
-                <casebio:FileExtension>pdf</casebio:FileExtension>
+              matching: [
+                "<casebio:DocumentType>BSTMT</casebio:DocumentType>",
+                "<casebio:FileExtension>pdf</casebio:FileExtension>",
+                "<casebio:Text>Client Statement</casebio:Text>",
               ],
             )
           end
@@ -91,9 +96,10 @@ module CCMS
             expect(requestor.formatted_xml).to be_soap_envelope_with(
               command: "casebim:DocumentUploadRQ",
               transaction_id: expected_tx_id,
-              matching: %w[
-                <casebio:DocumentType>BSTMT</casebio:DocumentType>
-                <casebio:FileExtension>pdf</casebio:FileExtension>
+              matching: [
+                "<casebio:DocumentType>BSTMT</casebio:DocumentType>",
+                "<casebio:FileExtension>pdf</casebio:FileExtension>",
+                "<casebio:Text>Partner Statement</casebio:Text>",
               ],
             )
           end
@@ -109,9 +115,10 @@ module CCMS
             expect(requestor.formatted_xml).to be_soap_envelope_with(
               command: "casebim:DocumentUploadRQ",
               transaction_id: expected_tx_id,
-              matching: %w[
-                <casebio:DocumentType>PAYSLIP</casebio:DocumentType>
-                <casebio:FileExtension>pdf</casebio:FileExtension>
+              matching: [
+                "<casebio:DocumentType>PAYSLIP</casebio:DocumentType>",
+                "<casebio:FileExtension>pdf</casebio:FileExtension>",
+                "<casebio:Text>Client Employment</casebio:Text>",
               ],
             )
           end
@@ -127,9 +134,10 @@ module CCMS
             expect(requestor.formatted_xml).to be_soap_envelope_with(
               command: "casebim:DocumentUploadRQ",
               transaction_id: expected_tx_id,
-              matching: %w[
-                <casebio:DocumentType>COURT_ORD</casebio:DocumentType>
-                <casebio:FileExtension>pdf</casebio:FileExtension>
+              matching: [
+                "<casebio:DocumentType>COURT_ORD</casebio:DocumentType>",
+                "<casebio:FileExtension>pdf</casebio:FileExtension>",
+                "<casebio:Text>Court Order or Application</casebio:Text>",
               ],
             )
           end
@@ -145,9 +153,10 @@ module CCMS
             expect(requestor.formatted_xml).to be_soap_envelope_with(
               command: "casebim:DocumentUploadRQ",
               transaction_id: expected_tx_id,
-              matching: %w[
-                <casebio:DocumentType>BEN_LTR</casebio:DocumentType>
-                <casebio:FileExtension>pdf</casebio:FileExtension>
+              matching: [
+                "<casebio:DocumentType>BEN_LTR</casebio:DocumentType>",
+                "<casebio:FileExtension>pdf</casebio:FileExtension>",
+                "<casebio:Text>Passporting Evidence</casebio:Text>",
               ],
             )
           end
@@ -163,8 +172,27 @@ module CCMS
             expect(requestor.formatted_xml).to be_soap_envelope_with(
               command: "casebim:DocumentUploadRQ",
               transaction_id: expected_tx_id,
+              matching: [
+                "<casebio:DocumentType>STATE</casebio:DocumentType>",
+                "<casebio:FileExtension>pdf</casebio:FileExtension>",
+                "<casebio:Text>Statement of Case</casebio:Text>",
+              ],
+            )
+          end
+        end
+
+        context "when sent a legacy document" do
+          let(:type) { "employment_evidence_pdf" }
+
+          include_context "with ccms soa configuration"
+
+          it "generates the expected XML" do
+            allow(requestor).to receive(:transaction_request_id).and_return(expected_tx_id)
+            expect(requestor.formatted_xml).to be_soap_envelope_with(
+              command: "casebim:DocumentUploadRQ",
+              transaction_id: expected_tx_id,
               matching: %w[
-                <casebio:DocumentType>STATE</casebio:DocumentType>
+                <casebio:DocumentType>ADMIN1</casebio:DocumentType>
                 <casebio:FileExtension>pdf</casebio:FileExtension>
               ],
             )

--- a/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
+++ b/spec/services/ccms/submitters/obtain_document_id_service_spec.rb
@@ -135,16 +135,18 @@ module CCMS
               )
             end
 
-            it "creates two documents as ADMIN1, one as STATE, one as BSTMT, and one as EX_RPT" do
+            it "creates two documents as REPORT, one as STATE, one as BSTMT, and one as EX_RPT and no ADMIN1 files any more" do
               instance.call
               admin1_documents = SubmissionHistory.where(submission_id: submission.id).map(&:request).map { |x| x.scan("ADMIN1") }.flatten.count
+              report_documents = SubmissionHistory.where(submission_id: submission.id).map(&:request).map { |x| x.scan("REPORT") }.flatten.count
               state_documents = SubmissionHistory.where(submission_id: submission.id).map(&:request).map { |x| x.scan("STATE") }.flatten.count
               bstmt_documents = SubmissionHistory.where(submission_id: submission.id).map(&:request).map { |x| x.scan("BSTMT") }.flatten.count
               expert_documents = SubmissionHistory.where(submission_id: submission.id).map(&:request).map { |x| x.scan("EX_RPT") }.flatten.count
-              expect(admin1_documents).to eq 2
               expect(state_documents).to eq 1
               expect(bstmt_documents).to eq 1
               expect(expert_documents).to eq 1
+              expect(report_documents).to eq 2
+              expect(admin1_documents).to eq 0
             end
 
             it "writes the response body to the history record" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5404)

## Improve document upload values for caseworkers

* Update the database to handle the file extension and free-text fields
* Update the seed data to ensure it matches the new document types and includes file extensions and additional text values
* Updates the DocumentIdRequestor and DocumentUploadRequestor classes to call the values in the database with fallbacks to ADMIN1 and default file extension if an unknown or legacy document type is presented

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
