### PR TITLE
AP-5394: Update SCA review and print

### DIFF
--- a/app/models/concerns/delegated_functions.rb
+++ b/app/models/concerns/delegated_functions.rb
@@ -3,6 +3,10 @@ module DelegatedFunctions
     proceedings.any?(&:used_delegated_functions?)
   end
 
+  def non_sca_used_delegated_functions?
+    used_delegated_functions? && !special_children_act_proceedings?
+  end
+
   def used_delegated_functions_on
     earliest_delegated_functions_date
   end

--- a/app/views/shared/check_answers/_client_details.html.erb
+++ b/app/views/shared/check_answers/_client_details.html.erb
@@ -180,7 +180,7 @@
     <% end %>
   <% end %>
 
-  <% if :email.in?(attributes) %>
+  <% if :email.in?(attributes) && applicant.email.present? %>
     <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__email" }) do |row| %>
       <%= row.with_key(text: t(".email"), classes: "govuk-!-width-one-half") %>
       <%= row.with_value(text: applicant.email) %>

--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -33,6 +33,6 @@
 <%= render("shared/check_answers/supporting_evidence", read_only:) %>
 
 <!--This is to prevent the separate representation section from showing up anywhere other than the merits report -->
-<% if @legal_aid_application.summary_state.to_s == 'submitted' && @legal_aid_application.special_children_act_proceedings? %>
+<% if controller_name == 'merits_reports' && @legal_aid_application.special_children_act_proceedings? %>
   <%= render("shared/check_answers/separate_representation") %>
 <% end %>

--- a/app/views/shared/check_answers/_proceeding_details_section.html.erb
+++ b/app/views/shared/check_answers/_proceeding_details_section.html.erb
@@ -10,13 +10,15 @@
         <%= row.with_key(text: t(".delegated_functions"), classes: "govuk-!-width-one-half") %>
         <%= row.with_value { proceeding.used_delegated_functions_on&.strftime("%-d %B %Y") } %>
       <% end %>
-      <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__emergency_level_of_service-#{index}" }) do |row| %>
-        <%= row.with_key(text: t(".emergency_level_of_service"), classes: "govuk-!-width-one-half") %>
-        <%= row.with_value { proceeding.emergency_level_of_service_name } %>
-      <% end %>
-      <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__emergency_scope_limits-#{index}" }) do |row| %>
-        <%= row.with_key(text: t(".emergency_scope_limits"), classes: "govuk-!-width-one-half") %>
-        <%= row.with_value { scope_limits(proceeding, "emergency") } %>
+      <% if @legal_aid_application.non_sca_used_delegated_functions? %>
+        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__emergency_level_of_service-#{index}" }) do |row| %>
+          <%= row.with_key(text: t(".emergency_level_of_service"), classes: "govuk-!-width-one-half") %>
+          <%= row.with_value { proceeding.emergency_level_of_service_name } %>
+        <% end %>
+        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__emergency_scope_limits-#{index}" }) do |row| %>
+          <%= row.with_key(text: t(".emergency_scope_limits"), classes: "govuk-!-width-one-half") %>
+          <%= row.with_value { scope_limits(proceeding, "emergency") } %>
+        <% end %>
       <% end %>
     <% end %>
     <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__substantive_level_of_service-#{index}" }) do |row| %>

--- a/app/views/shared/review_application/_questions_and_answers.html.erb
+++ b/app/views/shared/review_application/_questions_and_answers.html.erb
@@ -48,7 +48,7 @@
     <%= render("shared/check_answers/proceeding_details_section") %>
   </section>
 
-  <% if @legal_aid_application.used_delegated_functions? %>
+  <% if @legal_aid_application.non_sca_used_delegated_functions? %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-heading-m"><%= t ".emergency_cost_limit" %></h2>

--- a/features/providers/review_and_print.feature
+++ b/features/providers/review_and_print.feature
@@ -182,4 +182,24 @@ Feature: Review and print your application
       | h3  | Regular payments |
       | h2  | Your client's capital |
 
+  Scenario: For a backdated SCA journey
+    Given I have completed a backdated special children act journey
+    When I view the review and print your application page
 
+    Then the following sections should exist:
+      | tag | section |
+      | h1  | Review and print your application |
+      | h2  | Client details |
+      | h2  | What you're applying for |
+      | h2  | Income, regular payments and assets |
+      | h2  | Case details |
+      | h1  | Print your application |
+
+    And I should see 'Delegated functions'
+    And I should not see 'Email address'
+    And I should not see 'Emergency level of service'
+    And I should not see 'Emergency scope limits'
+
+    And the following sections should not exist:
+      | tag | section |
+      | h2  | Emergency cost limit |

--- a/features/step_definitions/review_and_print_steps.rb
+++ b/features/step_definitions/review_and_print_steps.rb
@@ -200,6 +200,26 @@ Given("I have completed a non-means tested journey with merits") do
   login_as @legal_aid_application.provider
 end
 
+Given("I have completed a backdated special children act journey") do
+  @legal_aid_application = create(
+    :legal_aid_application,
+    :with_applicant_and_address,
+    :with_non_means_tested_state_machine, # needs updating to SCA state machine when available
+    :with_merits_statement_of_case,
+    :with_opponent,
+    :with_proceedings,
+    :with_delegated_functions_on_proceedings,
+    explicit_proceedings: %i[pb059],
+    set_lead_proceeding: :pb059,
+    df_options: { PB059: [10.days.ago.to_date, 1.day.ago.to_date] },
+  )
+
+  @legal_aid_application.applicant.update!(email: nil)
+  create :legal_framework_merits_task_list, :pb059_with_no_tasks, legal_aid_application: @legal_aid_application
+
+  login_as @legal_aid_application.provider
+end
+
 When("I view the review and print your application page") do
   visit(providers_legal_aid_application_review_and_print_application_path(@legal_aid_application))
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5394)

Update the review_and_print and submitted_application pages:
* hide the email row from client if it is empty
* hide the emergency level of service and scope limits for SCA DF applications
* hide the Emergency cost limit block for SCA DF applications
* hide the separate representation block on the submitted_application page too.  It will _only_appear on the merits_report now 


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
