### PR TITLE
AP-5347: Change flow from restrictions to mandatory capital disregards when flag enabled

### DIFF
--- a/app/services/flow/steps/provider_capital/restrictions_step.rb
+++ b/app/services/flow/steps/provider_capital/restrictions_step.rb
@@ -5,7 +5,7 @@ module Flow
         path: ->(application) { Steps.urls.providers_legal_aid_application_means_restrictions_path(application) },
         forward: lambda do |application|
           if application.capture_policy_disregards?
-            :policy_disregards
+            Setting.means_test_review_a? ? :capital_disregards_mandatory : :policy_disregards
           else
             application.passported? ? :check_passported_answers : :check_capital_answers
           end

--- a/spec/services/flow/steps/provider_capital/restrictions_step_spec.rb
+++ b/spec/services/flow/steps/provider_capital/restrictions_step_spec.rb
@@ -21,10 +21,20 @@ RSpec.describe Flow::Steps::ProviderCapital::RestrictionsStep, type: :request do
   describe "#forward" do
     subject { described_class.forward.call(legal_aid_application) }
 
-    context "when capture_policy_disregards is true" do
+    context "when capture_policy_disregards is true and mtr2 accelerated measures is disabled" do
+      before { allow(Setting).to receive(:means_test_review_a?).and_return(false) }
+
       let(:capture_policy_disregards?) { true }
 
       it { is_expected.to eq :policy_disregards }
+    end
+
+    context "when capture_policy_disregards is true and mtr2 accelerated measures is enabled" do
+      before { allow(Setting).to receive(:means_test_review_a?).and_return(true) }
+
+      let(:capture_policy_disregards?) { true }
+
+      it { is_expected.to eq :capital_disregards_mandatory }
     end
 
     context "when passported is true" do


### PR DESCRIPTION


## What
Change capital question flow from restrictions to mandatory capital disregards when flag enabled

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5347)

Missed as part of AP-5347? This is a branching step flow that directs to policy disregards, and therefore needs to move foward to mandatory capital disregards when the mtra flag is enabled.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
