### PR TITLE
AP-5396: Update SCA merits report

### DIFF
--- a/app/components/reports/merits/delegated_functions_component.rb
+++ b/app/components/reports/merits/delegated_functions_component.rb
@@ -19,8 +19,8 @@ module Reports::Merits
 
     def row(key, value)
       {
-        key: { text: key },
-        value: { text: value, classes: "govuk-!-text-align-right" },
+        key: { text: key, classes: "govuk-!-width-one-half" },
+        value: { text: value },
       }
     end
 

--- a/app/views/providers/merits_reports/show.html.erb
+++ b/app/views/providers/merits_reports/show.html.erb
@@ -52,7 +52,7 @@
         ),
       ) %>
 
-  <% if @legal_aid_application.used_delegated_functions? %>
+  <% if @legal_aid_application.non_sca_used_delegated_functions? %>
     <h2 class="govuk-heading-m"><%= t ".emergency_cost_limit" %></h2>
 
     <%= render(

--- a/app/views/shared/check_answers/_merits_proceeding_section.html.erb
+++ b/app/views/shared/check_answers/_merits_proceeding_section.html.erb
@@ -101,38 +101,40 @@
       <%= render("shared/check_answers/relationship_to_child", proceeding:, relationship_to_child: proceeding.relationship_to_child, read_only:) %>
     <% end %>
 
-    <%= govuk_summary_list(actions: !read_only) do |summary_list| %>
-      <% if proceeding.vary_order %>
-        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{proceeding.id}_vary_order" }) do |row| %>
-          <%= row.with_key(text: t(".vary_order"), classes: "govuk-!-width-one-half") %>
-          <%= row.with_value(text: proceeding.vary_order.details) %>
-          <%= row.with_action(
-                text: t("generic.change"),
-                href: providers_merits_task_list_vary_order_path(proceeding),
-                visually_hidden_text: t(".vary_order"),
-              ) %>
+    <% unless proceeding.special_childrens_act? %>
+      <%= govuk_summary_list(actions: !read_only) do |summary_list| %>
+        <% if proceeding.vary_order %>
+          <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{proceeding.id}_vary_order" }) do |row| %>
+            <%= row.with_key(text: t(".vary_order"), classes: "govuk-!-width-one-half") %>
+            <%= row.with_value(text: proceeding.vary_order.details) %>
+            <%= row.with_action(
+                  text: t("generic.change"),
+                  href: providers_merits_task_list_vary_order_path(proceeding),
+                  visually_hidden_text: t(".vary_order"),
+                ) %>
+          <% end %>
         <% end %>
-      <% end %>
 
-      <% if proceeding.opponents_application %>
-        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{proceeding.id}_opponents_application" }) do |row| %>
-          <%= row.with_key(text: t(".opponents_application_question"), classes: "govuk-!-width-one-half") %>
-          <%= row.with_value(text: yes_no(proceeding.opponents_application.has_opponents_application)) %>
-          <%= row.with_action(
-                text: t("generic.change"),
-                href: providers_merits_task_list_opponents_application_path(proceeding),
-                visually_hidden_text: t(".opponents_application_question"),
-              ) %>
-        <% end %>
-        <% if proceeding.opponents_application.reason_for_applying %>
-          <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{proceeding.id}_opponents_application_reason" }) do |row| %>
-            <%= row.with_key(text: t(".opponents_application_reason"), classes: "govuk-!-width-one-half") %>
-            <%= row.with_value(text: proceeding.opponents_application.reason_for_applying) %>
+        <% if proceeding.opponents_application %>
+          <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{proceeding.id}_opponents_application" }) do |row| %>
+            <%= row.with_key(text: t(".opponents_application_question"), classes: "govuk-!-width-one-half") %>
+            <%= row.with_value(text: yes_no(proceeding.opponents_application.has_opponents_application)) %>
             <%= row.with_action(
                   text: t("generic.change"),
                   href: providers_merits_task_list_opponents_application_path(proceeding),
-                  visually_hidden_text: t(".opponents_application_reason"),
+                  visually_hidden_text: t(".opponents_application_question"),
                 ) %>
+          <% end %>
+          <% if proceeding.opponents_application.reason_for_applying %>
+            <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{proceeding.id}_opponents_application_reason" }) do |row| %>
+              <%= row.with_key(text: t(".opponents_application_reason"), classes: "govuk-!-width-one-half") %>
+              <%= row.with_value(text: proceeding.opponents_application.reason_for_applying) %>
+              <%= row.with_action(
+                    text: t("generic.change"),
+                    href: providers_merits_task_list_opponents_application_path(proceeding),
+                    visually_hidden_text: t(".opponents_application_reason"),
+                  ) %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/shared/check_answers/_separate_representation.html.erb
+++ b/app/views/shared/check_answers/_separate_representation.html.erb
@@ -1,5 +1,5 @@
 <% if @legal_aid_application.separate_representation_required %>
-  <section class="print-no-break">
+  <section class="print-no-break govuk-!-padding-top-6">
     <h2 class="govuk-heading-l"><%= t(".heading") %></h2>
 
     <%= govuk_summary_list(actions: false, classes: "govuk-!-margin-bottom-9") do |summary_list| %>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5396)

Update the merits report when handling SCA cases:
- Hide Emergency cost limit section for a backdated SCA application
- The delegated function section is now aligned to matchthe rest of the page
- The spacing above Separate representation has been corrected to match the other sections' spacing

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
