### PR TITLE
AP-5436: Stop redirecting to page that no longer exists

### DIFF
--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,1 +1,5 @@
+require "pagy/extras/overflow"
+
 Pagy::I18n.load(locale: "en", filepath: Rails.root.join("config/locales/en/pagy.yml"))
+
+Pagy::DEFAULT[:overflow] = :last_page

--- a/spec/requests/providers/legal_aid_applications_spec.rb
+++ b/spec/requests/providers/legal_aid_applications_spec.rb
@@ -109,6 +109,15 @@ RSpec.describe "providers legal aid application requests" do
           end
         end
 
+        context "and navigating to a page that doesn't exist" do
+          let(:params) { { page: 12 } }
+
+          it "successfully redirects to page that exists" do
+            get_request
+            expect(response).to have_http_status(:ok)
+          end
+        end
+
         context "when an application has been discarded" do
           before { create(:legal_aid_application, :discarded, provider:) }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5436)

If e.g 11 applications exist, and there are 10 on each page, when the 11th is deleted, the application tried to redirect to page 2. Address this so it always redirects to page 1

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
