### PR TITLE
ap-5338: add sca fields to application details report

### DIFF
--- a/app/models/application_digest.rb
+++ b/app/models/application_digest.rb
@@ -15,7 +15,8 @@ class ApplicationDigest < ApplicationRecord
     legal_linked
     no_fixed_address
     biological_parent
-    parental_responsibility_order
+    parental_responsibility_agreement
+    parental_responsibility_court_order
     child_subject
     autogranted
   ].freeze
@@ -69,7 +70,8 @@ class ApplicationDigest < ApplicationRecord
         number_of_legal_linked_applications: laa.legal_linked_applications_count,
         no_fixed_address: laa.applicant.no_fixed_residence?,
         biological_parent: laa.biological_parent_relationship?,
-        parental_responsibility_order: laa.parental_responsibility_order_relationship?,
+        parental_responsibility_agreement: laa.parental_responsibility_agreement_relationship?,
+        parental_responsibility_court_order: laa.parental_responsibility_court_order_relationship?,
         child_subject: laa.child_subject_relationship?,
         autogranted: laa.auto_grant_special_children_act?(nil),
       }

--- a/app/models/application_digest.rb
+++ b/app/models/application_digest.rb
@@ -18,6 +18,7 @@ class ApplicationDigest < ApplicationRecord
     parental_responsibility_agreement
     parental_responsibility_court_order
     child_subject
+    parental_responsibility_evidence
     autogranted
   ].freeze
 
@@ -73,6 +74,7 @@ class ApplicationDigest < ApplicationRecord
         parental_responsibility_agreement: laa.parental_responsibility_agreement_relationship?,
         parental_responsibility_court_order: laa.parental_responsibility_court_order_relationship?,
         child_subject: laa.child_subject_relationship?,
+        parental_responsibility_evidence: laa.parental_responsibility_evidence?,
         autogranted: laa.auto_grant_special_children_act?(nil),
       }
     end

--- a/app/models/application_digest.rb
+++ b/app/models/application_digest.rb
@@ -14,6 +14,10 @@ class ApplicationDigest < ApplicationRecord
     family_linked
     legal_linked
     no_fixed_address
+    biological_parent
+    parental_responsibility_order
+    child_subject
+    autogranted
   ].freeze
 
   class << self
@@ -64,6 +68,10 @@ class ApplicationDigest < ApplicationRecord
         legal_linked_lead_or_associated: laa.legal_linked_lead_or_associated,
         number_of_legal_linked_applications: laa.legal_linked_applications_count,
         no_fixed_address: laa.applicant.no_fixed_residence?,
+        biological_parent: laa.biological_parent_relationship?,
+        parental_responsibility_order: laa.parental_responsibility_order_relationship?,
+        child_subject: laa.child_subject_relationship?,
+        autogranted: laa.auto_grant_special_children_act?(nil),
       }
     end
 

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -650,6 +650,18 @@ class LegalAidApplication < ApplicationRecord
     proceedings.where(sca_type: "related")
   end
 
+  def biological_parent?
+    proceedings.any? { |proceeding| proceeding.relationship_to_child.eql?("biological") }
+  end
+
+  def parental_responsibility_order?
+    proceedings.any? { |proceeding| proceeding.relationship_to_child.eql?("court_order") }
+  end
+
+  def child_subject?
+    proceedings.any? { |proceeding| proceeding.relationship_to_child.eql?("child_subject") }
+  end
+
 private
 
   def expired_by_2023_surname_at_birth_issue?

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -650,15 +650,15 @@ class LegalAidApplication < ApplicationRecord
     proceedings.where(sca_type: "related")
   end
 
-  def biological_parent?
+  def biological_parent_relationship?
     proceedings.any? { |proceeding| proceeding.relationship_to_child.eql?("biological") }
   end
 
-  def parental_responsibility_order?
+  def parental_responsibility_order_relationship?
     proceedings.any? { |proceeding| proceeding.relationship_to_child.eql?("court_order") }
   end
 
-  def child_subject?
+  def child_subject_relationship?
     proceedings.any? { |proceeding| proceeding.relationship_to_child.eql?("child_subject") }
   end
 

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -654,12 +654,20 @@ class LegalAidApplication < ApplicationRecord
     proceedings.any? { |proceeding| proceeding.relationship_to_child.eql?("biological") }
   end
 
-  def parental_responsibility_order_relationship?
+  def parental_responsibility_court_order_relationship?
     proceedings.any? { |proceeding| proceeding.relationship_to_child.eql?("court_order") }
+  end
+
+  def parental_responsibility_agreement_relationship?
+    proceedings.any? { |proceeding| proceeding.relationship_to_child.eql?("parental_responsibility_agreement") }
   end
 
   def child_subject_relationship?
     proceedings.any? { |proceeding| proceeding.relationship_to_child.eql?("child_subject") }
+  end
+
+  def parental_responsibility_evidence?
+    attachments&.parental_responsibility&.exists?
   end
 
   def auto_grant_special_children_act?(_options)

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -662,6 +662,11 @@ class LegalAidApplication < ApplicationRecord
     proceedings.any? { |proceeding| proceeding.relationship_to_child.eql?("child_subject") }
   end
 
+  def auto_grant_special_children_act?(_options)
+    # TODO: extract autogrant logic into model
+    false
+  end
+
 private
 
   def expired_by_2023_surname_at_birth_issue?

--- a/app/services/reports/mis/application_detail_csv_line.rb
+++ b/app/services/reports/mis/application_detail_csv_line.rb
@@ -178,6 +178,7 @@ module Reports
           "Parental responsibility agreement relationship?",
           "Parental responsibility court order relationship?",
           "Child subject relationship?",
+          "Parental responsibility evidence?",
           "Autogranted?",
         ]
       end
@@ -473,7 +474,11 @@ module Reports
           @line << yesno(laa.parental_responsibility_agreement_relationship?)
           @line << yesno(laa.parental_responsibility_court_order_relationship?)
           @line << yesno(laa.child_subject_relationship?)
+          @line << if laa.parental_responsibility_agreement_relationship? || laa.parental_responsibility_court_order_relationship?
+                     yesno(laa.parental_responsibility_evidence?)
+                   end
         else
+          @line << nil
           @line << nil
           @line << nil
           @line << nil

--- a/app/services/reports/mis/application_detail_csv_line.rb
+++ b/app/services/reports/mis/application_detail_csv_line.rb
@@ -173,6 +173,10 @@ module Reports
           "Number of legal links",
           "No fixed address",
           "Previous CCMS ref?",
+          "Child subject client involvment type?",
+          "Biological parent relationship?",
+          "Parental responsibility order relationship?",
+          "Child subject relationship?",
         ]
       end
 
@@ -209,6 +213,8 @@ module Reports
         linked_applications
         home_address
         previous_ccms_ref
+        child_client_involvement_type
+        sca
         sanitise
       end
 
@@ -452,6 +458,22 @@ module Reports
 
       def previous_ccms_ref
         @line << yesno(laa.applicant.previous_reference.present?)
+      end
+
+      def child_client_involvement_type
+        @line << yesno(proceedings.any? { |proceeding| proceeding.client_involvement_type_ccms_code.eql?("W") })
+      end
+
+      def sca
+        if laa.special_children_act_proceedings?
+          @line << yesno(laa.biological_parent?)
+          @line << yesno(laa.parental_responsibility_order?)
+          @line << yesno(laa.child_subject?)
+        else
+          @line << nil
+          @line << nil
+          @line << nil
+        end
       end
 
       def yesno(value)

--- a/app/services/reports/mis/application_detail_csv_line.rb
+++ b/app/services/reports/mis/application_detail_csv_line.rb
@@ -177,6 +177,7 @@ module Reports
           "Biological parent relationship?",
           "Parental responsibility order relationship?",
           "Child subject relationship?",
+          "Autogranted?",
         ]
       end
 
@@ -215,6 +216,7 @@ module Reports
         previous_ccms_ref
         child_client_involvement_type
         sca
+        autogranted
         sanitise
       end
 
@@ -474,6 +476,10 @@ module Reports
           @line << nil
           @line << nil
         end
+      end
+
+      def autogranted
+        @line << yesno(laa.auto_grant_special_children_act?(nil))
       end
 
       def yesno(value)

--- a/app/services/reports/mis/application_detail_csv_line.rb
+++ b/app/services/reports/mis/application_detail_csv_line.rb
@@ -214,7 +214,7 @@ module Reports
         linked_applications
         home_address
         previous_ccms_ref
-        child_client_involvement_type
+        child_subject_client_involvement_type
         sca
         autogranted
         sanitise
@@ -462,15 +462,15 @@ module Reports
         @line << yesno(laa.applicant.previous_reference.present?)
       end
 
-      def child_client_involvement_type
+      def child_subject_client_involvement_type
         @line << yesno(proceedings.any? { |proceeding| proceeding.client_involvement_type_ccms_code.eql?("W") })
       end
 
       def sca
         if laa.special_children_act_proceedings?
-          @line << yesno(laa.biological_parent?)
-          @line << yesno(laa.parental_responsibility_order?)
-          @line << yesno(laa.child_subject?)
+          @line << yesno(laa.biological_parent_relationship?)
+          @line << yesno(laa.parental_responsibility_order_relationship?)
+          @line << yesno(laa.child_subject_relationship?)
         else
           @line << nil
           @line << nil

--- a/app/services/reports/mis/application_detail_csv_line.rb
+++ b/app/services/reports/mis/application_detail_csv_line.rb
@@ -175,7 +175,8 @@ module Reports
           "Previous CCMS ref?",
           "Child subject client involvment type?",
           "Biological parent relationship?",
-          "Parental responsibility order relationship?",
+          "Parental responsibility agreement relationship?",
+          "Parental responsibility court order relationship?",
           "Child subject relationship?",
           "Autogranted?",
         ]
@@ -469,9 +470,11 @@ module Reports
       def sca
         if laa.special_children_act_proceedings?
           @line << yesno(laa.biological_parent_relationship?)
-          @line << yesno(laa.parental_responsibility_order_relationship?)
+          @line << yesno(laa.parental_responsibility_agreement_relationship?)
+          @line << yesno(laa.parental_responsibility_court_order_relationship?)
           @line << yesno(laa.child_subject_relationship?)
         else
+          @line << nil
           @line << nil
           @line << nil
           @line << nil

--- a/db/migrate/20241107092712_add_sca_fields_to_application_digest.rb
+++ b/db/migrate/20241107092712_add_sca_fields_to_application_digest.rb
@@ -1,0 +1,10 @@
+class AddSCAFieldsToApplicationDigest < ActiveRecord::Migration[7.2]
+  def change
+    add_column :application_digests, :biological_parent, :boolean
+    add_column :application_digests, :parental_responsibility_agreement, :boolean
+    add_column :application_digests, :parental_responsibility_court_order, :boolean
+    add_column :application_digests, :child_subject, :boolean
+    add_column :application_digests, :parental_responsibility_evidence, :boolean
+    add_column :application_digests, :autogranted, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_30_094958) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -183,6 +183,12 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_30_094958) do
     t.string "legal_linked_lead_or_associated"
     t.integer "number_of_legal_linked_applications"
     t.boolean "no_fixed_address"
+    t.boolean "biological_parent"
+    t.boolean "parental_responsibility_agreement"
+    t.boolean "parental_responsibility_court_order"
+    t.boolean "child_subject"
+    t.boolean "parental_responsibility_evidence"
+    t.boolean "autogranted"
     t.index ["legal_aid_application_id"], name: "index_application_digests_on_legal_aid_application_id", unique: true
   end
 

--- a/spec/factories/attachments.rb
+++ b/spec/factories/attachments.rb
@@ -32,6 +32,12 @@ FactoryBot.define do
       attachment_name { "bank_transaction_report.csv" }
     end
 
+    trait :parental_responsibility do
+      attachment_type { "parental_responsibility" }
+      sequence(:attachment_name) { |n| "parental_responsibility_#{n}" }
+      sequence(:original_filename) { "original_filename.pdf" }
+    end
+
     trait :uploaded_evidence_collection do
       attachment_type { "uncategorised" }
       attachment_name { "uploaded_evidence_collection" }

--- a/spec/models/application_digest_spec.rb
+++ b/spec/models/application_digest_spec.rb
@@ -522,5 +522,57 @@ RSpec.describe ApplicationDigest do
         end
       end
     end
+
+    describe "sca fields" do
+      let(:sca_proceeding) { create(:proceeding, :pb059, relationship_to_child:) }
+
+      before { laa.proceedings << sca_proceeding }
+
+      context "when the application has a proceeding with relationship_to_child biological" do
+        let(:relationship_to_child) { "biological" }
+
+        it "returns the expected data" do
+          application_digest
+          expect(digest.biological_parent).to be true
+          expect(digest.parental_responsibility_order).to be false
+          expect(digest.child_subject).to be false
+        end
+      end
+
+      context "when the application has a proceeding with relationship_to_child court_order" do
+        let(:relationship_to_child) { "court_order" }
+
+        before { laa.proceedings << sca_proceeding }
+
+        it "returns the expected data" do
+          application_digest
+          expect(digest.biological_parent).to be false
+          expect(digest.parental_responsibility_order).to be true
+          expect(digest.child_subject).to be false
+        end
+      end
+
+      context "when the application has a proceeding with relationship_to_child child_subject" do
+        let(:relationship_to_child) { "child_subject" }
+
+        before { laa.proceedings << sca_proceeding }
+
+        it "returns the expected data" do
+          application_digest
+          expect(digest.biological_parent).to be false
+          expect(digest.parental_responsibility_order).to be false
+          expect(digest.child_subject).to be true
+        end
+      end
+    end
+
+    describe "autogranted" do
+      context "when the application is not autogranted" do
+        it "returns autogranted false" do
+          application_digest
+          expect(digest.autogranted).to be false
+        end
+      end
+    end
   end
 end

--- a/spec/models/application_digest_spec.rb
+++ b/spec/models/application_digest_spec.rb
@@ -537,13 +537,18 @@ RSpec.describe ApplicationDigest do
           expect(digest.parental_responsibility_agreement).to be false
           expect(digest.parental_responsibility_court_order).to be false
           expect(digest.child_subject).to be false
+          expect(digest.parental_responsibility_evidence).to be false
         end
       end
 
       context "when the application has a proceeding with relationship_to_child parental_responsibility_agreement" do
         let(:relationship_to_child) { "parental_responsibility_agreement" }
+        let(:parental_responsibility_evidence) { create(:attachment, :parental_responsibility, attachment_name: "parental_responsibility") }
 
-        before { laa.proceedings << sca_proceeding }
+        before do
+          laa.proceedings << sca_proceeding
+          laa.attachments << parental_responsibility_evidence
+        end
 
         it "returns the expected data" do
           application_digest
@@ -551,6 +556,7 @@ RSpec.describe ApplicationDigest do
           expect(digest.parental_responsibility_agreement).to be true
           expect(digest.parental_responsibility_court_order).to be false
           expect(digest.child_subject).to be false
+          expect(digest.parental_responsibility_evidence).to be true
         end
       end
 
@@ -565,6 +571,7 @@ RSpec.describe ApplicationDigest do
           expect(digest.parental_responsibility_agreement).to be false
           expect(digest.parental_responsibility_court_order).to be true
           expect(digest.child_subject).to be false
+          expect(digest.parental_responsibility_evidence).to be false
         end
       end
 
@@ -579,6 +586,7 @@ RSpec.describe ApplicationDigest do
           expect(digest.parental_responsibility_agreement).to be false
           expect(digest.parental_responsibility_court_order).to be false
           expect(digest.child_subject).to be true
+          expect(digest.parental_responsibility_evidence).to be false
         end
       end
     end

--- a/spec/models/application_digest_spec.rb
+++ b/spec/models/application_digest_spec.rb
@@ -534,7 +534,22 @@ RSpec.describe ApplicationDigest do
         it "returns the expected data" do
           application_digest
           expect(digest.biological_parent).to be true
-          expect(digest.parental_responsibility_order).to be false
+          expect(digest.parental_responsibility_agreement).to be false
+          expect(digest.parental_responsibility_court_order).to be false
+          expect(digest.child_subject).to be false
+        end
+      end
+
+      context "when the application has a proceeding with relationship_to_child parental_responsibility_agreement" do
+        let(:relationship_to_child) { "parental_responsibility_agreement" }
+
+        before { laa.proceedings << sca_proceeding }
+
+        it "returns the expected data" do
+          application_digest
+          expect(digest.biological_parent).to be false
+          expect(digest.parental_responsibility_agreement).to be true
+          expect(digest.parental_responsibility_court_order).to be false
           expect(digest.child_subject).to be false
         end
       end
@@ -547,7 +562,8 @@ RSpec.describe ApplicationDigest do
         it "returns the expected data" do
           application_digest
           expect(digest.biological_parent).to be false
-          expect(digest.parental_responsibility_order).to be true
+          expect(digest.parental_responsibility_agreement).to be false
+          expect(digest.parental_responsibility_court_order).to be true
           expect(digest.child_subject).to be false
         end
       end
@@ -560,7 +576,8 @@ RSpec.describe ApplicationDigest do
         it "returns the expected data" do
           application_digest
           expect(digest.biological_parent).to be false
-          expect(digest.parental_responsibility_order).to be false
+          expect(digest.parental_responsibility_agreement).to be false
+          expect(digest.parental_responsibility_court_order).to be false
           expect(digest.child_subject).to be true
         end
       end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -2258,6 +2258,21 @@ RSpec.describe LegalAidApplication do
     end
   end
 
+  describe "#parental_responsibility_evidence?" do
+    subject { legal_aid_application.parental_responsibility_evidence? }
+
+    context "with aan application that has parental responsibility evidence" do
+      let(:legal_aid_application) { create(:legal_aid_application, attachments: [parental_responsibility_evidence]) }
+      let(:parental_responsibility_evidence) { create(:attachment, :parental_responsibility, attachment_name: "parental_responsibility") }
+
+      it { is_expected.to be true }
+    end
+
+    context "without a proceeding with a child_subject relationship" do
+      it { is_expected.to be false }
+    end
+  end
+
 private
 
   def uploaded_evidence_output

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -2210,10 +2210,10 @@ RSpec.describe LegalAidApplication do
     end
   end
 
-  describe "#parental_responsibility_order_relationship?" do
-    subject { legal_aid_application.parental_responsibility_order_relationship? }
+  describe "#parental_responsibility_court_order_relationship?" do
+    subject { legal_aid_application.parental_responsibility_court_order_relationship? }
 
-    context "with a proceeding with a parental_responsibility_order relationship" do
+    context "with a proceeding with a parental_responsibility_court_order relationship" do
       before { legal_aid_application.proceedings << sca_proceeding }
 
       let(:sca_proceeding) { create(:proceeding, :pb059, relationship_to_child: "court_order") }
@@ -2221,7 +2221,23 @@ RSpec.describe LegalAidApplication do
       it { is_expected.to be true }
     end
 
-    context "without a proceeding with a parental_responsibility_order relationship" do
+    context "without a proceeding with a parental_responsibility_court_order relationship" do
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#parental_responsibility_agreement_relationship?" do
+    subject { legal_aid_application.parental_responsibility_agreement_relationship? }
+
+    context "with a proceeding with a parental_responsibility_agreement relationship" do
+      before { legal_aid_application.proceedings << sca_proceeding }
+
+      let(:sca_proceeding) { create(:proceeding, :pb059, relationship_to_child: "parental_responsibility_agreement") }
+
+      it { is_expected.to be true }
+    end
+
+    context "without a proceeding with a parental_responsibility_agreement relationship" do
       it { is_expected.to be false }
     end
   end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -2194,6 +2194,54 @@ RSpec.describe LegalAidApplication do
     end
   end
 
+  describe "#biological_parent_relationship?" do
+    subject { legal_aid_application.biological_parent_relationship? }
+
+    context "with a proceeding with a biological_parent relationship" do
+      before { legal_aid_application.proceedings << sca_proceeding }
+
+      let(:sca_proceeding) { create(:proceeding, :pb059, relationship_to_child: "biological") }
+
+      it { is_expected.to be true }
+    end
+
+    context "without a proceeding with a biological parent relationship" do
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#parental_responsibility_order_relationship?" do
+    subject { legal_aid_application.parental_responsibility_order_relationship? }
+
+    context "with a proceeding with a parental_responsibility_order relationship" do
+      before { legal_aid_application.proceedings << sca_proceeding }
+
+      let(:sca_proceeding) { create(:proceeding, :pb059, relationship_to_child: "court_order") }
+
+      it { is_expected.to be true }
+    end
+
+    context "without a proceeding with a parental_responsibility_order relationship" do
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#child_subject_relationship?" do
+    subject { legal_aid_application.child_subject_relationship? }
+
+    context "with a proceeding with a child_subject relationship" do
+      before { legal_aid_application.proceedings << sca_proceeding }
+
+      let(:sca_proceeding) { create(:proceeding, :pb059, relationship_to_child: "child_subject") }
+
+      it { is_expected.to be true }
+    end
+
+    context "without a proceeding with a child_subject relationship" do
+      it { is_expected.to be false }
+    end
+  end
+
 private
 
   def uploaded_evidence_output

--- a/spec/services/reports/mis/application_detail_csv_line_spec.rb
+++ b/spec/services/reports/mis/application_detail_csv_line_spec.rb
@@ -853,6 +853,74 @@ module Reports
           end
         end
 
+        describe "child client involvement type" do
+          context "when the provider has selected child subject for any of the application proceedings" do
+            before { legal_aid_application.proceedings << proceeding }
+
+            let(:proceeding) { create(:proceeding, :pb059, client_involvement_type_ccms_code: "W") }
+
+            it "sets child subject client involement type to Yes" do
+              expect(value_for("Child subject client involvment type?")).to eq "Yes"
+            end
+          end
+
+          context "when the provider has not selected child subject for any of the application proceedings" do
+            it "sets child subject client involement type to No" do
+              expect(value_for("Child subject client involvment type?")).to eq "No"
+            end
+          end
+        end
+
+        describe "SCA fields" do
+          context "when the application has no SCA proceedings" do
+            it "returns the expected data" do
+              expect(value_for("Biological parent relationship?")).to be_nil
+              expect(value_for("Parental responsibility order relationship?")).to be_nil
+              expect(value_for("Child subject relationship?")).to be_nil
+            end
+          end
+
+          context "when the application has an sca proceeding" do
+            let(:sca_proceeding) { create(:proceeding, :pb059, relationship_to_child:) }
+
+            before { legal_aid_application.proceedings << sca_proceeding }
+
+            context "when the application has a proceeding with relationship_to_child biological" do
+              let(:relationship_to_child) { "biological" }
+
+              it "returns the expected data" do
+                expect(value_for("Biological parent relationship?")).to eq "Yes"
+                expect(value_for("Parental responsibility order relationship?")).to eq "No"
+                expect(value_for("Child subject relationship?")).to eq "No"
+              end
+            end
+
+            context "when the application has a proceeding with relationship_to_child court_order" do
+              let(:relationship_to_child) { "court_order" }
+
+              before { legal_aid_application.proceedings << sca_proceeding }
+
+              it "returns the expected data" do
+                expect(value_for("Biological parent relationship?")).to eq "No"
+                expect(value_for("Parental responsibility order relationship?")).to eq "Yes"
+                expect(value_for("Child subject relationship?")).to eq "No"
+              end
+            end
+
+            context "when the application has a proceeding with relationship_to_child child_subject" do
+              let(:relationship_to_child) { "child_subject" }
+
+              before { legal_aid_application.proceedings << sca_proceeding }
+
+              it "returns the expected data" do
+                expect(value_for("Biological parent relationship?")).to eq "No"
+                expect(value_for("Parental responsibility order relationship?")).to eq "No"
+                expect(value_for("Child subject relationship?")).to eq "Yes"
+              end
+            end
+          end
+        end
+
         context "when the applicant age cannot be generated" do
           let(:legal_aid_application) { create(:legal_aid_application, applicant:) }
           let(:applicant) do

--- a/spec/services/reports/mis/application_detail_csv_line_spec.rb
+++ b/spec/services/reports/mis/application_detail_csv_line_spec.rb
@@ -875,7 +875,8 @@ module Reports
           context "when the application has no SCA proceedings" do
             it "returns the expected data" do
               expect(value_for("Biological parent relationship?")).to be_nil
-              expect(value_for("Parental responsibility order relationship?")).to be_nil
+              expect(value_for("Parental responsibility agreement relationship?")).to be_nil
+              expect(value_for("Parental responsibility court order relationship?")).to be_nil
               expect(value_for("Child subject relationship?")).to be_nil
             end
           end
@@ -890,7 +891,19 @@ module Reports
 
               it "returns the expected data" do
                 expect(value_for("Biological parent relationship?")).to eq "Yes"
-                expect(value_for("Parental responsibility order relationship?")).to eq "No"
+                expect(value_for("Parental responsibility agreement relationship?")).to eq "No"
+                expect(value_for("Parental responsibility court order relationship?")).to eq "No"
+                expect(value_for("Child subject relationship?")).to eq "No"
+              end
+            end
+
+            context "when the application has a proceeding with relatitionship_to_child parental_responsibl;ity_agreement" do
+              let(:relationship_to_child) { "parental_responsibility_agreement" }
+
+              it "returns the expected data" do
+                expect(value_for("Biological parent relationship?")).to eq "No"
+                expect(value_for("Parental responsibility agreement relationship?")).to eq "Yes"
+                expect(value_for("Parental responsibility court order relationship?")).to eq "No"
                 expect(value_for("Child subject relationship?")).to eq "No"
               end
             end
@@ -898,11 +911,10 @@ module Reports
             context "when the application has a proceeding with relationship_to_child court_order" do
               let(:relationship_to_child) { "court_order" }
 
-              before { legal_aid_application.proceedings << sca_proceeding }
-
               it "returns the expected data" do
                 expect(value_for("Biological parent relationship?")).to eq "No"
-                expect(value_for("Parental responsibility order relationship?")).to eq "Yes"
+                expect(value_for("Parental responsibility agreement relationship?")).to eq "No"
+                expect(value_for("Parental responsibility court order relationship?")).to eq "Yes"
                 expect(value_for("Child subject relationship?")).to eq "No"
               end
             end
@@ -910,11 +922,10 @@ module Reports
             context "when the application has a proceeding with relationship_to_child child_subject" do
               let(:relationship_to_child) { "child_subject" }
 
-              before { legal_aid_application.proceedings << sca_proceeding }
-
               it "returns the expected data" do
                 expect(value_for("Biological parent relationship?")).to eq "No"
-                expect(value_for("Parental responsibility order relationship?")).to eq "No"
+                expect(value_for("Parental responsibility agreement relationship?")).to eq "No"
+                expect(value_for("Parental responsibility court order relationship?")).to eq "No"
                 expect(value_for("Child subject relationship?")).to eq "Yes"
               end
             end

--- a/spec/services/reports/mis/application_detail_csv_line_spec.rb
+++ b/spec/services/reports/mis/application_detail_csv_line_spec.rb
@@ -853,7 +853,7 @@ module Reports
           end
         end
 
-        describe "child client involvement type" do
+        describe "child subject client involvement type" do
           context "when the provider has selected child subject for any of the application proceedings" do
             before { legal_aid_application.proceedings << proceeding }
 
@@ -933,7 +933,7 @@ module Reports
           context "when the application is not autogranted" do
             before { allow(legal_aid_application).to receive(:auto_grant_special_children_act?).and_return(false) }
 
-            it "sets autogranted? to Yes" do
+            it "sets autogranted? to No" do
               expect(value_for("Autogranted?")).to eq "No"
             end
           end

--- a/spec/services/reports/mis/application_detail_csv_line_spec.rb
+++ b/spec/services/reports/mis/application_detail_csv_line_spec.rb
@@ -878,6 +878,7 @@ module Reports
               expect(value_for("Parental responsibility agreement relationship?")).to be_nil
               expect(value_for("Parental responsibility court order relationship?")).to be_nil
               expect(value_for("Child subject relationship?")).to be_nil
+              expect(value_for("Parental responsibility evidence?")).to be_nil
             end
           end
 
@@ -894,6 +895,7 @@ module Reports
                 expect(value_for("Parental responsibility agreement relationship?")).to eq "No"
                 expect(value_for("Parental responsibility court order relationship?")).to eq "No"
                 expect(value_for("Child subject relationship?")).to eq "No"
+                expect(value_for("Parental responsibility evidence?")).to be_nil
               end
             end
 
@@ -905,17 +907,22 @@ module Reports
                 expect(value_for("Parental responsibility agreement relationship?")).to eq "Yes"
                 expect(value_for("Parental responsibility court order relationship?")).to eq "No"
                 expect(value_for("Child subject relationship?")).to eq "No"
+                expect(value_for("Parental responsibility evidence?")).to eq "No"
               end
             end
 
             context "when the application has a proceeding with relationship_to_child court_order" do
               let(:relationship_to_child) { "court_order" }
+              let(:parental_responsibility_evidence) { create(:attachment, :parental_responsibility, attachment_name: "parental_responsibility") }
+
+              before { legal_aid_application.attachments << parental_responsibility_evidence }
 
               it "returns the expected data" do
                 expect(value_for("Biological parent relationship?")).to eq "No"
                 expect(value_for("Parental responsibility agreement relationship?")).to eq "No"
                 expect(value_for("Parental responsibility court order relationship?")).to eq "Yes"
                 expect(value_for("Child subject relationship?")).to eq "No"
+                expect(value_for("Parental responsibility evidence?")).to eq "Yes"
               end
             end
 
@@ -927,6 +934,7 @@ module Reports
                 expect(value_for("Parental responsibility agreement relationship?")).to eq "No"
                 expect(value_for("Parental responsibility court order relationship?")).to eq "No"
                 expect(value_for("Child subject relationship?")).to eq "Yes"
+                expect(value_for("Parental responsibility evidence?")).to be_nil
               end
             end
           end

--- a/spec/services/reports/mis/application_detail_csv_line_spec.rb
+++ b/spec/services/reports/mis/application_detail_csv_line_spec.rb
@@ -921,6 +921,24 @@ module Reports
           end
         end
 
+        describe "autogranted" do
+          context "when the application is autogranted" do
+            before { allow(legal_aid_application).to receive(:auto_grant_special_children_act?).and_return(true) }
+
+            it "sets autogranted? to Yes" do
+              expect(value_for("Autogranted?")).to eq "Yes"
+            end
+          end
+
+          context "when the application is not autogranted" do
+            before { allow(legal_aid_application).to receive(:auto_grant_special_children_act?).and_return(false) }
+
+            it "sets autogranted? to Yes" do
+              expect(value_for("Autogranted?")).to eq "No"
+            end
+          end
+        end
+
         context "when the applicant age cannot be generated" do
           let(:legal_aid_application) { create(:legal_aid_application, applicant:) }
           let(:applicant) do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5338)

Added biological_parent?, parental_responsibility_order?, child_subject? and autogranted? columns to the application digest and additionally child_subject_client_involvement_type?  to the application details report.

Whether or not the application is an SCA application can already be determined from the matter_types column and similarly the applicant age from the applicant_age column.

TODO

After discussions, it was decided that it was best to wait to populate the auto_grant_special_children_act? on the LegalAidApplication model until after the autogrant work is complete.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
