### PR TITLE
AP-5418: Update save as draft handling in the means pages

### DIFF
--- a/app/controllers/providers/means/receives_state_benefits_controller.rb
+++ b/app/controllers/providers/means/receives_state_benefits_controller.rb
@@ -7,12 +7,8 @@ module Providers
 
       def update
         @form = ReceivesStateBenefitsForm.new(form_params)
-        if @form.save
-          remove_state_benefits unless applicant.receives_state_benefits?
-          go_forward(applicant.receives_state_benefits?)
-        else
-          render :show
-        end
+        remove_state_benefits unless @form.receives_state_benefits?
+        render :show unless save_continue_or_draft(@form, receives_state_benefits: @form.receives_state_benefits?)
       end
 
     private

--- a/app/controllers/providers/means/student_finances_controller.rb
+++ b/app/controllers/providers/means/student_finances_controller.rb
@@ -8,13 +8,8 @@ module Providers
 
       def update
         @form = ::Applicants::StudentFinanceForm.new(student_finance_params)
-
-        if @form.save
-          remove_student_finance_amount unless student_finance?
-          go_forward unless save_continue_or_draft(@form)
-        else
-          render :show
-        end
+        remove_student_finance_amount unless @form.student_finance?
+        render :show unless save_continue_or_draft(@form)
       end
 
     private

--- a/app/controllers/providers/partners/receives_state_benefits_controller.rb
+++ b/app/controllers/providers/partners/receives_state_benefits_controller.rb
@@ -9,12 +9,8 @@ module Providers
 
       def update
         @form = ReceivesStateBenefitsForm.new(form_params)
-        if @form.save
-          remove_state_benefits unless partner.receives_state_benefits?
-          go_forward(partner.receives_state_benefits?)
-        else
-          render :show
-        end
+        remove_state_benefits unless @form.receives_state_benefits?
+        render :show unless save_continue_or_draft(@form, receives_state_benefits: @form.receives_state_benefits?)
       end
 
     private

--- a/app/controllers/providers/partners/student_finances_controller.rb
+++ b/app/controllers/providers/partners/student_finances_controller.rb
@@ -10,13 +10,8 @@ module Providers
 
       def update
         @form = ::Partners::StudentFinanceForm.new(student_finance_params)
-
-        if @form.save
-          remove_student_finance_amount unless student_finance?
-          go_forward unless save_continue_or_draft(@form)
-        else
-          render :show
-        end
+        remove_student_finance_amount unless @form.student_finance?
+        render :show unless save_continue_or_draft(@form)
       end
 
     private

--- a/app/forms/providers/means/receives_state_benefits_form.rb
+++ b/app/forms/providers/means/receives_state_benefits_form.rb
@@ -5,7 +5,11 @@ module Providers
 
       attr_accessor :receives_state_benefits
 
-      validates :receives_state_benefits, presence: true
+      validates :receives_state_benefits, presence: true, unless: :draft?
+
+      def receives_state_benefits?
+        receives_state_benefits.eql?("true")
+      end
     end
   end
 end

--- a/app/forms/providers/partners/receives_state_benefits_form.rb
+++ b/app/forms/providers/partners/receives_state_benefits_form.rb
@@ -5,7 +5,11 @@ module Providers
 
       attr_accessor :receives_state_benefits
 
-      validates :receives_state_benefits, presence: true
+      validates :receives_state_benefits, presence: true, unless: :draft?
+
+      def receives_state_benefits?
+        receives_state_benefits.eql?("true")
+      end
     end
   end
 end

--- a/app/forms/student_finances/base_student_finance_form.rb
+++ b/app/forms/student_finances/base_student_finance_form.rb
@@ -1,9 +1,7 @@
 module StudentFinances
   class BaseStudentFinanceForm < BaseForm
-    validates :student_finance, inclusion: { in: %w[true false] }
-    validates :student_finance_amount, currency: { greater_than_or_equal_to: 0 }, if: :student_finance?
-
-  private
+    validates :student_finance, inclusion: { in: %w[true false] }, unless: :draft?
+    validates :student_finance_amount, currency: { greater_than_or_equal_to: 0 }, if: :student_finance?, unless: :draft?
 
     def student_finance?
       student_finance.eql?("true")

--- a/app/services/flow/steps/partner/receives_state_benefits_step.rb
+++ b/app/services/flow/steps/partner/receives_state_benefits_step.rb
@@ -3,8 +3,8 @@ module Flow
     module Partner
       ReceivesStateBenefitsStep = Step.new(
         path: ->(application) { Steps.urls.providers_legal_aid_application_partners_receives_state_benefits_path(application) },
-        forward: lambda do |_application, receives_state_benefits|
-          receives_state_benefits ? :partner_state_benefits : :partner_regular_incomes
+        forward: lambda do |_application, options|
+          options[:receives_state_benefits] ? :partner_state_benefits : :partner_regular_incomes
         end,
         check_answers: lambda do |application|
           if application.partner.receives_state_benefits?

--- a/app/services/flow/steps/provider_means_state_benefits/receives_state_benefits_step.rb
+++ b/app/services/flow/steps/provider_means_state_benefits/receives_state_benefits_step.rb
@@ -3,8 +3,8 @@ module Flow
     module ProviderMeansStateBenefits
       ReceivesStateBenefitsStep = Step.new(
         path: ->(application) { Steps.urls.providers_legal_aid_application_means_receives_state_benefits_path(application) },
-        forward: lambda do |_application, receives_state_benefits|
-          receives_state_benefits ? :state_benefits : :regular_incomes
+        forward: lambda do |_application, options|
+          options[:receives_state_benefits] ? :state_benefits : :regular_incomes
         end,
         check_answers: lambda do |application|
           if application.applicant.receives_state_benefits?

--- a/app/views/shared/state_benefits/_new_benefit_form.erb
+++ b/app/views/shared/state_benefits/_new_benefit_form.erb
@@ -29,6 +29,6 @@
                                               ->(option) { t("transaction_types.frequencies.#{option}") },
                                               legend: { tag: "h2", size: "s", text: t(".benefits_frequency") } %>
     <% end %>
-    <%= next_action_buttons(show_draft: true, form:) %>
+    <%= next_action_buttons(show_draft: false, form:) %>
   <% end %>
 <% end %>

--- a/spec/requests/providers/means/receives_state_benefits_controller_spec.rb
+++ b/spec/requests/providers/means/receives_state_benefits_controller_spec.rb
@@ -99,6 +99,19 @@ RSpec.describe Providers::Means::ReceivesStateBenefitsController do
           end
         end
       end
+
+      context "when form submitted with Save as draft button" do
+        let(:params) do
+          {
+            applicant: { receives_state_benefits: "true" },
+            draft_button: "Save and come back later",
+          }
+        end
+
+        it "redirects to the list of applications" do
+          expect(response).to redirect_to submitted_providers_legal_aid_applications_path
+        end
+      end
     end
   end
 end

--- a/spec/requests/providers/means/student_finances_controller_spec.rb
+++ b/spec/requests/providers/means/student_finances_controller_spec.rb
@@ -158,5 +158,20 @@ RSpec.describe Providers::Means::StudentFinancesController do
 
       it_behaves_like "an authenticated provider from a different firm"
     end
+
+    context "when form submitted with Save as draft button" do
+      let(:params) do
+        {
+          applicant: { student_finance:, student_finance_amount: },
+          draft_button: "Save and come back later",
+        }
+      end
+
+      it "redirects to the list of applications" do
+        login_as provider
+        request
+        expect(response).to redirect_to submitted_providers_legal_aid_applications_path
+      end
+    end
   end
 end

--- a/spec/requests/providers/partners/receives_state_benefits_controller_spec.rb
+++ b/spec/requests/providers/partners/receives_state_benefits_controller_spec.rb
@@ -82,6 +82,19 @@ RSpec.describe Providers::Partners::ReceivesStateBenefitsController do
           expect(response).to have_http_status(:redirect)
         end
       end
+
+      context "when form submitted with Save as draft button" do
+        let(:params) do
+          {
+            partner: { receives_state_benefits: "true" },
+            draft_button: "Save and come back later",
+          }
+        end
+
+        it "redirects to the list of applications" do
+          expect(response).to redirect_to submitted_providers_legal_aid_applications_path
+        end
+      end
     end
   end
 end

--- a/spec/requests/providers/partners/student_finances_controller_spec.rb
+++ b/spec/requests/providers/partners/student_finances_controller_spec.rb
@@ -146,5 +146,20 @@ RSpec.describe Providers::Partners::StudentFinancesController do
 
       it_behaves_like "an authenticated provider from a different firm"
     end
+
+    context "when form submitted with Save as draft button" do
+      let(:params) do
+        {
+          partner: { student_finance:, student_finance_amount: },
+          draft_button: "Save and come back later",
+        }
+      end
+
+      it "redirects to the list of applications" do
+        login_as provider
+        request
+        expect(response).to redirect_to submitted_providers_legal_aid_applications_path
+      end
+    end
   end
 end

--- a/spec/services/flow/steps/partner/receives_state_benefits_step_spec.rb
+++ b/spec/services/flow/steps/partner/receives_state_benefits_step_spec.rb
@@ -10,16 +10,16 @@ RSpec.describe Flow::Steps::Partner::ReceivesStateBenefitsStep, type: :request d
   end
 
   describe "#forward" do
-    subject { described_class.forward.call(legal_aid_application, receives_state_benefits) }
+    subject { described_class.forward.call(legal_aid_application, options) }
 
     context "when receives_state_benefits is false" do
-      let(:receives_state_benefits) { false }
+      let(:options) { { receives_state_benefits: false } }
 
       it { is_expected.to eq :partner_regular_incomes }
     end
 
     context "when receives_state_benefits is true" do
-      let(:receives_state_benefits) { true }
+      let(:options) { { receives_state_benefits: true } }
 
       it { is_expected.to eq :partner_state_benefits }
     end

--- a/spec/services/flow/steps/provider_means_state_benefits/receives_state_benefits_step_spec.rb
+++ b/spec/services/flow/steps/provider_means_state_benefits/receives_state_benefits_step_spec.rb
@@ -10,16 +10,16 @@ RSpec.describe Flow::Steps::ProviderMeansStateBenefits::ReceivesStateBenefitsSte
   end
 
   describe "#forward" do
-    subject { described_class.forward.call(application, receives_state_benefits) }
+    subject { described_class.forward.call(application, options) }
 
     context "when applicant receives state benefits" do
-      let(:receives_state_benefits) { true }
+      let(:options) { { receives_state_benefits: true } }
 
       it { is_expected.to eq :state_benefits }
     end
 
     context "when applicant does not receive state benefits" do
-      let(:receives_state_benefits) { false }
+      let(:options) { { receives_state_benefits: false } }
 
       it { is_expected.to eq :regular_incomes }
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5418)

Previously there was no handler for the Save and come back later button

Now we save the form and redirect to the application list as expected

I have removed the save_as_draft button from the new_benefit_form as the database has been configured to not allow empty fields and this means we cannot save part completed data on this page

I will create a follow up ticket to investigate the impact of changing the database table.  It will have a note to reinstate the save as draft function on this ticket if the DB can be updated

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
