### PR TITLE
AP-5395: Update SCA means_tested display on Means Report

### DIFF
--- a/app/helpers/client_helper.rb
+++ b/app/helpers/client_helper.rb
@@ -1,0 +1,8 @@
+module ClientHelper
+  def means_tested?(legal_aid_application)
+    return "No, SCA application" if legal_aid_application.special_children_act_proceedings?
+    return "No, client under 18" if legal_aid_application.applicant.under_18?
+
+    "Yes"
+  end
+end

--- a/app/views/shared/check_answers/_client_details.html.erb
+++ b/app/views/shared/check_answers/_client_details.html.erb
@@ -71,7 +71,7 @@
   <% if :means_test.in?(attributes) %>
     <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__means_test" }) do |row| %>
       <%= row.with_key(text: t(".means_tested"), classes: "govuk-!-width-one-half") %>
-      <%= row.with_value(text: yes_no(!@legal_aid_application.non_means_tested?)) %>
+      <%= row.with_value(text: means_tested?(@legal_aid_application)) %>
     <% end %>
   <% end %>
 

--- a/spec/helpers/client_helper_spec.rb
+++ b/spec/helpers/client_helper_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe ClientHelper do
+  let(:legal_aid_application) { build_stubbed(:legal_aid_application, applicant:) }
+  let(:applicant) { build_stubbed(:applicant) }
+
+  describe "means_tested?" do
+    subject(:means_tested) { means_tested?(legal_aid_application) }
+
+    context "when the client is means tested" do
+      it { is_expected.to eql("Yes") }
+    end
+
+    context "when the client is not means tested because they are under 18" do
+      before { allow(applicant).to receive(:under_18?).and_return(true) }
+
+      it { is_expected.to eql("No, client under 18") }
+    end
+
+    context "when the client is not means tested because they are under 18 and it's an SCA application" do
+      before do
+        allow(legal_aid_application).to receive(:special_children_act_proceedings?).and_return(true)
+        allow(applicant).to receive(:under_18?).and_return(true)
+      end
+
+      it { is_expected.to eql("No, SCA application") }
+    end
+
+    context "when the client is not means tested because it's an SCA application" do
+      before { allow(legal_aid_application).to receive(:special_children_act_proceedings?).and_return(true) }
+
+      it { is_expected.to eql("No, SCA application") }
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5395)

Create ClientHelper for means_tested display text and call it from the _client_details partial

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
