### PR TITLE
ap-5390: update change_of_names interrupt

### DIFF
--- a/app/controllers/providers/proceedings_sca/interrupts_controller.rb
+++ b/app/controllers/providers/proceedings_sca/interrupts_controller.rb
@@ -1,6 +1,7 @@
 module Providers
   module ProceedingsSCA
     class InterruptsController < ProviderBaseController
+      prefix_step_with :proceedings_sca
       def show
         type
       end

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -30,6 +30,7 @@ module Flow
         proceedings_sca_heard_togethers: Steps::ProceedingsSCA::HeardTogethersStep,
         proceedings_sca_heard_as_alternatives: Steps::ProceedingsSCA::HeardAsAlternativesStep,
         proceedings_sca_change_of_names: Steps::ProceedingsSCA::ChangeOfNamesStep,
+        proceedings_sca_interrupts: Steps::ProceedingsSCA::InterruptsStep,
         has_other_proceedings: Steps::ProviderStart::HasOtherProceedingsStep,
         limitations: Steps::ProviderStart::LimitationsStep,
         has_national_insurance_numbers: Steps::ProviderStart::HasNationalInsuranceNumbersStep,

--- a/app/services/flow/steps/proceedings_sca/interrupts_step.rb
+++ b/app/services/flow/steps/proceedings_sca/interrupts_step.rb
@@ -1,0 +1,9 @@
+module Flow
+  module Steps
+    module ProceedingsSCA
+      InterruptsStep = Step.new(
+        path: ->(application) { Steps.urls.providers_legal_aid_application_sca_interrupt_path(application, application.provider_step_params["type"]) },
+      )
+    end
+  end
+end

--- a/app/views/providers/proceedings_sca/interrupts/show.html.erb
+++ b/app/views/providers/proceedings_sca/interrupts/show.html.erb
@@ -6,12 +6,19 @@
       <% if I18n.exists?("providers.proceedings_sca.interrupts.show.#{@type}.paragraph") %>
         <p class="govuk-body"><%= t(".#{@type}.paragraph") %></p>
       <% end %>
-      <p class="govuk-body"><%= t(".#{@type}.options") %></p>
-      <%= govuk_list t(".#{@type}.option_bullets_html"), type: :bullet %>
+      <% unless @type == "change_of_name" %>
+        <p class="govuk-body"><%= t(".#{@type}.options") %></p>
+        <%= govuk_list t(".#{@type}.option_bullets_html"), type: :bullet %>
+      <% end %>
     </div>
 
     <div class='govuk-button-group'>
-      <%= govuk_button_link_to t(".#{@type}.applications"), providers_legal_aid_application_sca_interrupt_path(@legal_aid_application, @type), method: :delete, inverse: true, role: "button" %>
+      <% if @type == "change_of_name" %>
+        <%= govuk_button_link_to t(".#{@type}.change"), providers_legal_aid_application_change_of_names_path, inverse: true, role: "button" %>
+        <%= govuk_button_link_to t(".#{@type}.applications"), in_progress_providers_legal_aid_applications_path, inverse: true, role: "button" %>
+      <% else %>
+        <%= govuk_button_link_to t(".#{@type}.proceedings"), providers_legal_aid_application_sca_interrupt_path(@legal_aid_application, @type), method: :delete, inverse: true, role: "button" %>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1866,7 +1866,7 @@ en:
           change_of_name:
             <<: *default
             title_html: Change of name applications are not eligible for legal aid
-            paragraph: You can go back and change your answer if this is not a change of names application
+            paragraph: You can go back and change your answer if this is not a change of name application.
             change: Change your answer
             applications: Back to your applications
       child_subjects:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1842,7 +1842,7 @@ en:
               - go back and change your answer
               - use legal help
             options: "You can do one of the following:"
-            applications: Select a different proceeding or matter type
+            proceedings: Select a different proceeding or matter type
           heard_as_alternatives:
             <<: *default
             title_html: You cannot submit this application under special children act
@@ -1850,7 +1850,7 @@ en:
             option_bullets_html:
               - check for a different matter type in this service or <a href="https://portal.legalservices.gov.uk/">use CCMS</a>
               - go back and change your answer
-            applications: Check for another matter type
+            proceedings: Check for another matter type
           supervision:
             <<: *default
             title_html: For special children act, a supervision order cannot be varied, discharged or extended
@@ -1866,10 +1866,9 @@ en:
           change_of_name:
             <<: *default
             title_html: Change of name applications are not eligible for legal aid
-            option_bullets_html:
-              - select a different proceeding
-              - go back and change your answer
-            applications: Select a different proceeding
+            paragraph: You can go back and change your answer if this is not a change of names application
+            change: Change your answer
+            applications: Back to your applications
       child_subjects:
         error: Select yes if your client is the child subject of this proceeding
         show:

--- a/spec/services/flow/steps/proceedings_sca/interrupts_step_spec.rb
+++ b/spec/services/flow/steps/proceedings_sca/interrupts_step_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::ProceedingsSCA::InterruptsStep, type: :request do
+  let(:legal_aid_application) { build_stubbed(:legal_aid_application, provider_step_params:) }
+  let(:provider_step_params) { { type: } }
+  let(:type) { "change_of_name" }
+
+  describe "#path" do
+    subject { described_class.path.call(legal_aid_application) }
+
+    it { is_expected.to eql providers_legal_aid_application_sca_interrupt_path(legal_aid_application, type) }
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5390)

- Amended the interrupt page for change of names to reflect the designs in the ticket.
- Fixed a bug where an error "path of step interrupts is undefined" was being raised if a user attempted to return to an application that was previously on the interrupts page from the legal_aid_applications index/Your applications In progress page.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
