### PR TITLE
AP-5442: Implement SCA firm permissions

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -28,6 +28,10 @@ class Provider < ApplicationRecord
     ProviderDetailsCreator.call(self)
   end
 
+  def sca_permissions?
+    user_permissions.map(&:role).include?("special_children_act")
+  end
+
   def user_permissions
     permissions.empty? ? firm_permissions : permissions
   end

--- a/app/services/legal_framework/proceeding_types/all.rb
+++ b/app/services/legal_framework/proceeding_types/all.rb
@@ -40,7 +40,7 @@ module LegalFramework
         result = JSON.parse(request.body).map { |pt_hash| ProceedingTypeStruct.new(pt_hash) }
         # TODO: remove the below when the SCA feature flag is removed
         # filter out SCA applications
-        result.select!(&:not_sca?) unless Setting.special_childrens_act?
+        result.select!(&:not_sca?) unless Setting.special_childrens_act? && @legal_aid_application.provider.sca_permissions?
 
         # TODO: remove the below when the PLF feature flag is removed
         # Filter out PLF applications

--- a/app/views/providers/has_national_insurance_numbers/show.html.erb
+++ b/app/views/providers/has_national_insurance_numbers/show.html.erb
@@ -9,7 +9,7 @@
 
     <%= form.govuk_radio_buttons_fieldset(:has_national_insurance_number,
                                           legend: { text: page_title, size: "xl", tag: "h1" },
-                                          hint: { text: Setting.special_childrens_act? ? nil : t(".hint") }) do %>
+                                          hint: { text: Setting.special_childrens_act? && @legal_aid_application.provider.sca_permissions? ? nil : t(".hint") }) do %>
 
       <%= form.govuk_radio_button(
             :has_national_insurance_number,

--- a/db/seeds/permissions.rb
+++ b/db/seeds/permissions.rb
@@ -1,6 +1,7 @@
 class PermissionsPopulator
   ROLES = {
     # "example.permission.group" => "Description of example group",
+    "special_children_act" => "Allow the firm to access SCA proceedings",
   }.freeze
 
   def self.run

--- a/features/cassettes/Adding_an_SCA_Secure_Accommodation_Order_proceeding_sets_all_client_involvement_types_to_Child/When_a_provider_is_adding_proceedings_and_only_adds_a_Secure_Accommodation_Order.yml
+++ b/features/cassettes/Adding_an_SCA_Secure_Accommodation_Order_proceeding_sets_all_client_involvement_types_to_Child/When_a_provider_is_adding_proceedings_and_only_adds_a_Secure_Accommodation_Order.yml
@@ -15,7 +15,7 @@ http_interactions:
       message: OK
     headers:
       date:
-      - Tue, 05 Nov 2024 11:30:24 GMT
+      - Tue, 12 Nov 2024 11:00:34 GMT
       content-type:
       - application/json;charset=UTF-8
       transfer-encoding:
@@ -37,8 +37,8 @@ http_interactions:
       string: "{\r\n  \"header\" : {\r\n    \"uri\" : \"https://api.os.uk/search/places/v1/postcode?lr=EN&postcode=SW1H9EA\",\r\n
         \   \"query\" : \"postcode=SW1H9EA\",\r\n    \"offset\" : 0,\r\n    \"totalresults\"
         : 5,\r\n    \"format\" : \"JSON\",\r\n    \"dataset\" : \"DPA\",\r\n    \"lr\"
-        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"113\",\r\n    \"lastupdate\"
-        : \"2024-11-04\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
+        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"114\",\r\n    \"lastupdate\"
+        : \"2024-11-11\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
         : [ {\r\n    \"DPA\" : {\r\n      \"UPRN\" : \"100023337883\",\r\n      \"UDPRN\"
         : \"23749699\",\r\n      \"ADDRESS\" : \"84, PETTY FRANCE, LONDON, SW1H 9EA\",\r\n
         \     \"BUILDING_NUMBER\" : \"84\",\r\n      \"THOROUGHFARE_NAME\" : \"PETTY
@@ -133,7 +133,7 @@ http_interactions:
         \     \"BLPU_STATE_DATE\" : \"15/06/2020\",\r\n      \"LANGUAGE\" : \"EN\",\r\n
         \     \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\" : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\"
         : \"1N\"\r\n    }\r\n  } ]\r\n}"
-  recorded_at: Tue, 05 Nov 2024 11:30:24 GMT
+  recorded_at: Tue, 12 Nov 2024 11:00:34 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
@@ -151,7 +151,7 @@ http_interactions:
       message: OK
     headers:
       date:
-      - Tue, 05 Nov 2024 11:30:25 GMT
+      - Tue, 12 Nov 2024 11:00:35 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -171,13 +171,13 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"7ea34d937561546e889000733c1bfb66"
+      - W/"54185048beea547c7317187ff4b17094"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 99be5fc4c21ce7ed124c6f79e245806b
+      - '09e0931cdd83d2f242882694615600ab'
       x-runtime:
-      - '0.060411'
+      - '0.154016'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -200,9 +200,6 @@ http_interactions:
         be represented on an application for an adoption order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM04","meaning":"Secure accommodation order","description":"to
         be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07E","meaning":"Care order - enforcement
-        - discharge","description":"to be represented on an application to discharge
-        a care order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM29A","meaning":"Exclusion requirement
         - appeal","description":"to be represented on an application to vary/discharge
         an exclusion requirement.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
@@ -225,27 +222,35 @@ http_interactions:
         on an application to vary or discharge a contact order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM30E","meaning":"Placement order - enforcement","description":"to
         be represented on an application for a placement order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J
-        - amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        law family (PLF)"},{"ccms_code":"PBM21","meaning":"Specific issue order -
+        vary or discharge","description":"to be represented on an application to vary
+        or discharge a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM02","meaning":"Adoption - not being held
+        in family proceedings court","description":"to be represented on an application
+        for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32A","meaning":"Special guardianship order
+        - appeal","description":"to be represented on an application for a Special
+        Guardianship Order . Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29","meaning":"Exclusion requirement","description":"to
+        be represented on an application to vary/discharge an exclusion requirement.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J
+        - appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
         only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM13A","meaning":"Substitute supervision
-        with care - appeal","description":"to be represented on an application to
-        substitute a supervision order with care order under section 39 (4) Children
-        Act 1989. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27","meaning":"Emergency protection order","description":"to
-        be represented on an application for or to extend an emergency protection
-        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order - where the child(ren) will live. Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        8 children (S8)"},{"ccms_code":"PBM08A","meaning":"Education supervision order
+        - appeal","description":"to be represented on an application for an education
+        supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27E","meaning":"Emergency protection order
+        - enforcement","description":"to be represented on an application for or to
+        extend an emergency protection order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
         (CAO) - residence - enforcement","description":"to be represented on an application
         for a child arrangements order –where the child(ren) will live. Enforcement
         only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
@@ -281,12 +286,261 @@ http_interactions:
         8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
         enforcement","description":"to be represented on an application for a specific
         issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM06A","meaning":"Supervision order - appeal
+        8 children (S8)"},{"ccms_code":"PB026","meaning":"Emergency protection order","description":"to
+        be represented on an application for an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM06A","meaning":"Supervision order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM07","meaning":"Care order - discharge","description":"to
+        be represented on an application to discharge a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24A","meaning":"Supervision order - appeal","description":"to
+        be represented on an application for a supervision order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM39A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order - where the child(ren) will live. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18","meaning":"Child arrangements order
+        (CAO) - contact - vary or discharge","description":"to be represented on an
+        application to vary or discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32","meaning":"Special guardianship order","description":"to
+        be represented on an application for a Special Guardianship Order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM20","meaning":"Prohibited steps order
         - vary or discharge","description":"to be represented on an application to
-        vary or discharge a supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        vary or discharge a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM13","meaning":"Substitute supervision
         with care","description":"to be represented on an application to substitute
         a supervision order with care order under section 39 (4) Children Act 1989.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM45E","meaning":"Adoption order - parent
+        or parental responsibility - enforcement","description":"To represent a parent
+        or person with parental responsibility on an application for a placement order.
+        Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM30","meaning":"Placement order","description":"to
+        be represented on an application for a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM10","meaning":"Child assessment order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27A","meaning":"Emergency protection order
+        - appeal","description":"to be represented on an application for or to extend
+        an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary or discharge","description":"to be represented
+        on an application to vary or discharge a residence order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
+        for an injunction, order or declaration under the inherent jurisdiction of
+        the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
+        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM07A","meaning":"Care order - appeal - discharge","description":"to
+        be represented on an application to discharge a care order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM28","meaning":"Emergency protection order
+        - discharge","description":"to be represented on an application to discharge
+        an emergency protection order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM17A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM22","meaning":"Parental responsibility","description":"to
+        be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM36A","meaning":"Care order - joined party
+        - appeal","description":"to be represented on an application for a care order
+        Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM17","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM37","meaning":"Supervision order - joined
+        party","description":"to be represented on an application for a supervision
+        order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary or discharge","description":"to be
+        represented on an application to vary or discharge a residence order. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE099E","meaning":"Amd enforcement-breach-S8","description":"to
+        be represented on an application, following breach, for an amendment to an
+        enforcement order or for a further enforcement order under section 11J and
+        Schedule A1 Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PB003","meaning":"Child assessment order","description":"to
+        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PB004","meaning":"Emergency protection
+        order - extend","description":"to be represented on an application for or
+        to extend an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM26","meaning":"Child assessment order","description":"to
+        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM33E","meaning":"Revocation placement order
+        - enforcement","description":"to be represented on an application for revocation
+        of a placement order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM07E","meaning":"Care order - enforcement
+        - discharge","description":"to be represented on an application to discharge
+        a care order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27","meaning":"Emergency protection order","description":"to
+        be represented on an application for or to extend an emergency protection
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM39E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order - where the child(ren) will live. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
+        - appeal","description":"to be represented on an application for a prohibited
+        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM20A","meaning":"Prohibited steps order
+        - appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM26A","meaning":"Child assessment order
+        - appeal","description":"to be represented on an application for a child assessment
+        order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM16A","meaning":"Prohibited steps order - appeal","description":"to
+        be represented on an application for a prohibited steps order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary
+        or discharge","description":"to be represented on an application to extend,
+        vary or discharge an order under Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM35E","meaning":"Special guardianship order -
+        enforcement - vary or discharge","description":"To be represented on an application
+        for variation/discharge of a special guardianship order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM16","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
+        committal","description":"to be represented on an application for committal
+        and for an enforcement order under section 11J Children Act 1989. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM16E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM11E","meaning":"End contact with a child
+        in care - enforcement","description":"to be represented on an application
+        to terminate contact with a child/children in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32E","meaning":"Special guardianship order
+        - enforcement","description":"to be represented on an application for a Special
+        Guardianship Order . Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM21E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM33A","meaning":"Revocation placement order
+        - appeal","description":"to be represented on an application for revocation
+        of a placement order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24","meaning":"Supervision order","description":"to
+        be represented on an application for a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM11","meaning":"End contact with a child
+        in care","description":"to be represented on an application to terminate contact
+        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB005","meaning":"Emergency protection order
+        - discharge","description":"to be represented on an application to discharge
+        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"SE007","meaning":"Prohibited steps order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PB006","meaning":"Secure accommodation order","description":"to
+        be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM22A","meaning":"Parental responsibility
+        - appeal","description":"to be represented on an application for parental
+        responsibility.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM05","meaning":"Contact with a child in
+        care","description":"to be represented on an application for contact with
+        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary or discharge","description":"to be represented
+        on an application to vary or discharge a contact order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM35","meaning":"Special guardianship order
+        - vary or discharge","description":"To be represented on an application for
+        variation/discharge of a special guardianship order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA002","meaning":"Protection from harassment
+        act 1997 under section 5 - vary or discharge","description":"to be represented
+        on an application to vary or discharge an order under section 5 Protection
+        from Harassment Act 1997 where the parties are associated persons (as defined
+        by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM39","meaning":"Child arrangements order (CAO)
+        - residence","description":"to be represented on an application for a child
+        arrangements order - where the child(ren) will live.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM28A","meaning":"Emergency protection order
+        - appeal - discharge","description":"to be represented on an application to
+        discharge an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
+        - appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM09A","meaning":"Recovery of children order
+        - appeal","description":"to be represented on an application for the recovery
+        of a child/children.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM04E","meaning":"Secure accommodation order
+        - enforcement","description":"to be represented on an application for a secure
+        accommodation order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM01A","meaning":"Declaration for overseas
+        adoption - appeal","description":"to be represented on an application for
+        a declaration as to an overseas adoption.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM10A","meaning":"Child assessment order
+        - appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a child assessment order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE014","meaning":"Child arrangements order
+        (CAO) - residence","description":"to be represented on an application for
+        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM35A","meaning":"Special guardianship order
+        - appeal - vary or discharge","description":"To be represented on an application
+        for variation/discharge of a special guardianship order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM26E","meaning":"Child assessment order
+        - enforcement","description":"to be represented on an application for a child
+        assessment order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM05E","meaning":"Contact with a child in
+        care - enforcement","description":"to be represented on an application for
+        contact with a child in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM09E","meaning":"Recovery of children order
+        - enforcement","description":"to be represented on an application for the
+        recovery of a child/children.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J - amendment
+        following breach","description":"to be represented on an application, following
+        breach, for an amendment to an enforcement order or for a further enforcement
+        order under section 11J and Schedule A1 Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM13A","meaning":"Substitute supervision
+        with care - appeal","description":"to be represented on an application to
+        substitute a supervision order with care order under section 39 (4) Children
+        Act 1989. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"SE016","meaning":"Child arrangements order
         (CAO) - residence - vary","description":"to be represented on an application
         to vary or discharge a child arrangements order –where the child(ren) will
@@ -294,18 +548,149 @@ http_interactions:
         8 children (S8)"},{"ccms_code":"PBM20E","meaning":"Prohibited steps order
         - enforcement - vary or discharge","description":"to be represented on an
         application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary or discharge","description":"to be represented
-        on an application to vary or discharge a residence order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM19E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary or discharge","description":"to be
-        represented on an application to vary or discharge a residence order. Enforcement
+        law family (PLF)"},{"ccms_code":"PBM38A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order - who the child(ren) spend time with. Appeals
         only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM33","meaning":"Revocation placement order","description":"to
+        be represented on an application for revocation of a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM06E","meaning":"Supervision order - enforcement
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM21A","meaning":"Specific issue order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM38E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order - who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM08E","meaning":"Education supervision
+        order - enforcement","description":"to be represented on an application for
+        an education supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM23A","meaning":"Care order - appeal","description":"to
+        be represented on an application for a care order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM05A","meaning":"Contact with a child in
+        care - appeal","description":"to be represented on an application for contact
+        with a child in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19","meaning":"Child arrangements order
+        (CAO) - residence - vary or discharge","description":"to be represented on
+        an application to vary or discharge a residence order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM40","meaning":"Placement order - parent
+        or parental responsibility","description":"To represent a parent or person
+        with parental responsibility on an application for a placement order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM40E","meaning":"Injunction under Human
+        rights act 1998","description":"to be represented on an appeal to the Judge
+        against a decision of the District Judge or Master in an action between the
+        client and the opponent(s).","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM45","meaning":"Declaration of parentage","description":"To
+        represent a parent or person with parental responsibility on an application
+        for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM04A","meaning":"Secure accommodation order
+        - appeal","description":"to be represented on an application for a secure
+        accommodation order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM37A","meaning":"Supervision order - joined
+        party - appeal","description":"to be represented on an application for a supervision
+        order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"}]'
+  recorded_at: Tue, 12 Nov 2024 11:00:35 GMT
+- request:
+    method: post
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
+    body:
+      encoding: UTF-8
+      string: '{"current_proceedings":[],"allowed_categories":["MAT"],"search_term":""}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v2.12.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Tue, 12 Nov 2024 11:00:37 GMT
+      content-type:
+      - application/json; charset=utf-8
+      content-length:
+      - '52632'
+      connection:
+      - keep-alive
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      x-permitted-cross-domain-policies:
+      - none
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      vary:
+      - Accept, Origin
+      etag:
+      - W/"54185048beea547c7317187ff4b17094"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 60312af26103bdce5e5b5a4eec7d5379
+      x-runtime:
+      - '0.206942'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '[{"ccms_code":"PBM06","meaning":"Supervision order - vary or discharge","description":"to
+        be represented on an application to vary or discharge a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB059","meaning":"Supervision order","description":"to
+        be represented on an application for a supervision order","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM01","meaning":"Declaration for overseas
+        adoption","description":"to be represented on an application for a declaration
+        as to an overseas adoption.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM02E","meaning":"Adoption order - enforcement","description":"to
+        be represented on an application for an adoption order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36E","meaning":"Care order - joined party
+        - enforcement","description":"to be represented on an application for a care
+        order Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB057","meaning":"Care order","description":"to
+        be represented on an application for a care order","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM02A","meaning":"Adoption order - appeal","description":"to
+        be represented on an application for an adoption order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM04","meaning":"Secure accommodation order","description":"to
+        be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29A","meaning":"Exclusion requirement
+        - appeal","description":"to be represented on an application to vary/discharge
+        an exclusion requirement.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29E","meaning":"Exclusion requirement
+        - enforcement","description":"to be represented on an application to vary/discharge
+        an exclusion requirement.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM23E","meaning":"Care order - enforcement","description":"to
+        be represented on an application for a care order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24E","meaning":"Supervision order - enforcement","description":"to
+        be represented on an application for a supervision order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM17E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM30A","meaning":"Placement order - appeal","description":"to
+        be represented on an application for a placement order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36","meaning":"Care order - joined party","description":"to
+        be represented on an application for a care order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary or discharge","description":"to be represented
+        on an application to vary or discharge a contact order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM30E","meaning":"Placement order - enforcement","description":"to
+        be represented on an application for a placement order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM21","meaning":"Specific issue order -
         vary or discharge","description":"to be represented on an application to vary
         or discharge a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
@@ -334,390 +719,7 @@ http_interactions:
         (CAO) - contact - enforcement - vary","description":"to be represented on
         an application to vary/discharge a child arrangements order-who the child(ren)
         spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PB026","meaning":"Emergency protection order","description":"to
-        be represented on an application for an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"SE099E","meaning":"Amd enforcement-breach-S8","description":"to
-        be represented on an application, following breach, for an amendment to an
-        enforcement order or for a further enforcement order under section 11J and
-        Schedule A1 Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PB003","meaning":"Child assessment order","description":"to
-        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB004","meaning":"Emergency protection
-        order - extend","description":"to be represented on an application for or
-        to extend an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM07","meaning":"Care order - discharge","description":"to
-        be represented on an application to discharge a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26","meaning":"Child assessment order","description":"to
-        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
-        high court injunction","description":"to be represented on an application
-        for an injunction, order or declaration under the inherent jurisdiction of
-        the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM04A","meaning":"Secure accommodation order
-        - appeal","description":"to be represented on an application for a secure
-        accommodation order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11","meaning":"End contact with a child
-        in care","description":"to be represented on an application to terminate contact
-        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
-        (FGM) protection order","description":"To be represented on an application
-        for a Female Genital Mutilation Protection Order under the Female Genital
-        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"PBM20A","meaning":"Prohibited steps order - appeal
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26A","meaning":"Child assessment order
-        - appeal","description":"to be represented on an application for a child assessment
-        order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"PBM16A","meaning":"Prohibited steps order - appeal","description":"to
-        be represented on an application for a prohibited steps order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PB005","meaning":"Emergency protection order
-        - discharge","description":"to be represented on an application to discharge
-        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PBM24A","meaning":"Supervision order -
-        appeal","description":"to be represented on an application for a supervision
-        order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order - where the child(ren) will live. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18","meaning":"Child arrangements order
-        (CAO) - contact - vary or discharge","description":"to be represented on an
-        application to vary or discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM21E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33A","meaning":"Revocation placement order
-        - appeal","description":"to be represented on an application for revocation
-        of a placement order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32","meaning":"Special guardianship order","description":"to
-        be represented on an application for a Special Guardianship Order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary
-        or discharge","description":"to be represented on an application to extend,
-        vary or discharge an order under Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"PBM35E","meaning":"Special guardianship order -
-        enforcement - vary or discharge","description":"To be represented on an application
-        for variation/discharge of a special guardianship order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33E","meaning":"Revocation placement order
-        - enforcement","description":"to be represented on an application for revocation
-        of a placement order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM16","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM16E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20","meaning":"Prohibited steps order
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE007","meaning":"Prohibited steps order
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM37A","meaning":"Supervision order - joined
-        party - appeal","description":"to be represented on an application for a supervision
-        order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PB006","meaning":"Secure accommodation order","description":"to
-        be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PBM22A","meaning":"Parental responsibility
-        - appeal","description":"to be represented on an application for parental
-        responsibility.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05","meaning":"Contact with a child in
-        care","description":"to be represented on an application for contact with
-        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary or discharge","description":"to be represented
-        on an application to vary or discharge a contact order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"DA002","meaning":"Protection from harassment
-        act 1997 under section 5 - vary or discharge","description":"to be represented
-        on an application to vary or discharge an order under section 5 Protection
-        from Harassment Act 1997 where the parties are associated persons (as defined
-        by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"PBM35","meaning":"Special guardianship order -
-        vary or discharge","description":"To be represented on an application for
-        variation/discharge of a special guardianship order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39","meaning":"Child arrangements order
-        (CAO) - residence","description":"to be represented on an application for
-        a child arrangements order - where the child(ren) will live.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM28A","meaning":"Emergency protection order
-        - appeal - discharge","description":"to be represented on an application to
-        discharge an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM09A","meaning":"Recovery of children order
-        - appeal","description":"to be represented on an application for the recovery
-        of a child/children.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM04E","meaning":"Secure accommodation order
-        - enforcement","description":"to be represented on an application for a secure
-        accommodation order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM01A","meaning":"Declaration for overseas
-        adoption - appeal","description":"to be represented on an application for
-        a declaration as to an overseas adoption.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM05E","meaning":"Contact with a child in
-        care - enforcement","description":"to be represented on an application for
-        contact with a child in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order - who the child(ren) spend time with. Appeals
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11E","meaning":"End contact with a child
-        in care - enforcement","description":"to be represented on an application
-        to terminate contact with a child/children in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM09E","meaning":"Recovery of children order
-        - enforcement","description":"to be represented on an application for the
-        recovery of a child/children.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32E","meaning":"Special guardianship order
-        - enforcement","description":"to be represented on an application for a Special
-        Guardianship Order . Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33","meaning":"Revocation placement order","description":"to
-        be represented on an application for revocation of a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM22","meaning":"Parental responsibility","description":"to
-        be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM35A","meaning":"Special guardianship order
-        - appeal - vary or discharge","description":"To be represented on an application
-        for variation/discharge of a special guardianship order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM10A","meaning":"Child assessment order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a child assessment order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE014","meaning":"Child arrangements order
-        (CAO) - residence","description":"to be represented on an application for
-        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM26E","meaning":"Child assessment order
-        - enforcement","description":"to be represented on an application for a child
-        assessment order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06E","meaning":"Supervision order - enforcement
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36A","meaning":"Care order - joined party
-        - appeal","description":"to be represented on an application for a care order
-        Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
-        order","description":"to be represented on an application for a forced marriage
-        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"PBM45E","meaning":"Adoption order - parent or parental
-        responsibility - enforcement","description":"To represent a parent or person
-        with parental responsibility on an application for a placement order. Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30","meaning":"Placement order","description":"to
-        be represented on an application for a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM10","meaning":"Child assessment order
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27A","meaning":"Emergency protection order
-        - appeal","description":"to be represented on an application for or to extend
-        an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37","meaning":"Supervision order - joined
-        party","description":"to be represented on an application for a supervision
-        order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order - who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM08E","meaning":"Education supervision
-        order - enforcement","description":"to be represented on an application for
-        an education supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23A","meaning":"Care order - appeal","description":"to
-        be represented on an application for a care order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05A","meaning":"Contact with a child in
-        care - appeal","description":"to be represented on an application for contact
-        with a child in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19","meaning":"Child arrangements order
-        (CAO) - residence - vary or discharge","description":"to be represented on
-        an application to vary or discharge a residence order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM24","meaning":"Supervision order","description":"to
-        be represented on an application for a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07A","meaning":"Care order - appeal -
-        discharge","description":"to be represented on an application to discharge
-        a care order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM28","meaning":"Emergency protection order
-        - discharge","description":"to be represented on an application to discharge
-        an emergency protection order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM40","meaning":"Placement order - parent
-        or parental responsibility","description":"To represent a parent or person
-        with parental responsibility on an application for a placement order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM40E","meaning":"Injunction under Human
-        rights act 1998","description":"to be represented on an appeal to the Judge
-        against a decision of the District Judge or Master in an action between the
-        client and the opponent(s).","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM45","meaning":"Declaration of parentage","description":"To
-        represent a parent or person with parental responsibility on an application
-        for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"}]'
-  recorded_at: Tue, 05 Nov 2024 11:30:25 GMT
-- request:
-    method: post
-    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
-    body:
-      encoding: UTF-8
-      string: '{"current_proceedings":[],"allowed_categories":["MAT"],"search_term":""}'
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Faraday v2.12.0
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      date:
-      - Tue, 05 Nov 2024 11:30:27 GMT
-      content-type:
-      - application/json; charset=utf-8
-      content-length:
-      - '52632'
-      connection:
-      - keep-alive
-      x-frame-options:
-      - SAMEORIGIN
-      x-xss-protection:
-      - '0'
-      x-content-type-options:
-      - nosniff
-      x-permitted-cross-domain-policies:
-      - none
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      vary:
-      - Accept, Origin
-      etag:
-      - W/"7ea34d937561546e889000733c1bfb66"
-      cache-control:
-      - max-age=0, private, must-revalidate
-      x-request-id:
-      - 65d31d4e5ffef9ed799d7fd21fbd3904
-      x-runtime:
-      - '0.162427'
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-    body:
-      encoding: UTF-8
-      string: '[{"ccms_code":"PBM06","meaning":"Supervision order - vary or discharge","description":"to
-        be represented on an application to vary or discharge a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PB059","meaning":"Supervision order","description":"to
-        be represented on an application for a supervision order","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PBM01","meaning":"Declaration for overseas
-        adoption","description":"to be represented on an application for a declaration
-        as to an overseas adoption.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM02E","meaning":"Adoption order - enforcement","description":"to
-        be represented on an application for an adoption order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36E","meaning":"Care order - joined party
-        - enforcement","description":"to be represented on an application for a care
-        order Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PB057","meaning":"Care order","description":"to
-        be represented on an application for a care order","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PBM02A","meaning":"Adoption order - appeal","description":"to
-        be represented on an application for an adoption order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM04","meaning":"Secure accommodation order","description":"to
-        be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07E","meaning":"Care order - enforcement
-        - discharge","description":"to be represented on an application to discharge
-        a care order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29A","meaning":"Exclusion requirement
-        - appeal","description":"to be represented on an application to vary/discharge
-        an exclusion requirement.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29E","meaning":"Exclusion requirement
-        - enforcement","description":"to be represented on an application to vary/discharge
-        an exclusion requirement.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23E","meaning":"Care order - enforcement","description":"to
-        be represented on an application for a care order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24E","meaning":"Supervision order - enforcement","description":"to
-        be represented on an application for a supervision order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30A","meaning":"Placement order - appeal","description":"to
-        be represented on an application for a placement order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36","meaning":"Care order - joined party","description":"to
-        be represented on an application for a care order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary or discharge","description":"to be represented
-        on an application to vary or discharge a contact order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30E","meaning":"Placement order - enforcement","description":"to
-        be represented on an application for a placement order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J
-        - amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM13A","meaning":"Substitute supervision
-        with care - appeal","description":"to be represented on an application to
-        substitute a supervision order with care order under section 39 (4) Children
-        Act 1989. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27","meaning":"Emergency protection order","description":"to
-        be represented on an application for or to extend an emergency protection
-        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order - where the child(ren) will live. Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
         (CAO) - residence - enforcement","description":"to be represented on an application
         for a child arrangements order –where the child(ren) will live. Enforcement
         only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
@@ -753,62 +755,89 @@ http_interactions:
         8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
         enforcement","description":"to be represented on an application for a specific
         issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM06A","meaning":"Supervision order - appeal
+        8 children (S8)"},{"ccms_code":"PB026","meaning":"Emergency protection order","description":"to
+        be represented on an application for an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM06A","meaning":"Supervision order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM07","meaning":"Care order - discharge","description":"to
+        be represented on an application to discharge a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24A","meaning":"Supervision order - appeal","description":"to
+        be represented on an application for a supervision order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM39A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order - where the child(ren) will live. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18","meaning":"Child arrangements order
+        (CAO) - contact - vary or discharge","description":"to be represented on an
+        application to vary or discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32","meaning":"Special guardianship order","description":"to
+        be represented on an application for a Special Guardianship Order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM20","meaning":"Prohibited steps order
         - vary or discharge","description":"to be represented on an application to
-        vary or discharge a supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        vary or discharge a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM13","meaning":"Substitute supervision
         with care","description":"to be represented on an application to substitute
         a supervision order with care order under section 39 (4) Children Act 1989.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM20E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM45E","meaning":"Adoption order - parent
+        or parental responsibility - enforcement","description":"To represent a parent
+        or person with parental responsibility on an application for a placement order.
+        Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM30","meaning":"Placement order","description":"to
+        be represented on an application for a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM10","meaning":"Child assessment order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27A","meaning":"Emergency protection order
+        - appeal","description":"to be represented on an application for or to extend
+        an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM19A","meaning":"Child arrangements order
         (CAO) - residence - appeal - vary or discharge","description":"to be represented
         on an application to vary or discharge a residence order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
         be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM19E","meaning":"Child arrangements order
+        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
+        for an injunction, order or declaration under the inherent jurisdiction of
+        the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
+        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM07A","meaning":"Care order - appeal - discharge","description":"to
+        be represented on an application to discharge a care order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM28","meaning":"Emergency protection order
+        - discharge","description":"to be represented on an application to discharge
+        an emergency protection order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM17A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM22","meaning":"Parental responsibility","description":"to
+        be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM36A","meaning":"Care order - joined party
+        - appeal","description":"to be represented on an application for a care order
+        Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM17","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM37","meaning":"Supervision order - joined
+        party","description":"to be represented on an application for a supervision
+        order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19E","meaning":"Child arrangements order
         (CAO) - residence - enforcement - vary or discharge","description":"to be
         represented on an application to vary or discharge a residence order. Enforcement
         only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21","meaning":"Specific issue order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM02","meaning":"Adoption - not being held
-        in family proceedings court","description":"to be represented on an application
-        for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32A","meaning":"Special guardianship order
-        - appeal","description":"to be represented on an application for a Special
-        Guardianship Order . Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29","meaning":"Exclusion requirement","description":"to
-        be represented on an application to vary/discharge an exclusion requirement.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J
-        - appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM08A","meaning":"Education supervision order
-        - appeal","description":"to be represented on an application for an education
-        supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27E","meaning":"Emergency protection order
-        - enforcement","description":"to be represented on an application for or to
-        extend an emergency protection order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PB026","meaning":"Emergency protection order","description":"to
-        be represented on an application for an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"SE099E","meaning":"Amd enforcement-breach-S8","description":"to
+        law family (PLF)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE099E","meaning":"Amd enforcement-breach-S8","description":"to
         be represented on an application, following breach, for an amendment to an
         enforcement order or for a further enforcement order under section 11J and
         Schedule A1 Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
@@ -827,43 +856,27 @@ http_interactions:
         (CAO) - contact - enforcement","description":"to be represented on an application
         for a child arrangements order-who the child(ren) spend time with. Enforcement
         only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM07","meaning":"Care order - discharge","description":"to
-        be represented on an application to discharge a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26","meaning":"Child assessment order","description":"to
+        8 children (S8)"},{"ccms_code":"PBM26","meaning":"Child assessment order","description":"to
         be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
-        high court injunction","description":"to be represented on an application
-        for an injunction, order or declaration under the inherent jurisdiction of
-        the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM04A","meaning":"Secure accommodation order
-        - appeal","description":"to be represented on an application for a secure
-        accommodation order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11","meaning":"End contact with a child
-        in care","description":"to be represented on an application to terminate contact
-        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
-        (FGM) protection order","description":"To be represented on an application
-        for a Female Genital Mutilation Protection Order under the Female Genital
-        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"PBM20A","meaning":"Prohibited steps order - appeal
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM33E","meaning":"Revocation placement order
+        - enforcement","description":"to be represented on an application for revocation
+        of a placement order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM07E","meaning":"Care order - enforcement
+        - discharge","description":"to be represented on an application to discharge
+        a care order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27","meaning":"Emergency protection order","description":"to
+        be represented on an application for or to extend an emergency protection
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM39E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order - where the child(ren) will live. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
+        - appeal","description":"to be represented on an application for a prohibited
+        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM20A","meaning":"Prohibited steps order
+        - appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM26A","meaning":"Child assessment order
         - appeal","description":"to be represented on an application for a child assessment
         order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
@@ -872,39 +885,12 @@ http_interactions:
         Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
         abuse (DA)"},{"ccms_code":"PBM16A","meaning":"Prohibited steps order - appeal","description":"to
         be represented on an application for a prohibited steps order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PB005","meaning":"Emergency protection order
-        - discharge","description":"to be represented on an application to discharge
-        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PBM24A","meaning":"Supervision order -
-        appeal","description":"to be represented on an application for a supervision
-        order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order - where the child(ren) will live. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18","meaning":"Child arrangements order
-        (CAO) - contact - vary or discharge","description":"to be represented on an
-        application to vary or discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM21E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33A","meaning":"Revocation placement order
-        - appeal","description":"to be represented on an application for revocation
-        of a placement order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32","meaning":"Special guardianship order","description":"to
-        be represented on an application for a Special Guardianship Order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary
         or discharge","description":"to be represented on an application to extend,
         vary or discharge an order under Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
         abuse (DA)"},{"ccms_code":"PBM35E","meaning":"Special guardianship order -
         enforcement - vary or discharge","description":"To be represented on an application
         for variation/discharge of a special guardianship order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33E","meaning":"Revocation placement order
-        - enforcement","description":"to be represented on an application for revocation
-        of a placement order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM16","meaning":"Prohibited steps order","description":"to
         be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
@@ -917,20 +903,38 @@ http_interactions:
         8 children (S8)"},{"ccms_code":"PBM16E","meaning":"Prohibited steps order
         - enforcement","description":"to be represented on an application for a prohibited
         steps order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20","meaning":"Prohibited steps order
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE007","meaning":"Prohibited steps order
+        law family (PLF)"},{"ccms_code":"PBM11E","meaning":"End contact with a child
+        in care - enforcement","description":"to be represented on an application
+        to terminate contact with a child/children in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32E","meaning":"Special guardianship order
+        - enforcement","description":"to be represented on an application for a Special
+        Guardianship Order . Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM21E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM33A","meaning":"Revocation placement order
+        - appeal","description":"to be represented on an application for revocation
+        of a placement order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24","meaning":"Supervision order","description":"to
+        be represented on an application for a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM11","meaning":"End contact with a child
+        in care","description":"to be represented on an application to terminate contact
+        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB005","meaning":"Emergency protection order
+        - discharge","description":"to be represented on an application to discharge
+        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"SE007","meaning":"Prohibited steps order
         - vary or discharge","description":"to be represented on an application to
         vary or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
         8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
         revocation - appeal","description":"to be represented on an application for
         the revocation of an enforcement order under section 11J and Schedule A1 Children
         Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM37A","meaning":"Supervision order - joined
-        party - appeal","description":"to be represented on an application for a supervision
-        order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PB006","meaning":"Secure accommodation order","description":"to
+        8 children (S8)"},{"ccms_code":"PB006","meaning":"Secure accommodation order","description":"to
         be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PBM22A","meaning":"Parental responsibility
         - appeal","description":"to be represented on an application for parental
@@ -941,17 +945,17 @@ http_interactions:
         law family (PLF)"},{"ccms_code":"PBM18E","meaning":"Child arrangements order
         (CAO) - contact - enforcement - vary or discharge","description":"to be represented
         on an application to vary or discharge a contact order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM35","meaning":"Special guardianship order
+        - vary or discharge","description":"To be represented on an application for
+        variation/discharge of a special guardianship order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"DA002","meaning":"Protection from harassment
         act 1997 under section 5 - vary or discharge","description":"to be represented
         on an application to vary or discharge an order under section 5 Protection
         from Harassment Act 1997 where the parties are associated persons (as defined
         by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"PBM35","meaning":"Special guardianship order -
-        vary or discharge","description":"To be represented on an application for
-        variation/discharge of a special guardianship order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39","meaning":"Child arrangements order
-        (CAO) - residence","description":"to be represented on an application for
-        a child arrangements order - where the child(ren) will live.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        abuse (DA)"},{"ccms_code":"PBM39","meaning":"Child arrangements order (CAO)
+        - residence","description":"to be represented on an application for a child
+        arrangements order - where the child(ren) will live.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM28A","meaning":"Emergency protection order
         - appeal - discharge","description":"to be represented on an application to
         discharge an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
@@ -973,73 +977,65 @@ http_interactions:
         law family (PLF)"},{"ccms_code":"SE013","meaning":"Child arrangements order
         (CAO) - contact","description":"to be represented on an application for a
         child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM05E","meaning":"Contact with a child in
-        care - enforcement","description":"to be represented on an application for
-        contact with a child in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order - who the child(ren) spend time with. Appeals
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11E","meaning":"End contact with a child
-        in care - enforcement","description":"to be represented on an application
-        to terminate contact with a child/children in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM09E","meaning":"Recovery of children order
-        - enforcement","description":"to be represented on an application for the
-        recovery of a child/children.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32E","meaning":"Special guardianship order
-        - enforcement","description":"to be represented on an application for a Special
-        Guardianship Order . Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33","meaning":"Revocation placement order","description":"to
-        be represented on an application for revocation of a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM22","meaning":"Parental responsibility","description":"to
-        be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM35A","meaning":"Special guardianship order
-        - appeal - vary or discharge","description":"To be represented on an application
-        for variation/discharge of a special guardianship order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM10A","meaning":"Child assessment order
+        8 children (S8)"},{"ccms_code":"PBM10A","meaning":"Child assessment order
         - appeal - vary or discharge","description":"to be represented on an application
         to vary or discharge a child assessment order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"SE014","meaning":"Child arrangements order
         (CAO) - residence","description":"to be represented on an application for
         a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM26E","meaning":"Child assessment order
+        8 children (S8)"},{"ccms_code":"PBM35A","meaning":"Special guardianship order
+        - appeal - vary or discharge","description":"To be represented on an application
+        for variation/discharge of a special guardianship order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM26E","meaning":"Child assessment order
         - enforcement","description":"to be represented on an application for a child
         assessment order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06E","meaning":"Supervision order - enforcement
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36A","meaning":"Care order - joined party
-        - appeal","description":"to be represented on an application for a care order
-        Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM05E","meaning":"Contact with a child in
+        care - enforcement","description":"to be represented on an application for
+        contact with a child in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM09E","meaning":"Recovery of children order
+        - enforcement","description":"to be represented on an application for the
+        recovery of a child/children.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
         order","description":"to be represented on an application for a forced marriage
         protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"PBM45E","meaning":"Adoption order - parent or parental
-        responsibility - enforcement","description":"To represent a parent or person
-        with parental responsibility on an application for a placement order. Enforcement
+        abuse (DA)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J - amendment
+        following breach","description":"to be represented on an application, following
+        breach, for an amendment to an enforcement order or for a further enforcement
+        order under section 11J and Schedule A1 Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM13A","meaning":"Substitute supervision
+        with care - appeal","description":"to be represented on an application to
+        substitute a supervision order with care order under section 39 (4) Children
+        Act 1989. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM20E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM38A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order - who the child(ren) spend time with. Appeals
         only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30","meaning":"Placement order","description":"to
-        be represented on an application for a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM10","meaning":"Child assessment order
+        law family (PLF)"},{"ccms_code":"PBM33","meaning":"Revocation placement order","description":"to
+        be represented on an application for revocation of a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM06E","meaning":"Supervision order - enforcement
         - vary or discharge","description":"to be represented on an application to
-        vary or discharge a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27A","meaning":"Emergency protection order
-        - appeal","description":"to be represented on an application for or to extend
-        an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17A","meaning":"Specific issue order -
+        vary or discharge a supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
         appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37","meaning":"Supervision order - joined
-        party","description":"to be represented on an application for a supervision
-        order","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM21A","meaning":"Specific issue order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM38E","meaning":"Child arrangements order
         (CAO) - contact - enforcement","description":"to be represented on an application
         for a child arrangements order - who the child(ren) spend time with. Enforcement
@@ -1058,15 +1054,7 @@ http_interactions:
         law family (PLF)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
         - enforcement","description":"to be represented on an application for a prohibited
         steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PBM24","meaning":"Supervision order","description":"to
-        be represented on an application for a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07A","meaning":"Care order - appeal -
-        discharge","description":"to be represented on an application to discharge
-        a care order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM28","meaning":"Emergency protection order
-        - discharge","description":"to be represented on an application to discharge
-        an emergency protection order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM40","meaning":"Placement order - parent
+        8 children (S8)"},{"ccms_code":"PBM40","meaning":"Placement order - parent
         or parental responsibility","description":"To represent a parent or person
         with parental responsibility on an application for a placement order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM40E","meaning":"Injunction under Human
@@ -1076,8 +1064,14 @@ http_interactions:
         law family (PLF)"},{"ccms_code":"PBM45","meaning":"Declaration of parentage","description":"To
         represent a parent or person with parental responsibility on an application
         for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM04A","meaning":"Secure accommodation order
+        - appeal","description":"to be represented on an application for a secure
+        accommodation order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM37A","meaning":"Supervision order - joined
+        party - appeal","description":"to be represented on an application for a supervision
+        order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"}]'
-  recorded_at: Tue, 05 Nov 2024 11:30:27 GMT
+  recorded_at: Tue, 12 Nov 2024 11:00:37 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/PB003
@@ -1095,7 +1089,7 @@ http_interactions:
       message: OK
     headers:
       date:
-      - Tue, 05 Nov 2024 11:30:27 GMT
+      - Tue, 12 Nov 2024 11:00:37 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1119,9 +1113,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 679033d3326abd38a5742bdab825438f
+      - 5de941cda35f7eaac3868060bd2c908b
       x-runtime:
-      - '0.011332'
+      - '0.027297'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1134,7 +1128,7 @@ http_interactions:
         hearing","description":"Limited to all steps up to and including final hearing
         and any action necessary to implement (but not enforce) the order."}},"service_levels":[{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":true}]}'
-  recorded_at: Tue, 05 Nov 2024 11:30:27 GMT
+  recorded_at: Tue, 12 Nov 2024 11:00:37 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/PB003
@@ -1152,7 +1146,7 @@ http_interactions:
       message: OK
     headers:
       date:
-      - Tue, 05 Nov 2024 11:30:29 GMT
+      - Tue, 12 Nov 2024 11:00:39 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1176,16 +1170,16 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 3c441cf5f53e7cbaafe4d59be1ce8cff
+      - 5a4bb640ecac35502232648d151ce3a1
       x-runtime:
-      - '0.002803'
+      - '0.008187'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"success":true,"client_involvement_type":[{"ccms_code":"D","description":"Respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"}]}'
-  recorded_at: Tue, 05 Nov 2024 11:30:29 GMT
+  recorded_at: Tue, 12 Nov 2024 11:00:39 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
@@ -1203,7 +1197,7 @@ http_interactions:
       message: OK
     headers:
       date:
-      - Tue, 05 Nov 2024 11:30:30 GMT
+      - Tue, 12 Nov 2024 11:00:40 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1223,13 +1217,13 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"88f1f3b74c9f969389b3a5a76b6f46e5"
+      - W/"246596f382307309453d8e8bf500097f"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - f8a097f4af8c44f4fad961a7777125c1
+      - f352bb6d8353bf07326cdead09a5c7a1
       x-runtime:
-      - '0.065870'
+      - '0.087271'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1238,33 +1232,39 @@ http_interactions:
         be represented on an application for a supervision order","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PB057","meaning":"Care order","description":"to
         be represented on an application for a care order","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PB021","meaning":"Contact order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PB030","meaning":"Child arrangements order
         (CAO) - residence","description":"to be represented on an application for
         a child arrangements order-where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PB014","meaning":"End contact with a child
+        in care","description":"to be represented on an application to terminate contact
+        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PB022","meaning":"Residence - vary or discharge","description":"to
         be represented on an application to vary or discharge a residence order.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PB023","meaning":"Prohibited steps order
         - vary or discharge","description":"to be represented on an application to
         vary or discharge a prohibitive steps order.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB024","meaning":"Specific issue order
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a specific issues order.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB014","meaning":"End contact with a child
-        in care","description":"to be represented on an application to terminate contact
-        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PB026","meaning":"Emergency protection
         order","description":"to be represented on an application for an emergency
         protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PB019","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PB051","meaning":"Placement order","description":"to
+        be represented on an application for a placement order .","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PB007","meaning":"Contact with a child
+        in care","description":"to be represented on an application for contact with
+        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PB004","meaning":"Emergency protection
         order - extend","description":"to be represented on an application for or
         to extend an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB019","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PB024","meaning":"Specific issue order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a specific issues order.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PB005","meaning":"Emergency protection
         order - discharge","description":"to be represented on an application to discharge
         an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB020","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PB006","meaning":"Secure accommodation
         order","description":"to be represented on an application for a secure accommodation
         order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
@@ -1279,16 +1279,10 @@ http_interactions:
         child arrangements order-who the child(ren) spend time with","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PB027","meaning":"Parental responsibility","description":"to
         be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB051","meaning":"Placement order","description":"to
-        be represented on an application for a placement order .","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB021","meaning":"Contact order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB007","meaning":"Contact with a child
-        in care","description":"to be represented on an application for contact with
-        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PB020","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"}]'
-  recorded_at: Tue, 05 Nov 2024 11:30:30 GMT
+  recorded_at: Tue, 12 Nov 2024 11:00:40 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
@@ -1306,7 +1300,7 @@ http_interactions:
       message: OK
     headers:
       date:
-      - Tue, 05 Nov 2024 11:30:32 GMT
+      - Tue, 12 Nov 2024 11:00:42 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1326,13 +1320,13 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"88f1f3b74c9f969389b3a5a76b6f46e5"
+      - W/"246596f382307309453d8e8bf500097f"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 204a214881a08530b6dc12ca7894aeca
+      - 040cb7247ea8eb36707705b3136ce36f
       x-runtime:
-      - '0.070379'
+      - '0.086211'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1341,33 +1335,39 @@ http_interactions:
         be represented on an application for a supervision order","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PB057","meaning":"Care order","description":"to
         be represented on an application for a care order","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PB021","meaning":"Contact order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PB030","meaning":"Child arrangements order
         (CAO) - residence","description":"to be represented on an application for
         a child arrangements order-where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PB014","meaning":"End contact with a child
+        in care","description":"to be represented on an application to terminate contact
+        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PB022","meaning":"Residence - vary or discharge","description":"to
         be represented on an application to vary or discharge a residence order.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PB023","meaning":"Prohibited steps order
         - vary or discharge","description":"to be represented on an application to
         vary or discharge a prohibitive steps order.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB024","meaning":"Specific issue order
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a specific issues order.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB014","meaning":"End contact with a child
-        in care","description":"to be represented on an application to terminate contact
-        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PB026","meaning":"Emergency protection
         order","description":"to be represented on an application for an emergency
         protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PB019","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PB051","meaning":"Placement order","description":"to
+        be represented on an application for a placement order .","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PB007","meaning":"Contact with a child
+        in care","description":"to be represented on an application for contact with
+        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PB004","meaning":"Emergency protection
         order - extend","description":"to be represented on an application for or
         to extend an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB019","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PB024","meaning":"Specific issue order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a specific issues order.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PB005","meaning":"Emergency protection
         order - discharge","description":"to be represented on an application to discharge
         an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB020","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PB006","meaning":"Secure accommodation
         order","description":"to be represented on an application for a secure accommodation
         order.","full_s8_only":false,"sca_core":true,"sca_related":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
@@ -1382,16 +1382,10 @@ http_interactions:
         child arrangements order-who the child(ren) spend time with","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PB027","meaning":"Parental responsibility","description":"to
         be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB051","meaning":"Placement order","description":"to
-        be represented on an application for a placement order .","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB021","meaning":"Contact order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB007","meaning":"Contact with a child
-        in care","description":"to be represented on an application for contact with
-        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PB020","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"}]'
-  recorded_at: Tue, 05 Nov 2024 11:30:31 GMT
+  recorded_at: Tue, 12 Nov 2024 11:00:42 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/PB006
@@ -1409,7 +1403,7 @@ http_interactions:
       message: OK
     headers:
       date:
-      - Tue, 05 Nov 2024 11:30:32 GMT
+      - Tue, 12 Nov 2024 11:00:42 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1433,9 +1427,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - bc497dd50860f9a50b89a270f17791f0
+      - 4ad034ec015d07fff107b1a4c48fd8c8
       x-runtime:
-      - '0.013984'
+      - '0.018129'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1449,5 +1443,5 @@ http_interactions:
         hearing","description":"Limited to all steps up to and including final hearing
         and any action necessary to implement (but not enforce) the order."}},"service_levels":[{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":true}]}'
-  recorded_at: Tue, 05 Nov 2024 11:30:32 GMT
+  recorded_at: Tue, 12 Nov 2024 11:00:42 GMT
 recorded_with: VCR 6.3.1

--- a/features/providers/special_children_act/secure_accomodation_order_cit.feature
+++ b/features/providers/special_children_act/secure_accomodation_order_cit.feature
@@ -1,8 +1,9 @@
 Feature: Adding an SCA Secure Accommodation Order proceeding sets all client_involvement_types to Child
   @javascript @vcr
-  Scenario: When a provider is adding proceedings and only adds a
+  Scenario: When a provider is adding proceedings and only adds a Secure Accommodation Order
     Given I start the journey as far as the applicant page
     And the feature flag for special_childrens_act is enabled
+    And the provider has SCA permissions
 
     When I enter name 'Test', 'User'
     Then I choose 'No'

--- a/features/step_definitions/debug_steps.rb
+++ b/features/step_definitions/debug_steps.rb
@@ -17,6 +17,12 @@ When(/^the feature flag for (.*?) is (enabled|disabled)$/) do |flag, enabled|
   Setting.setting.update!("#{flag}": value)
 end
 
+And(/^the provider has SCA permissions$/) do
+  # TODO: Remove when removing Setting.special_children_act
+  sca_permission = Permission.find_by(role: "special_children_act") || create(:permission, :special_children_act)
+  @registered_provider.firm.permissions << sca_permission
+end
+
 And(/^the MTR-A start date is in the past$/) do
   # TODO: Remove when removing Setting.means_test_review_a
   allow(Rails.configuration.x).to receive(:mtr_a_start_date).and_return(Date.yesterday)

--- a/spec/factories/firms.rb
+++ b/spec/factories/firms.rb
@@ -4,6 +4,14 @@ FactoryBot.define do
     name { Faker::Company.name }
   end
 
+  trait :with_sca_permissions do
+    permissions do
+      sca = Permission.find_by(role: "special_children_act")
+      sca = create(:permission, :special_children_act) if sca.nil?
+      [sca]
+    end
+  end
+
   trait :with_no_permissions do
     permissions { [] }
   end

--- a/spec/factories/permissions.rb
+++ b/spec/factories/permissions.rb
@@ -2,5 +2,10 @@ FactoryBot.define do
   factory :permission do
     sequence(:role) { |n| "role_#{n}" }
     sequence(:description) { |n| "The description for role_#{n}" }
+
+    trait :special_children_act do
+      role { "special_children_act" }
+      description { "Allow the firm to access SCA proceedings" }
+    end
   end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -40,6 +40,35 @@ RSpec.describe Provider do
         expect(provider.user_permissions).to be_empty
       end
     end
+
+    context "when the firm has SCA permissions" do
+      let(:firm) { create(:firm, :with_sca_permissions) }
+      let(:provider) { create(:provider, :with_no_permissions, firm:) }
+
+      it "returns a value" do
+        expect(provider.user_permissions).to be_a(ActiveRecord::Relation)
+      end
+    end
+  end
+
+  describe "sca_permissions?" do
+    context "with no permissions for provider and their firm" do
+      let(:firm) { create(:firm, :with_no_permissions) }
+      let(:provider) { create(:provider, :with_no_permissions, firm:) }
+
+      it "returns false" do
+        expect(provider.sca_permissions?).to be false
+      end
+    end
+
+    context "when the firm has SCA permissions" do
+      let(:firm) { create(:firm, :with_sca_permissions) }
+      let(:provider) { create(:provider, :with_no_permissions, firm:) }
+
+      it "returns a value" do
+        expect(provider.sca_permissions?).to be true
+      end
+    end
   end
 
   describe "#cms_apply_role?" do

--- a/spec/services/legal_framework/proceeding_types/all_spec.rb
+++ b/spec/services/legal_framework/proceeding_types/all_spec.rb
@@ -21,8 +21,20 @@ RSpec.describe LegalFramework::ProceedingTypes::All do
     context "when the special children act setting is on" do
       let(:sca_enabled) { true }
 
-      it "returns the expected proceedings" do
-        expect(call.map(&:ccms_code)).to match_array %w[DA001 SE097 DA003 SE016E DA006 PB003]
+      context "and the firm has SCA permissions enabled" do
+        let(:firm) { create(:firm, :with_sca_permissions) }
+        let(:provider) { create(:provider, :with_no_permissions, firm:) }
+        let(:legal_aid_application) { create :legal_aid_application, provider: }
+
+        it "returns the expected proceedings" do
+          expect(call.map(&:ccms_code)).to match_array %w[DA001 SE097 DA003 SE016E DA006 PB003]
+        end
+      end
+
+      context "and the firm does not have SCA permissions enabled" do
+        it "returns the expected proceedings" do
+          expect(call.map(&:ccms_code)).to match_array %w[DA001 SE097 DA003 SE016E DA006]
+        end
       end
     end
 
@@ -44,8 +56,20 @@ RSpec.describe LegalFramework::ProceedingTypes::All do
       let(:sca_enabled) { true }
       let(:plf_enabled) { true }
 
-      it "returns the expected proceedings" do
-        expect(call.map(&:ccms_code)).to match_array %w[DA001 SE097 DA003 SE016E DA006 PB003 PBM01]
+      context "and the firm has SCA permissions enabled" do
+        let(:firm) { create(:firm, :with_sca_permissions) }
+        let(:provider) { create(:provider, :with_no_permissions, firm:) }
+        let(:legal_aid_application) { create :legal_aid_application, provider: }
+
+        it "returns the expected proceedings" do
+          expect(call.map(&:ccms_code)).to match_array %w[DA001 SE097 DA003 SE016E DA006 PB003 PBM01]
+        end
+      end
+
+      context "and the firm does not have SCA permissions enabled" do
+        it "returns the expected proceedings" do
+          expect(call.map(&:ccms_code)).to match_array %w[DA001 SE097 DA003 SE016E DA006 PBM01]
+        end
       end
     end
   end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5442)

This implements a `special_children_act` role in the permissions table
It then ensures that, once the feature flag is enabled, only a provider with the role set is able to search for SCA proceedings 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
