### PR TITLE
AP-5473: Replace display_emergency_certificate? calls

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -425,16 +425,12 @@ class LegalAidApplication < ApplicationRecord
     default_substantive_cost_limitation
   end
 
-  def display_emergency_certificate?
-    used_delegated_functions? && !special_children_act_proceedings?
-  end
-
   def substantive_cost_overridable?
     substantive_cost_limitation.present? && default_substantive_cost_limitation < MAX_SUBSTANTIVE_COST_LIMIT && !special_children_act_proceedings? && !family_linked_associated_application?
   end
 
   def emergency_cost_overridable?
-    display_emergency_certificate? && !family_linked_associated_application?
+    non_sca_used_delegated_functions? && !family_linked_associated_application?
   end
 
   def substantive_cost_limitation

--- a/app/views/providers/limitations/_proceeding_type.html.erb
+++ b/app/views/providers/limitations/_proceeding_type.html.erb
@@ -17,7 +17,7 @@
       </span>
     </h3>
     <%= govuk_details(summary_text: t(".details_heading")) do %>
-      <% if @legal_aid_application.display_emergency_certificate? %>
+      <% if @legal_aid_application.non_sca_used_delegated_functions? %>
         <h4 class="govuk-heading-m"><%= t(".emergency_certificate") %></h4>
         <p><strong><%= t(".form_of_service") %></strong>
           <%= proceeding.emergency_level_of_service_name %>

--- a/app/views/providers/limitations/show.html.erb
+++ b/app/views/providers/limitations/show.html.erb
@@ -13,7 +13,7 @@
                locals: { translation_path: "providers.limitations.show" } %>
 
     <h2 class="govuk-heading-l"><%= t(".cost_heading") %></h2>
-    <% if @legal_aid_application.display_emergency_certificate? %>
+    <% if @legal_aid_application.non_sca_used_delegated_functions? %>
       <h3 class="govuk-heading-m"><%= t(".emergency_certificate") %></h3>
 
       <p class="govuk-body">

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -2174,28 +2174,6 @@ RSpec.describe LegalAidApplication do
     end
   end
 
-  describe "#display_emergency_certificate?" do
-    subject { legal_aid_application.display_emergency_certificate? }
-
-    let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings, :with_delegated_functions_on_proceedings, explicit_proceedings: %i[da001], df_options: { DA001: [Time.zone.today, Time.zone.today] }) }
-
-    context "when the provider has used delegated functions" do
-      it { is_expected.to be true }
-    end
-
-    context "when the provider has not used delegated functions" do
-      let(:legal_aid_application) { create(:legal_aid_application) }
-
-      it { is_expected.to be false }
-    end
-
-    context "when there are special childrens act proceedings" do
-      before { legal_aid_application.proceedings << create(:proceeding, :pb003) }
-
-      it { is_expected.to be false }
-    end
-  end
-
   describe "#related_proceedings" do
     subject { legal_aid_application.related_proceedings }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

There was a duplicate method in the delegated_functions concern that is being used in multiple other places.  Therefore the removal and replacement of these calls to the other method made the most sense

The replacement method is 
```ruby 
  def non_sca_used_delegated_functions?
    used_delegated_functions? && !special_children_act_proceedings?
  end
```

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
