### PR TITLE
Ap 5389 update heard as alternatives page

### DIFF
--- a/app/assets/stylesheets/interruption-panel.scss
+++ b/app/assets/stylesheets/interruption-panel.scss
@@ -48,7 +48,7 @@
   }
 
   .govuk-list--bullet{
-    a:visited{
+    a, a:visited{
       color: govuk-colour("white");
     }
   }

--- a/app/assets/stylesheets/interruption-panel.scss
+++ b/app/assets/stylesheets/interruption-panel.scss
@@ -46,6 +46,12 @@
     border-left: $govuk-border-width-wide solid govuk-colour("white");
     color: govuk-colour("white");
   }
+
+  .govuk-list--bullet{
+    a:visited{
+      color: govuk-colour("white");
+    }
+  }
 }
 
 @media (min-width: 769px) {

--- a/app/controllers/providers/proceedings_sca/interrupts_controller.rb
+++ b/app/controllers/providers/proceedings_sca/interrupts_controller.rb
@@ -5,6 +5,12 @@ module Providers
         type
       end
 
+      def destroy
+        legal_aid_application.proceedings.order(:created_at).last.destroy!
+        replace_last_page_in_history(submitted_providers_legal_aid_applications_path)
+        redirect_to providers_legal_aid_application_proceedings_types_path
+      end
+
     private
 
       def type

--- a/app/views/providers/proceedings_sca/interrupts/show.html.erb
+++ b/app/views/providers/proceedings_sca/interrupts/show.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <div class='govuk-button-group'>
-      <%= govuk_button_link_to t(".#{@type}.applications"), submitted_providers_legal_aid_applications_path, inverse: true, role: "button" %>
+      <%= govuk_button_link_to t(".#{@type}.applications"), providers_legal_aid_application_sca_interrupt_path(@legal_aid_application, @type), method: :delete, inverse: true, role: "button" %>
     </div>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -283,6 +283,7 @@ Rails.application.routes.draw do
 
       scope module: :proceedings_sca do
         get "/interrupt/:type", to: "interrupts#show", as: "sca_interrupt"
+        delete "/interrupt/:type", to: "interrupts#destroy"
         resource :proceeding_issue_statuses, only: %i[show update], path: "proceeding_issue_status"
         resources :heard_togethers, only: %i[show update], path: "will_proceedings_be_heard_together"
         resource :supervision_orders, only: %i[show update], path: "supervision_order_changes"

--- a/spec/requests/providers/proceedings_sca/interrupts_controller_spec.rb
+++ b/spec/requests/providers/proceedings_sca/interrupts_controller_spec.rb
@@ -2,12 +2,14 @@ require "rails_helper"
 
 RSpec.describe Providers::ProceedingsSCA::InterruptsController do
   let(:legal_aid_application) { create(:legal_aid_application) }
+  let(:current_proceeding) { create(:proceeding, :pb007) }
   let(:provider) { legal_aid_application.provider }
+  let(:display) { "supervision" }
+
+  before { legal_aid_application.proceedings << current_proceeding }
 
   describe "GET /providers/applications/:id/interrupt/:type" do
     subject(:get_request) { get providers_legal_aid_application_sca_interrupt_path(legal_aid_application, display) }
-
-    let(:display) { "supervision" }
 
     context "when the provider is not authenticated" do
       before { get_request }
@@ -37,6 +39,31 @@ RSpec.describe Providers::ProceedingsSCA::InterruptsController do
           expect(response.body).to include("You cannot choose a special children act proceeding if it has not been issued")
           expect(response.body).to include("Select a different proceeding or matter type")
         end
+      end
+    end
+  end
+
+  describe "DELETE /providers/applications/:id/interrupt/:current_proceeding/:type" do
+    subject(:delete_request) { delete "/providers/applications/#{legal_aid_application.id}/interrupt/#{display}" }
+
+    context "when the provider is not authenticated" do
+      before { delete_request }
+
+      it_behaves_like "a provider not authenticated"
+    end
+
+    context "when the provider is authenticated" do
+      before do
+        login_as provider
+        delete_request
+      end
+
+      it "redirects to the proceeding types path" do
+        expect(response).to redirect_to providers_legal_aid_application_proceedings_types_path
+      end
+
+      it "deletes the current proceeding" do
+        expect { current_proceeding.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5389)

- Changed the colour for visited link on interrupt page to white.
- Delete the current proceeding and redirect to the proceeding search page if the user selects to Check for another matter type. Also add applications index page to page history as user will no longer be able to navigate back (as the proceeding has been deleted).

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
