### PR TITLE
AP-5450: Working discretionary disregards form

### DIFF
--- a/app/controllers/providers/means/capital_disregards/discretionary_controller.rb
+++ b/app/controllers/providers/means/capital_disregards/discretionary_controller.rb
@@ -16,9 +16,10 @@ module Providers
       private
 
         def form_params
-          merge_with_model(legal_aid_application) do
-            params.require(:legal_aid_application).permit(discretionary_capital_disregards: []).merge(none_selected: params[:legal_aid_application][:none_selected])
-          end
+          params
+            .require(:providers_means_capital_disregards_discretionary_form)
+            .permit(:none_selected, discretionary_capital_disregards: [])
+            .merge(legal_aid_application:)
         end
       end
     end

--- a/app/views/providers/means/capital_disregards/discretionary/show.html.erb
+++ b/app/views/providers/means/capital_disregards/discretionary/show.html.erb
@@ -6,14 +6,21 @@
   <%= page_template page_title: t(".h1-heading"), template: :basic, form: do %>
     <h1 class="govuk-heading-xl"><%= page_title %></h1>
     <p><%= t(".details.#{individual}") %></p>
-    <%= form.govuk_check_boxes_fieldset :discretionary_disregards,
+    <%= form.govuk_check_boxes_fieldset :discretionary_capital_disregards,
                                         legend: { text: t(".h2-heading.#{individual}"), size: "l", tag: "h2" },
                                         form_group: { class: @form.errors.any? ? "govuk-form-group--error" : "" } do %>
       <div class="govuk-hint"><%= t(".hint") %></div>
       <div class="govuk-hint"><%= t("generic.select_all_that_apply") %></div>
-      <div class="deselect-group" data-deselect-ctrl="#legal-aid-application-none-selected-true-field">
-        <% Providers::Means::CapitalDisregards::DiscretionaryForm::DISREGARD_TYPES.each do |disregard_type| %>
-          <%= form.govuk_check_box :discretionary_capital_disregards, disregard_type, link_errors: true, label: { text: t(".#{disregard_type}") }, hint: { text: t(".#{disregard_type}_hint", default: "") } %>
+
+      <div class="deselect-group" data-deselect-ctrl="#providers-means-capital-disregards-discretionary-form-none-selected-true-field">
+        <% Providers::Means::CapitalDisregards::DiscretionaryForm::DISREGARD_TYPES.each_with_index do |disregard_type, index| %>
+          <%= form.govuk_check_box(
+                :discretionary_capital_disregards,
+                disregard_type.to_s,
+                link_errors: index.zero?,
+                label: { text: t(".#{disregard_type}") },
+                hint: { text: t(".#{disregard_type}_hint", default: "") },
+              ) %>
         <% end %>
       </div>
 

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -651,8 +651,9 @@ en:
           attributes:
             base:
               none_selected: Select if your client has received any of these payments
-              none_selected_with_partner: Select which schemes or trusts have paid either your client or their partner, or select 'None of these payments'
+              none_selected_with_partner: Select if your client or their partner has received any of these payments
               none_and_another_option_selected: Your client must either receive one or more of these payments or none
+              none_and_another_option_selected_with_partner: Your client or their partner must either receive one or more of these payments or none
         proceeding:
           attributes:
             client_involvement_type_ccms_code:

--- a/features/providers/mtr_accelerated/discretionary_capital_disregards.feature
+++ b/features/providers/mtr_accelerated/discretionary_capital_disregards.feature
@@ -1,0 +1,95 @@
+Feature: Discretionary capital disregards question and flow
+# TODO: This flow file can be moved to a full flow non-passported journey feature after the MTR-A feature flag is removed
+
+  @javascript
+  Scenario: When the MTR-A feature flag is off I should not see the discretionary capital disregard question in the flow
+    Given the feature flag for means_test_review_a is disabled
+    And I have completed a non-passported non-employed application for "applicant" with bank statements as far as the end of the means income section
+    Then I should be on the "check_income_answers" page showing "Check your answers"
+
+    When I click "Save and continue"
+    Then I should be on a page with title "What you need to do"
+
+    When I click "Continue"
+    Then I should be on a page with title "Does your client own the home that they live in?"
+    And I choose 'No'
+
+    When I click "Save and continue"
+    Then I should be on a page with title "Does your client own a vehicle?"
+    And I choose 'No'
+
+    When I click "Save and continue"
+    Then I should be on a page with title "Which bank accounts does your client have?"
+    And I select "None of these"
+
+    When I click "Save and continue"
+    Then I should be on a page with title "Which savings or investments does your client have?"
+    And I select "None of these savings or investments"
+
+    When I click "Save and continue"
+    Then I should be on a page with title "Which assets does your client have?"
+    And I select "None of these assets"
+
+    When I click "Save and continue"
+    Then I should be on a page with title "Which schemes or trusts have paid your client?"
+    And I select "None of these schemes or trusts"
+
+    When I click "Save and continue"
+    Then I should be on the "check_capital_answers" page showing "Check your answers"
+
+  @javascript
+  Scenario: When the MTR-A feature flag is on I should see the discretionary capital disregard question in the flow
+    Given the feature flag for means_test_review_a is enabled
+    And I have completed a non-passported non-employed application for "applicant" with bank statements as far as the end of the means income section
+    Then I should be on the "check_income_answers" page showing "Check your answers"
+
+    When I click "Save and continue"
+    Then I should be on a page with title "What you need to do"
+
+    When I click "Continue"
+    Then I should be on a page with title "Does your client own the home they usually live in?"
+    And I choose 'No'
+
+    When I click "Save and continue"
+    Then I should be on a page with title "Does your client own a vehicle?"
+    And I choose 'No'
+
+    When I click "Save and continue"
+    Then I should be on a page with title "Which bank accounts does your client have?"
+    And I select "None of these"
+
+    When I click "Save and continue"
+    Then I should be on a page with title "Which savings or investments does your client have?"
+    And I select "None of these savings or investments"
+
+    When I click "Save and continue"
+    Then I should be on a page with title "Which assets does your client have?"
+    And I select "None of these assets"
+
+    When I click "Save and continue"
+    Then I should be on a page with title "Which schemes or trusts have paid your client?"
+    And I select "None of these schemes or trusts"
+
+    When I click "Save and continue"
+    Then I should be on a page with title "Payments to be reviewed"
+    And I should see "Select if your client has received any of these payments"
+    And the following sections should exist:
+      | tag | section |
+      | .govuk-checkboxes__label  | Backdated benefits and child maintenance payments received more than 24 months ago |
+      | .govuk-checkboxes__label  | Compensation, damages or ex-gratia payments for personal harm |
+      | .govuk-checkboxes__label  | Criminal Injuries Compensation Scheme payment |
+      | .govuk-checkboxes__label  | Grenfell Tower fire victims payment |
+      | .govuk-checkboxes__label  | London Emergencies Trust payment |
+      | .govuk-checkboxes__label  | National Emergencies Trust (NET) payment |
+      | .govuk-checkboxes__label  | Payments covering loss or harm related to proceedings in this application |
+      | .govuk-checkboxes__label  | Victims of Overseas Terrorism Compensation Scheme (VOTCS) 2012 payment |
+      | .govuk-checkboxes__label  | We Love Manchester Emergency Fund payment |
+    And I select "London Emergencies Trust payment"
+
+    When I click "Save and continue"
+    Then I should be on the "check_capital_answers" page showing "Check your answers"
+
+    When I click link "Back"
+    Then I should be on a page with title "Payments to be reviewed"
+    And the checkbox for Grenfell Tower fire victims payment should be unchecked
+    And the checkbox for London Emergencies Trust payment should be checked

--- a/spec/factories/applicants.rb
+++ b/spec/factories/applicants.rb
@@ -115,6 +115,11 @@ FactoryBot.define do
       has_partner { true }
     end
 
+    trait :with_partner_with_no_contrary_interest do
+      has_partner { true }
+      partner_has_contrary_interest { false }
+    end
+
     trait :no_nino do
       national_insurance_number { nil }
       has_national_insurance_number { false }

--- a/spec/requests/providers/means/capital_disregards/discretionary_controller_spec.rb
+++ b/spec/requests/providers/means/capital_disregards/discretionary_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Providers::Means::CapitalDisregards::DiscretionaryController do
     let(:discretionary_capital_disregards) { %w[backdated_benefits national_emergencies_trust] }
     let(:params) do
       {
-        legal_aid_application: {
+        providers_means_capital_disregards_discretionary_form: {
           discretionary_capital_disregards:,
           none_selected:,
         },
@@ -69,7 +69,7 @@ RSpec.describe Providers::Means::CapitalDisregards::DiscretionaryController do
 
         context "with nothing" do
           let(:none_selected) { "true" }
-          let(:discretionary_capital_disregards) { nil }
+          let(:discretionary_capital_disregards) { [] }
 
           context "with 'none of these' checkbox selected" do
             it "redirects to the next page" do


### PR DESCRIPTION
## What
Implement working discretionary disregards form for saving and displaying existing data.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5450)

The form as it previously existed was not reflecting selecting
disregards, synchronising of records (without a full delete).

Have used a separate pattern more similar to regular income/outgoings
because was seeing odd behaviour using the base form which does not
work well with a `has_many` relation per checkbox - it requires its own
intializer to handle its list of existing check box values, at least.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
