### PR TITLE
ap-5080: Do not alert apply team if citizen_start_email is undeliverable

### DIFF
--- a/app/services/govuk_emails/monitor.rb
+++ b/app/services/govuk_emails/monitor.rb
@@ -28,9 +28,9 @@ module GovukEmails
     def send_undeliverable_alerts
       return unless HostEnv.production?
 
-      AlertManager.capture_message("Unable to deliver mail to #{scheduled_mail.addressee} - ScheduledMailing record #{scheduled_mail.id}")
+      AlertManager.capture_message("Unable to deliver mail to #{scheduled_mail.addressee} - ScheduledMailing record #{scheduled_mail.id}") unless @scheduled_mail.mailer_method == "citizen_start_email"
 
-      send_undeliverable_alert_to_apply_team!
+      send_undeliverable_alert_to_apply_team! unless @scheduled_mail.mailer_method == "citizen_start_email"
       send_undeliverable_citizen_start_email_to_provider!
     end
 

--- a/app/services/govuk_emails/monitor.rb
+++ b/app/services/govuk_emails/monitor.rb
@@ -28,9 +28,9 @@ module GovukEmails
     def send_undeliverable_alerts
       return unless HostEnv.production?
 
-      AlertManager.capture_message("Unable to deliver mail to #{scheduled_mail.addressee} - ScheduledMailing record #{scheduled_mail.id}") unless @scheduled_mail.mailer_method == "citizen_start_email"
+      AlertManager.capture_message("Unable to deliver mail to #{scheduled_mail.addressee} - ScheduledMailing record #{scheduled_mail.id}") unless citizen_start_email?
 
-      send_undeliverable_alert_to_apply_team! unless @scheduled_mail.mailer_method == "citizen_start_email"
+      send_undeliverable_alert_to_apply_team! unless citizen_start_email?
       send_undeliverable_citizen_start_email_to_provider!
     end
 
@@ -75,6 +75,10 @@ module GovukEmails
 
     def provider_email_or_support
       HostEnv.staging? ? Rails.configuration.x.support_email_address : provider.email
+    end
+
+    def citizen_start_email?
+      @scheduled_mail.mailer_method == "citizen_start_email"
     end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5080)

Turn off alerts and emails to apply team for undeliverable citizen_start emails only.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
