### PR TITLE
AP-5393: Update SCA client declaration page

### DIFF
--- a/app/views/providers/confirm_client_declarations/show.html.erb
+++ b/app/views/providers/confirm_client_declarations/show.html.erb
@@ -8,7 +8,7 @@
   <%= page_template page_title: t(".h1-heading"), form: do %>
 
     <% provider_firm_name = @legal_aid_application.provider.firm.name %>
-    <% if @legal_aid_application.non_means_tested? %>
+    <% if @legal_aid_application.applicant&.under_18? %>
       <% i18n_prefix = "non_means_tested" %>
     <% elsif @legal_aid_application&.applicant&.has_partner_with_no_contrary_interest? %>
       <% i18n_prefix = "means_tested" %>

--- a/features/providers/special_children_act/client_declaration.feature
+++ b/features/providers/special_children_act/client_declaration.feature
@@ -1,0 +1,15 @@
+Feature: The certification page for SCA applications
+
+  @javascript @vcr
+  Scenario: Completes an application to the certification page for applicant that is 17
+    Given I have created an SCA application for a 17 year old
+    And I should be on the "confirm_client_declaration" page showing "Confirm the following"
+    Then I should see "they may have to pay towards legal aid"
+    And I should see "their date of birth on the application is correct based on the information you have"
+
+  @javascript @vcr
+  Scenario: Completes an application to the certification page for applicant that is 28
+    Given I have created an SCA application for a 28 year old
+    And I should be on the "confirm_client_declaration" page showing "Confirm the following"
+    Then I should see "they may have to pay towards legal aid"
+    And I should not see "their date of birth on the application is correct based on the information you have"

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -71,16 +71,20 @@ Given("I have created and submitted an application") do
   login_as @legal_aid_application.provider
 end
 
-Given(/^I have created an application for a (\d*?) year old$/) do |age|
+Given(/^I have created (an|an SCA) application for a (\d*?) year old$/) do |type, age|
   applicant = create(:applicant,
                      age_for_means_test_purposes: age,
                      date_of_birth: Time.zone.today - age.to_i.years)
+  proceeding = type == "an SCA" ? :pb059 : :da004
   @legal_aid_application = create(
     :application,
     :with_everything,
     :with_passported_state_machine,
     :checking_merits_answers,
     :initiated,
+    :with_proceedings,
+    explicit_proceedings: [proceeding],
+    set_lead_proceeding: proceeding,
     applicant:,
     provider: create(:provider),
     provider_step: "confirm_client_declarations",


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5393)

Update the handling on the view to be reliant on the age of the applicant rather than proceeding types (SCA)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
