### PR TITLE
Chore: Update UAT digest Rake task exclusion

### DIFF
--- a/lib/tasks/digest.rake
+++ b/lib/tasks/digest.rake
@@ -1,14 +1,28 @@
+def warning_message(task_name)
+  <<~WARNING.freeze
+    Digest rake tasks are deactivated on UAT environments, call with
+      BYPASS=true rake digest:#{task_name}
+    To bypass the UAT block
+  WARNING
+end
+
 namespace :digest do
   desc "Run DigestExtractor to update application digests"
   task extract: :environment do
-    next if HostEnv.uat?
+    if !HostEnv.staging_or_production? && ENV.fetch("BYPASS", nil).nil?
+      Rails.logger.info warning_message("extract")
+      next
+    end
 
     DigestExtractor.call
   end
 
   desc "Run DigestExporter to export digest records to google sheet"
   task export: :environment do
-    next if HostEnv.uat?
+    if !HostEnv.staging_or_production? && ENV.fetch("BYPASS", nil).nil?
+      Rails.logger.info warning_message("export")
+      next
+    end
 
     DigestExporter.call
   end
@@ -16,7 +30,10 @@ namespace :digest do
   namespace :extraction_date do
     desc "Reset the last_extracted date so that all application_digest records are refreshed"
     task reset: :environment do
-      next if HostEnv.uat?
+      if !HostEnv.staging_or_production? && ENV.fetch("BYPASS", nil).nil?
+        Rails.logger.info warning_message("extraction_date")
+        next
+      end
 
       Setting.setting.update!(digest_extracted_at: 20.years.ago)
     end


### PR DESCRIPTION
## What

It became problematic to test the digest on UAT branches when you have to comment out code that is tested...

This allows a dev to run the task with a `BYPASS=` ENVVAR to get a branch to run the export on demand without additional code changes

It also outputs a warning to guide us when it occurs

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
