### PR TITLE
AP-5465 Replace old secrets references

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/_envs.tpl
+++ b/helm_deploy/apply-for-legal-aid/templates/_envs.tpl
@@ -304,12 +304,12 @@ env:
   - name: LEGAL_FRAMEWORK_API_HOST
     valueFrom:
       secretKeyRef:
-        name: {{ template "apply-for-legal-aid.fullname" . }}
+        name: laa-apply-for-legalaid-secrets
         key: legalFrameworkApiHost
   - name: LEGAL_FRAMEWORK_API_HOST_JS
     valueFrom:
       secretKeyRef:
-        name: {{ template "apply-for-legal-aid.fullname" . }}
+        name: laa-apply-for-legalaid-secrets
         key: legalFrameworkApiHostJS
   - name: SLACK_ALERT_EMAIL
     valueFrom:
@@ -374,7 +374,7 @@ env:
   - name: GOOGLE_DATA_STUDIO_URL
     valueFrom:
       secretKeyRef:
-        name: {{ template "apply-for-legal-aid.fullname" . }}
+        name: laa-apply-for-legalaid-secrets
         key: googleDataStudioUrl
   - name: ENCRYPTION_PRIMARY_KEY
     valueFrom:


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5465)

Replace references to old secrets with the new secret. 
Secrets updated:
- googleDataStudioUrl
- legalFrameworkApiHost
- legalFrameworkApiJsHost

NB: This will be tested before merging (UAT), after merging (on Staging) and before and after deployment to production as it affects all environments and will affect the proceedings page. 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
