### PR TITLE
AP-5453: CYA truelayer transaction bug

### DIFF
--- a/app/controllers/providers/means/identify_types_of_incomes_controller.rb
+++ b/app/controllers/providers/means/identify_types_of_incomes_controller.rb
@@ -23,8 +23,8 @@ module Providers
     private
 
       def validate
-        legal_aid_application.errors.add :transaction_type_ids, error_message_for_none_and_another_option_selected if none_selected? && transaction_types_selected?
-        legal_aid_application.errors.add :transaction_type_ids, error_message_for_none_selected if [none_selected?, transaction_types_selected?].all?(false)
+        legal_aid_application.errors.add :applicant_transaction_type_ids, error_message_for_none_and_another_option_selected if none_selected? && transaction_types_selected?
+        legal_aid_application.errors.add :applicant_transaction_type_ids, error_message_for_none_selected if [none_selected?, transaction_types_selected?].all?(false)
       end
 
       def error_message_for_none_selected
@@ -38,14 +38,14 @@ module Providers
       def transaction_type_params
         params
           .require(:legal_aid_application)
-          .permit(:none_selected, transaction_type_ids: [])
+          .permit(:none_selected, applicant_transaction_type_ids: [])
       end
 
       def transaction_types
         @transaction_types ||= TransactionType
           .credits
           .without_housing_benefits
-          .with_children(ids: transaction_type_params[:transaction_type_ids])
+          .with_children(ids: transaction_type_params[:applicant_transaction_type_ids])
       end
 
       def transaction_types_selected?

--- a/app/controllers/providers/means/identify_types_of_outgoings_controller.rb
+++ b/app/controllers/providers/means/identify_types_of_outgoings_controller.rb
@@ -23,8 +23,8 @@ module Providers
     private
 
       def validate
-        legal_aid_application.errors.add :transaction_type_ids, error_message_for_none_and_another_option_selected if none_selected? && transaction_types_selected?
-        legal_aid_application.errors.add :transaction_type_ids, error_message_for_none_selected if [none_selected?, transaction_types_selected?].all?(false)
+        legal_aid_application.errors.add :applicant_transaction_type_ids, error_message_for_none_and_another_option_selected if none_selected? && transaction_types_selected?
+        legal_aid_application.errors.add :applicant_transaction_type_ids, error_message_for_none_selected if [none_selected?, transaction_types_selected?].all?(false)
       end
 
       def error_message_for_none_selected
@@ -36,11 +36,11 @@ module Providers
       end
 
       def legal_aid_application_params
-        params.require(:legal_aid_application).permit(transaction_type_ids: [])
+        params.require(:legal_aid_application).permit(applicant_transaction_type_ids: [])
       end
 
       def transaction_types
-        @transaction_types ||= TransactionType.debits.where(id: legal_aid_application_params[:transaction_type_ids])
+        @transaction_types ||= TransactionType.debits.where(id: legal_aid_application_params[:applicant_transaction_type_ids])
       end
 
       def transaction_types_selected?

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -245,6 +245,10 @@ class LegalAidApplication < ApplicationRecord
     legal_aid_application_transaction_types.where(owner_type:).map(&:transaction_type).pluck(:id)
   end
 
+  def applicant_transaction_type_ids
+    individual_transaction_type_ids("Applicant")
+  end
+
   def income_cash_transaction_types_for(owner_type)
     TransactionType.where(id: individual_transaction_type_ids(owner_type)).not_children.credits
   end

--- a/app/models/legal_aid_application_transaction_type.rb
+++ b/app/models/legal_aid_application_transaction_type.rb
@@ -20,6 +20,6 @@ private
     legal_aid_application
       .bank_transactions
       .where(transaction_type_id:)
-      .update!(transaction_type_id: nil)
+      .update!(transaction_type_id: nil, meta_data: nil)
   end
 end

--- a/app/services/flow/steps/provider_income/identify_types_of_income_step.rb
+++ b/app/services/flow/steps/provider_income/identify_types_of_income_step.rb
@@ -7,9 +7,7 @@ module Flow
           application.income_types? ? :cash_incomes : :student_finances
         end,
         check_answers: lambda do |application|
-          return :cash_incomes if application.income_types?
-
-          application.uploading_bank_statements? ? :check_income_answers : :income_summary
+          application.income_types? ? :cash_incomes : :check_income_answers
         end,
       )
     end

--- a/app/services/flow/steps/provider_income/identify_types_of_outgoings_step.rb
+++ b/app/services/flow/steps/provider_income/identify_types_of_outgoings_step.rb
@@ -15,9 +15,7 @@ module Flow
           end
         end,
         check_answers: lambda do |application|
-          return :cash_outgoings if application.outgoing_types?
-
-          application.uploading_bank_statements? ? :check_income_answers : :outgoings_summary
+          application.outgoing_types? ? :cash_outgoings : :check_income_answers
         end,
       )
     end

--- a/app/views/providers/means/identify_types_of_incomes/show.html.erb
+++ b/app/views/providers/means/identify_types_of_incomes/show.html.erb
@@ -15,7 +15,7 @@
       <div class="deselect-group govuk-!-padding-bottom-1" data-deselect-ctrl="#legal-aid-application-none-selected-true-field">
         <% TransactionType.credits.not_children.each_with_index do |transaction_type, index| %>
           <%= form.govuk_check_box(
-                :transaction_type_ids,
+                :applicant_transaction_type_ids,
                 transaction_type.id,
                 link_errors: index.zero?,
                 label: { text: t("transaction_types.names.providers.#{transaction_type.name}") },

--- a/app/views/providers/means/identify_types_of_outgoings/show.html.erb
+++ b/app/views/providers/means/identify_types_of_outgoings/show.html.erb
@@ -14,7 +14,7 @@
       <div class="deselect-group govuk-!-padding-bottom-1" data-deselect-ctrl="#legal-aid-application-none-selected-true-field">
         <% TransactionType.debits.each_with_index do |transaction_type, index| %>
           <%= form.govuk_check_box(
-                :transaction_type_ids,
+                :applicant_transaction_type_ids,
                 transaction_type.id,
                 link_errors: index.zero?,
                 label: { text: t("transaction_types.names.providers.#{transaction_type.name}") },

--- a/features/providers/regressions/client_truelayer_partner_bank_statements_check_means_answer.feature
+++ b/features/providers/regressions/client_truelayer_partner_bank_statements_check_means_answer.feature
@@ -34,6 +34,13 @@ Feature: Bank statement upload check your answers
     And the checkbox for Maintenance payments from a former partner should be unchecked
 
   @javascript
+  Scenario: Viewing client outgoings
+    When I click Check Your Answers Change link for "payments your client makes"
+    Then I should be on a page with title "Which of these payments does your client pay?"
+    And the checkbox for Childcare payments should be checked
+    And the checkbox for Maintenance payments to a former partner should be unchecked
+
+  @javascript
   Scenario: Viewing partner payments
     When I click Check Your Answers Change link for "payments the partner receives"
     Then I should be on the "regular_incomes" page showing "Which of these payments does the partner get?"

--- a/features/providers/regressions/client_truelayer_partner_bank_statements_check_means_answer.feature
+++ b/features/providers/regressions/client_truelayer_partner_bank_statements_check_means_answer.feature
@@ -1,0 +1,31 @@
+Feature: Bank statement upload check your answers
+  @javascript
+  Scenario: For a non-passported client truelayer with bank transactions and partner uploaded bank statements journey
+    Given csrf is enabled
+    And I am logged in as a provider
+    And csrf is enabled
+    And an applicant named Ida Paisley with a partner has completed their true layer interactions
+    And the client has a transaction named "babysitting" categorised as "Financial help from friends or family"
+    And the partner has a how much how many payment categorised as "Maintenance payments from a former partner"
+
+    When I visit the check income answers page
+    And the "Payments your client receives" section's questions and answers should match:
+      | question | answer |
+      | Benefits, charitable or government payments | None |
+      | Financial help from friends or family | £44.00 |
+      | Maintenance payments from a former partner | None |
+      | Income from a property or lodger | None |
+      | Pension | None |
+
+    And the "Payments the partner receives" section's questions and answers should match:
+      | question | answer |
+      | Benefits, charitable or government payments | None |
+      | Financial help from friends or family | None |
+      | Maintenance payments from a former partner | £50.00\nEvery week |
+      | Income from a property or lodger | None |
+      | Pension | None |
+
+    When I click Check Your Answers Change link for "payments your client receives"
+    Then I should be on a page with title "Which of these payments does your client get?"
+    And the checkbox for Financial help from friends or family should be checked
+    And the checkbox for Maintenance payments from a former partner should be unchecked

--- a/features/providers/regressions/client_truelayer_partner_bank_statements_check_means_answer.feature
+++ b/features/providers/regressions/client_truelayer_partner_bank_statements_check_means_answer.feature
@@ -1,6 +1,5 @@
 Feature: Bank statement upload check your answers
-  @javascript
-  Scenario: For a non-passported client truelayer with bank transactions and partner uploaded bank statements journey
+  Background:For a non-passported client truelayer with bank transactions and partner uploaded bank statements journey
     Given csrf is enabled
     And I am logged in as a provider
     And csrf is enabled
@@ -9,7 +8,7 @@ Feature: Bank statement upload check your answers
     And the partner has a how much how many payment categorised as "Maintenance payments from a former partner"
 
     When I visit the check income answers page
-    And the "Payments your client receives" section's questions and answers should match:
+    Then the "Payments your client receives" section's questions and answers should match:
       | question | answer |
       | Benefits, charitable or government payments | None |
       | Financial help from friends or family | £44.00 |
@@ -25,6 +24,8 @@ Feature: Bank statement upload check your answers
       | Income from a property or lodger | None |
       | Pension | None |
 
+  @javascript
+  Scenario: Viewing client payments
     When I click Check Your Answers Change link for "payments your client receives"
     Then I should be on a page with title "Which of these payments does your client get?"
     And the checkbox for Financial help from friends or family should be checked

--- a/features/providers/regressions/client_truelayer_partner_bank_statements_check_means_answer.feature
+++ b/features/providers/regressions/client_truelayer_partner_bank_statements_check_means_answer.feature
@@ -30,3 +30,46 @@ Feature: Bank statement upload check your answers
     Then I should be on a page with title "Which of these payments does your client get?"
     And the checkbox for Financial help from friends or family should be checked
     And the checkbox for Maintenance payments from a former partner should be unchecked
+
+  @javascript
+  Scenario: Viewing partner payments
+    When I click Check Your Answers Change link for "payments the partner receives"
+    Then I should be on the "regular_incomes" page showing "Which of these payments does the partner get?"
+    And the checkbox for Financial help from friends or family should be unchecked
+    And the checkbox for Maintenance payments from a former partner should be checked
+
+  @javascript
+  Scenario: De-selecting and re-selecting client payments
+    When I click Check Your Answers Change link for "payments your client receives"
+    Then I should be on a page with title "Which of these payments does your client get?"
+    And the checkbox for Financial help from friends or family should be checked
+
+    When I select "My client does not get any of these payments"
+    And I click "Save and continue"
+    Then I should be on a page with title "Check your answers"
+    And the "Payments your client receives" section's questions and answers should match:
+      | question | answer |
+      | Benefits, charitable or government payments | None |
+      | Financial help from friends or family | None |
+      | Maintenance payments from a former partner | None |
+      | Income from a property or lodger | None |
+      | Pension | None |
+
+    When I click Check Your Answers Change link for "payments your client receives"
+    Then I should be on a page with title "Which of these payments does your client get?"
+
+    When I select "Financial help from friends or family"
+    And I click "Save and continue"
+    Then I should be on the "cash_income" page showing "Select payments your client receives in cash"
+
+    When I select "My client receives none of these payments in cash"
+    And I click "Save and continue"
+    Then I should be on the "income_summary" page showing "Sort your client's income into categories"
+
+    When I click link "View statements and add transactions"
+    Then I should be on the "incoming_transactions/friends_or_family" page showing "Select payments from friends or family"
+
+    When I select "babysitting"
+    And I click "Save and continue"
+    Then I should be on the "income_summary" page showing "Sort your client's income into categories"
+    And I should see "babysitting"

--- a/features/providers/regressions/client_truelayer_partner_bank_statements_check_means_answer.feature
+++ b/features/providers/regressions/client_truelayer_partner_bank_statements_check_means_answer.feature
@@ -4,8 +4,10 @@ Feature: Bank statement upload check your answers
     And I am logged in as a provider
     And csrf is enabled
     And an applicant named Ida Paisley with a partner has completed their true layer interactions
-    And the client has a transaction named "babysitting" categorised as "Financial help from friends or family"
-    And the partner has a how much how many payment categorised as "Maintenance payments from a former partner"
+    And the client has a credit transaction named "babysitting" categorised as friends_or_family
+    And the client has a debit transaction named "after school club" categorised as child_care
+    And the partner has a how much how often payment categorised as maintenance_in
+    And the partner has a how much how often payment categorised as maintenance_out
 
     When I visit the check income answers page
     Then the "Payments your client receives" section's questions and answers should match:

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -392,7 +392,6 @@ Given("I start the means application and the applicant has uploaded transaction 
     :provider_assessing_means,
     :with_policy_disregards,
     :with_transaction_period,
-    :with_benefits_transactions,
     :with_cfe_v5_result,
     :with_proceedings,
     applicant: @applicant,

--- a/features/step_definitions/regression_steps.rb
+++ b/features/step_definitions/regression_steps.rb
@@ -1,0 +1,18 @@
+When("I visit the check income answers page") do
+  visit(providers_legal_aid_application_means_check_income_answers_path(@legal_aid_application))
+end
+
+When("the client has a transaction named {string} categorised as \"Financial help from friends or family\"") do |description|
+  bank_account = @legal_aid_application.applicant.bank_accounts.first
+  create(:bank_transaction, :credit, :friends_or_family, :manually_chosen, bank_account:, amount: 44, description:)
+  create(:legal_aid_application_transaction_type,
+         legal_aid_application: @legal_aid_application,
+         transaction_type: TransactionType.find_by(name: "friends_or_family"),
+         owner_type: "Applicant",
+         owner_id: @legal_aid_application.applicant)
+end
+
+When(/the partner has a how much how many payment categorised as "Maintenance payments from a former partner"/) do
+  @legal_aid_application.transaction_types << (TransactionType.find_by(name: "maintenance_in") || create(:transaction_type, :maintenance_in))
+  create(:regular_transaction, :maintenance_in, legal_aid_application: @legal_aid_application, amount: 50, frequency: "weekly", owner_id: @legal_aid_application.partner.id, owner_type: "Partner")
+end

--- a/features/step_definitions/regression_steps.rb
+++ b/features/step_definitions/regression_steps.rb
@@ -2,17 +2,19 @@ When("I visit the check income answers page") do
   visit(providers_legal_aid_application_means_check_income_answers_path(@legal_aid_application))
 end
 
-When("the client has a transaction named {string} categorised as \"Financial help from friends or family\"") do |description|
+When(/^the client has a (credit|debit) transaction named (.*) categorised as (.*)$/) do |type, description, category|
   bank_account = @legal_aid_application.applicant.bank_accounts.first
-  create(:bank_transaction, :credit, :friends_or_family, :manually_chosen, bank_account:, amount: 44, description:)
+  category.gsub!(/\s+/, "_")
+
+  create(:bank_transaction, type.to_sym, category.to_sym, :manually_chosen, bank_account:, amount: 44, description:)
   create(:legal_aid_application_transaction_type,
          legal_aid_application: @legal_aid_application,
-         transaction_type: TransactionType.find_by(name: "friends_or_family"),
+         transaction_type: TransactionType.find_by(name: category),
          owner_type: "Applicant",
          owner_id: @legal_aid_application.applicant)
 end
 
-When(/the partner has a how much how many payment categorised as "Maintenance payments from a former partner"/) do
-  @legal_aid_application.transaction_types << (TransactionType.find_by(name: "maintenance_in") || create(:transaction_type, :maintenance_in))
-  create(:regular_transaction, :maintenance_in, legal_aid_application: @legal_aid_application, amount: 50, frequency: "weekly", owner_id: @legal_aid_application.partner.id, owner_type: "Partner")
+When(/the partner has a how much how often payment categorised as (.*)/) do |category|
+  @legal_aid_application.transaction_types << (TransactionType.find_by(name: category) || create(:transaction_type, category.to_sym))
+  create(:regular_transaction, category.to_sym, legal_aid_application: @legal_aid_application, amount: 50, frequency: "weekly", owner_id: @legal_aid_application.partner.id, owner_type: "Partner")
 end

--- a/spec/models/legal_aid_application_transaction_type_spec.rb
+++ b/spec/models/legal_aid_application_transaction_type_spec.rb
@@ -103,12 +103,16 @@ RSpec.describe LegalAidApplicationTransactionType do
         bank_provider = create(:bank_provider, applicant: legal_aid_application.applicant)
         bank_account = create(:bank_account, bank_provider:)
 
-        create_list(:bank_transaction, 6, bank_account:, transaction_type: credit_transaction_type)
-        create_list(:bank_transaction, 3, bank_account:, transaction_type: debit_transaction_type)
+        create_list(:bank_transaction, 6, :manually_chosen, bank_account:, transaction_type: credit_transaction_type)
+        create_list(:bank_transaction, 3, :manually_chosen, bank_account:, transaction_type: debit_transaction_type)
       end
 
       context "when destroying object instance" do
         let(:action) { instance.destroy! }
+
+        it "removes meta-data from transactions" do
+          expect { action }.to change(legal_aid_application.bank_transactions.where(meta_data: nil), :count).by(6)
+        end
 
         it "removes associated bank transaction categorisation" do
           expect { action }.to change(legal_aid_application.bank_transactions.where(transaction_type: credit_transaction_type), :count).by(-6)

--- a/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
@@ -338,9 +338,9 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
             legal_aid_application.transaction_types.credits.destroy_all
           end
 
-          it "redirects to income_summary" do
+          it "redirects to next page in flow" do
             request
-            expect(response).to redirect_to(providers_legal_aid_application_income_summary_index_path(legal_aid_application))
+            expect(response).to have_http_status(:redirect)
           end
         end
 

--- a/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_incomes_controller_spec.rb
@@ -67,13 +67,13 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
     let(:params) do
       {
         legal_aid_application: {
-          transaction_type_ids:,
+          applicant_transaction_type_ids:,
         },
       }
     end
 
     context "when no transaction types selected" do
-      let(:transaction_type_ids) { [] }
+      let(:applicant_transaction_type_ids) { [] }
 
       it "does not add transaction types to the application" do
         expect { request }.not_to change(legal_aid_application.legal_aid_application_transaction_types, :count)
@@ -93,7 +93,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
     end
 
     context "when transaction types selected" do
-      let(:transaction_type_ids) { income_types.map(&:id) }
+      let(:applicant_transaction_type_ids) { income_types.map(&:id) }
 
       it "adds transaction types to the application" do
         expect { request }.to change(LegalAidApplicationTransactionType, :count).by(income_types.length)
@@ -116,7 +116,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
     end
 
     context "when application has transaction types of other kind" do
-      let(:transaction_type_ids) { [] }
+      let(:applicant_transaction_type_ids) { [] }
       let(:other_transaction_type) { create(:transaction_type, :debit) }
       let(:legal_aid_application) { create(:legal_aid_application, :with_applicant, transaction_types: [other_transaction_type]) }
 
@@ -130,7 +130,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
     end
 
     context "when no option has been chosen" do
-      let(:params) { { legal_aid_application: { transaction_type_ids: [] } } }
+      let(:params) { { legal_aid_application: { applicant_transaction_type_ids: [] } } }
 
       it "displays an error" do
         request
@@ -203,7 +203,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
         {
           legal_aid_application: {
             none_selected: "true",
-            transaction_type_ids: income_types.map(&:id),
+            applicant_transaction_type_ids: income_types.map(&:id),
           },
         }
       end
@@ -223,7 +223,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
     end
 
     context "when existing transaction types are deselected" do
-      let(:transaction_type_ids) { [friends_or_family_credit.id] }
+      let(:applicant_transaction_type_ids) { [friends_or_family_credit.id] }
 
       let(:benefits_credit) { create(:transaction_type, :benefits) }
       let(:friends_or_family_credit) { create(:transaction_type, :friends_or_family) }
@@ -267,7 +267,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
 
     context "when the wrong transaction type is passed in" do
       let!(:income_types) { create_list(:transaction_type, 3, :debit_with_standard_name) }
-      let(:transaction_type_ids) { income_types.map(&:id) }
+      let(:applicant_transaction_type_ids) { income_types.map(&:id) }
 
       it "does not add the transaction types" do
         expect { request }.not_to change { legal_aid_application.transaction_types.count }
@@ -275,7 +275,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
     end
 
     context "when benefits selected" do
-      let(:transaction_type_ids) { [benefits.id] }
+      let(:applicant_transaction_type_ids) { [benefits.id] }
       let(:benefits) { create(:transaction_type, :benefits) }
 
       before do
@@ -318,7 +318,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
         end
 
         context "with credit transaction types" do
-          let(:params) { { legal_aid_application: { transaction_type_ids: [create(:transaction_type, :credit).id] } } }
+          let(:params) { { legal_aid_application: { applicant_transaction_type_ids: [create(:transaction_type, :credit).id] } } }
 
           it "redirects to cash_incomes" do
             request
@@ -345,7 +345,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
         end
 
         context "with credit transaction types" do
-          let(:params) { { legal_aid_application: { transaction_type_ids: [create(:transaction_type, :credit).id] } } }
+          let(:params) { { legal_aid_application: { applicant_transaction_type_ids: [create(:transaction_type, :credit).id] } } }
 
           it "redirects to cash_incomes" do
             request
@@ -357,7 +357,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
 
     context "when the provider is not authenticated" do
       let(:login) { nil }
-      let(:transaction_type_ids) { [] }
+      let(:applicant_transaction_type_ids) { [] }
 
       before { request }
 
@@ -369,7 +369,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfIncomesController do
         {
           draft_button: "Save as draft",
           legal_aid_application: {
-            transaction_type_ids: [],
+            applicant_transaction_type_ids: [],
           },
         }
       end

--- a/spec/requests/providers/means/identify_types_of_outgoings_controller_spec.rb
+++ b/spec/requests/providers/means/identify_types_of_outgoings_controller_spec.rb
@@ -48,13 +48,13 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
     let(:params) do
       {
         legal_aid_application: {
-          transaction_type_ids:,
+          applicant_transaction_type_ids:,
         },
       }
     end
 
     context "when no transaction types selected" do
-      let(:transaction_type_ids) { [] }
+      let(:applicant_transaction_type_ids) { [] }
 
       it "does not add transaction types to the application" do
         expect { request }.not_to change(LegalAidApplicationTransactionType, :count)
@@ -74,7 +74,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
     end
 
     context "when transaction types selected" do
-      let(:transaction_type_ids) { outgoing_types.map(&:id) }
+      let(:applicant_transaction_type_ids) { outgoing_types.map(&:id) }
 
       it "adds transaction types to the application" do
         expect { request }.to change(LegalAidApplicationTransactionType, :count).by(outgoing_types.length)
@@ -109,7 +109,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
     end
 
     context "when application has transaction types of other kind" do
-      let(:transaction_type_ids) { [] }
+      let(:applicant_transaction_type_ids) { [] }
       let(:other_transaction_type) { create(:transaction_type, :credit) }
       let(:legal_aid_application) { create(:legal_aid_application, :with_applicant, :with_non_passported_state_machine, transaction_types: [other_transaction_type]) }
 
@@ -123,7 +123,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
     end
 
     context "when no option has been chosen" do
-      let(:params) { { legal_aid_application: { transaction_type_ids: [] } } }
+      let(:params) { { legal_aid_application: { applicant_transaction_type_ids: [] } } }
 
       it "displays an error" do
         request
@@ -255,7 +255,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
         {
           legal_aid_application: {
             none_selected: "true",
-            transaction_type_ids: outgoing_types.map(&:id),
+            applicant_transaction_type_ids: outgoing_types.map(&:id),
           },
         }
       end
@@ -275,7 +275,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
     end
 
     context "when the wrong transaction type is passed in" do
-      let(:transaction_type_ids) { income_types.map(&:id) }
+      let(:applicant_transaction_type_ids) { income_types.map(&:id) }
 
       it "does not add the transaction types" do
         expect { request }.not_to change { legal_aid_application.transaction_types.count }
@@ -310,7 +310,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
         end
 
         context "with debit transaction type" do
-          let(:params) { { legal_aid_application: { transaction_type_ids: [create(:transaction_type, :debit).id] } } }
+          let(:params) { { legal_aid_application: { applicant_transaction_type_ids: [create(:transaction_type, :debit).id] } } }
 
           it "redirects to the next step" do
             request
@@ -337,7 +337,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
         end
 
         context "with debit transaction types" do
-          let(:params) { { legal_aid_application: { transaction_type_ids: [create(:transaction_type, :debit).id] } } }
+          let(:params) { { legal_aid_application: { applicant_transaction_type_ids: [create(:transaction_type, :debit).id] } } }
 
           it "redirects to the next step" do
             request
@@ -349,7 +349,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
 
     context "when the provider is not authenticated" do
       let(:login) { nil }
-      let(:transaction_type_ids) { [] }
+      let(:applicant_transaction_type_ids) { [] }
 
       before { request }
 
@@ -357,7 +357,7 @@ RSpec.describe Providers::Means::IdentifyTypesOfOutgoingsController do
     end
 
     context "when form submitted with Save as draft button" do
-      let(:transaction_type_ids) { [] }
+      let(:applicant_transaction_type_ids) { [] }
       let(:submit_button) { { draft_button: "Save as draft" } }
 
       it "redirects to the list of applications" do

--- a/spec/services/flow/steps/provider_income/identify_types_of_income_step_spec.rb
+++ b/spec/services/flow/steps/provider_income/identify_types_of_income_step_spec.rb
@@ -34,16 +34,10 @@ RSpec.describe Flow::Steps::ProviderIncome::IdentifyTypesOfIncomeStep, type: :re
       it { is_expected.to eq :cash_incomes }
     end
 
-    context "when application has attached bank statement(s)" do
-      before { allow(legal_aid_application).to receive(:uploading_bank_statements?).and_return(true) }
+    context "when application has no income types" do
+      before { allow(legal_aid_application).to receive(:income_types?).and_return(false) }
 
       it { is_expected.to eq :check_income_answers }
-    end
-
-    context "when application does not have attached bank statement(s)" do
-      before { allow(legal_aid_application).to receive(:uploading_bank_statements?).and_return(false) }
-
-      it { is_expected.to eq :income_summary }
     end
   end
 end

--- a/spec/services/flow/steps/provider_income/identify_types_of_outgoings_step_spec.rb
+++ b/spec/services/flow/steps/provider_income/identify_types_of_outgoings_step_spec.rb
@@ -55,16 +55,10 @@ RSpec.describe Flow::Steps::ProviderIncome::IdentifyTypesOfOutgoingsStep, type: 
       it { is_expected.to eq :cash_outgoings }
     end
 
-    context "when application has attached bank statement(s)" do
-      before { allow(application).to receive(:uploading_bank_statements?).and_return(true) }
+    context "when application has no outgoing types" do
+      before { allow(application).to receive(:outgoing_types?).and_return(false) }
 
       it { is_expected.to eq :check_income_answers }
-    end
-
-    context "when application does not have attached bank statement(s)" do
-      before { allow(application).to receive(:uploading_bank_statements?).and_return(false) }
-
-      it { is_expected.to eq :outgoings_summary }
     end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5453)

This PR addresses a bug found while working on #7340 where a user returning to the Payments your client receives page from CYA would see payments that had been selected for a partner too

While resolving that, another bug was found where a payment that has been assigned to a category which was subsequently removed, cannot be re-assigned to a category (new or the previous one if re-enabled)

- Update checkbox selection on incoming truelayer, CYA path
- Update meta-data handling after incoming and outgoing checkboxes are cleared
- Update checkbox selection on outgoing truelayer, CYA path
- Update CYA routing when a provider selects no payments
- Update routing after the identify_* pages, there were routes that _could_ be reached that were weird!

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
