### PR TITLE
Fix deprecated call to erblint

### DIFF
--- a/lib/tasks/erblint.rake
+++ b/lib/tasks/erblint.rake
@@ -1,5 +1,5 @@
 desc "Run ERB lint"
 task erblint: :environment do
   path = "app/views app/components"
-  sh("erblint #{path}")
+  sh("erb_lint #{path}")
 end


### PR DESCRIPTION
## What
Fix deprecated call to erblint 

```
Calling `erblint` is deprecated, please call the renamed executable `erb_lint` instead.
```

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
