### PR TITLE
AP-5398: Update date_field_builder to handle spaces

### DIFF
--- a/app/forms/concerns/date_field_builder.rb
+++ b/app/forms/concerns/date_field_builder.rb
@@ -49,7 +49,11 @@ class DateFieldBuilder
 
   # An array of the data stored in the form's date part fields
   def from_form
-    @from_form ||= fields.map { |field| form.__send__(field) }
+    @from_form ||= fields.map do |field|
+      result = form.__send__(field)
+      result.strip! if result.is_a?(String)
+      result
+    end
   end
 
   def parts_hash

--- a/spec/forms/applicants/basic_details_form_spec.rb
+++ b/spec/forms/applicants/basic_details_form_spec.rb
@@ -116,6 +116,29 @@ RSpec.describe Applicants::BasicDetailsForm, type: :form do
       end
     end
 
+    context "with spaces in dates" do
+      let(:params) do
+        {
+          first_name: attributes[:first_name],
+          last_name: attributes[:last_name],
+          date_of_birth_1i: "1990  ",
+          date_of_birth_2i: "3 ",
+          date_of_birth_3i: " 2",
+          changed_last_name: "false",
+          model: applicant,
+        }
+      end
+
+      it "creates applicant successfully" do
+        expect { form.save }.to change(Applicant, :count)
+      end
+
+      it "saves the date" do
+        form.save!
+        expect(Applicant.last.date_of_birth).to eq(Date.new(1990, 3, 2))
+      end
+    end
+
     context "with invalid date_of_birth elements" do
       let(:params) do
         {


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5398)

When the builder is reading the form values, it now strips leading and trailing spaces from the individual parts of the date

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
