### PR TITLE
Disable digest export on UAT

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -2,6 +2,7 @@ SimpleCov.start "rails" do
   add_filter "config/"
   add_filter "spec/"
   add_filter "services/migration_helpers/"
+  add_filter "lib/tasks/"
 
   add_filter "lib/tasks/helpers/cfe_api_displayer.rb"
   add_filter "lib/tasks/helpers/cfe_payload_recorder.rb"

--- a/lib/tasks/digest.rake
+++ b/lib/tasks/digest.rake
@@ -1,17 +1,23 @@
 namespace :digest do
   desc "Run DigestExtractor to update application digests"
   task extract: :environment do
+    next if HostEnv.uat?
+
     DigestExtractor.call
   end
 
   desc "Run DigestExporter to export digest records to google sheet"
   task export: :environment do
+    next if HostEnv.uat?
+
     DigestExporter.call
   end
 
   namespace :extraction_date do
     desc "Reset the last_extracted date so that all application_digest records are refreshed"
     task reset: :environment do
+      next if HostEnv.uat?
+
       Setting.setting.update!(digest_extracted_at: 20.years.ago)
     end
   end

--- a/spec/lib/tasks/digest_spec.rb
+++ b/spec/lib/tasks/digest_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe "digest:", type: :task do
+  before do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+    allow(HostEnv).to receive(:uat?).and_return(false)
+  end
+
+  describe "extract" do
+    subject(:task) { Rake::Task["digest:extract"] }
+
+    before do
+      allow(DigestExtractor).to receive(:call).and_return(nil)
+    end
+
+    it "calls the service" do
+      task.execute
+      expect(DigestExtractor).to have_received(:call)
+    end
+
+    context "when host env is uat" do
+      before { allow(HostEnv).to receive(:uat?).and_return(true) }
+
+      it "does not the service" do
+        task.execute
+        expect(DigestExtractor).not_to have_received(:call)
+      end
+    end
+  end
+
+  describe "export" do
+    subject(:task) { Rake::Task["digest:export"] }
+
+    before do
+      allow(DigestExporter).to receive(:call).and_return(nil)
+    end
+
+    it "calls the service" do
+      task.execute
+      expect(DigestExporter).to have_received(:call)
+    end
+
+    context "when host env is uat" do
+      before { allow(HostEnv).to receive(:uat?).and_return(true) }
+
+      it "does not call the service" do
+        task.execute
+        expect(DigestExporter).not_to have_received(:call)
+      end
+    end
+  end
+
+  describe "extraction_date:reset" do
+    subject(:task) { Rake::Task["digest:extraction_date:reset"] }
+
+    let(:setting) { instance_double(Setting) }
+
+    before do
+      allow(Setting).to receive(:setting).and_return(setting)
+      allow(setting).to receive(:update!)
+    end
+
+    it "calls the service" do
+      task.execute
+      expect(setting).to have_received(:update!)
+    end
+
+    context "when host env is uat" do
+      before { allow(HostEnv).to receive(:uat?).and_return(true) }
+
+      it "does not call the service" do
+        task.execute
+        expect(setting).not_to have_received(:update!)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What
Disable digest extract, export and reset on UAT

It just causes a lot of failed pods which eat up quotas.

This is to prevent the regular failures that branches
on UAT get which create pods that eat up our pod quota
and distract devs unnecessarily.

We can remove if we are want to actually change and test
on a branch.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
