### PR TITLE
AP-3563: Fix cash income/outgoings error message and form value rendering

### DIFF
--- a/app/views/shared/partials/_revealing_checkbox.html.erb
+++ b/app/views/shared/partials/_revealing_checkbox.html.erb
@@ -13,7 +13,7 @@
     <% end %>
     <%= form.govuk_text_field "#{name}#{number}",
                               label: { text: model.period(number) },
-                              value: gds_number_to_currency(model.__send__(:"#{name}#{number}"), unit: ""),
+                              value: model.__send__(:"#{name}#{number}"),
                               prefix_text: defined?(input_prefix) ? input_prefix : nil,
                               form_group: { classes: error_class },
                               width: "one-third" %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -3,12 +3,12 @@ en:
   errors:
     aggregated_cash_income:
       blank: "Enter the cash amount received %{category} in %{month}"
-      invalid_type: Amount must be an amount of money, like 1,000
+      invalid_type: Amount must be an amount of money, like 1000
       negative: Amount must be more than or equal to zero
       too_many_decimals: Amount must not include more than 2 decimal numbers
     aggregated_cash_outgoings:
       blank: "Enter the cash amount paid %{category} in %{month}"
-      invalid_type: Amount must be an amount of money, like 1,000
+      invalid_type: Amount must be an amount of money, like 1000
       negative: Amount must be more than or equal to zero
       too_many_decimals: Amount must not include more than 2 decimal numbers
     applicant_bank_accounts:

--- a/spec/models/aggregated_cash_income_spec.rb
+++ b/spec/models/aggregated_cash_income_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe AggregatedCashIncome do
         end
 
         it "populates the errors" do
-          error_msg = "Amount must be an amount of money, like 1,000"
+          error_msg = "Amount must be an amount of money, like 1000"
           expect(aci.errors[:benefits1][0]).to eq error_msg
         end
       end
@@ -315,7 +315,7 @@ RSpec.describe AggregatedCashIncome do
 
           it "populates the errors" do
             call_update
-            expect(aci.errors[:benefits2]).to include "Amount must be an amount of money, like 1,000"
+            expect(aci.errors[:benefits2]).to include "Amount must be an amount of money, like 1000"
           end
         end
 

--- a/spec/models/aggregated_cash_outgoings_spec.rb
+++ b/spec/models/aggregated_cash_outgoings_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe AggregatedCashOutgoings do
         end
 
         it "populates the errors" do
-          error_msg = "Amount must be an amount of money, like 1,000"
+          error_msg = "Amount must be an amount of money, like 1000"
           expect(aco.errors[:rent_or_mortgage1][0]).to eq error_msg
         end
       end
@@ -265,7 +265,7 @@ RSpec.describe AggregatedCashOutgoings do
 
           it "populates the errors" do
             call_update
-            expect(aco.errors[:rent_or_mortgage2]).to include "Amount must be an amount of money, like 1,000"
+            expect(aco.errors[:rent_or_mortgage2]).to include "Amount must be an amount of money, like 1000"
           end
         end
 


### PR DESCRIPTION
## What
Fix cash income/outgoings error message and form value rendering

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3563)

This fixes two distinct problems encountered by the
bug ticket

1. The message states you should use a value `like 1,000` but commas and
other strings are not currently parseable/allowed.

2. When rendering the form the field value is amended to be a  "number to currency"
value with no unit. This renders commas for numeric values over 3 digits long.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
