### PR TITLE
Fix: nullify student_finance_amount when no

### DIFF
--- a/app/controllers/providers/means/student_finances_controller.rb
+++ b/app/controllers/providers/means/student_finances_controller.rb
@@ -2,28 +2,21 @@ module Providers
   module Means
     class StudentFinancesController < ProviderBaseController
       def show
-        @receives_student_finance = student_finance?
         @form = ::Applicants::StudentFinanceForm.new(model: applicant)
       end
 
       def update
-        @form = ::Applicants::StudentFinanceForm.new(student_finance_params)
-        remove_student_finance_amount unless @form.student_finance?
+        @form = ::Applicants::StudentFinanceForm.new(form_params)
         render :show unless save_continue_or_draft(@form)
       end
 
     private
 
-      def student_finance?
-        applicant.student_finance
+      def applicant
+        legal_aid_application.applicant
       end
 
-      def remove_student_finance_amount
-        applicant.student_finance_amount = nil
-        applicant.save!
-      end
-
-      def student_finance_params
+      def form_params
         merge_with_model(applicant) do
           params.require(:applicant).permit(:student_finance, :student_finance_amount)
         end

--- a/app/controllers/providers/partners/student_finances_controller.rb
+++ b/app/controllers/providers/partners/student_finances_controller.rb
@@ -4,13 +4,11 @@ module Providers
       prefix_step_with :partner
 
       def show
-        @receives_student_finance = student_finance?
         @form = ::Partners::StudentFinanceForm.new(model: partner)
       end
 
       def update
-        @form = ::Partners::StudentFinanceForm.new(student_finance_params)
-        remove_student_finance_amount unless @form.student_finance?
+        @form = ::Partners::StudentFinanceForm.new(form_params)
         render :show unless save_continue_or_draft(@form)
       end
 
@@ -20,16 +18,7 @@ module Providers
         legal_aid_application.partner
       end
 
-      def student_finance?
-        partner.student_finance
-      end
-
-      def remove_student_finance_amount
-        partner.student_finance_amount = nil
-        partner.save!
-      end
-
-      def student_finance_params
+      def form_params
         merge_with_model(partner) do
           params.require(:partner).permit(:student_finance, :student_finance_amount)
         end

--- a/app/forms/student_finances/base_student_finance_form.rb
+++ b/app/forms/student_finances/base_student_finance_form.rb
@@ -3,6 +3,10 @@ module StudentFinances
     validates :student_finance, inclusion: { in: %w[true false] }, unless: :draft?
     validates :student_finance_amount, currency: { greater_than_or_equal_to: 0 }, if: :student_finance?, unless: :draft?
 
+    before_validation do
+      attributes[:student_finance_amount] = nil unless student_finance?
+    end
+
     def student_finance?
       student_finance.eql?("true")
     end

--- a/app/views/providers/means/vehicle_details/_form.html.erb
+++ b/app/views/providers/means/vehicle_details/_form.html.erb
@@ -24,7 +24,7 @@
                                 hint: { text: t(".estimated_value.use_car_valuation_sites") },
                                 value: number_to_currency_or_original_string(@form.model.estimated_value),
                                 width: "one-third",
-                                prefix_text: "£" %>
+                                prefix_text: t("currency.gbp") %>
 
       <%= form.govuk_radio_buttons_fieldset(:payments_remain,
                                             legend: { text: t(".remaining_payments.question"), tag: "h2", size: "m" },

--- a/app/views/shared/_student_finances.html.erb
+++ b/app/views/shared/_student_finances.html.erb
@@ -11,7 +11,13 @@
                                           end,
                                           caption: { text: t("generic.#{client_or_partner}_means_caption"), size: "xl" },
                                           legend: { text: content_for(:page_title), tag: "h1", size: "xl" } do %>
-      <%= form.govuk_radio_button(:student_finance, true, label: { text: t("generic.yes") }, checked: @receives_student_finance, link_errors: true) do %>
+
+      <%= form.govuk_radio_button(
+            :student_finance,
+            true,
+            label: { text: t("generic.yes") },
+            link_errors: true,
+          ) do %>
         <%= form.govuk_text_field(
               :student_finance_amount,
               label: { text: t(".amount_label") },
@@ -20,7 +26,12 @@
               width: "one-quarter",
             ) %>
       <% end %>
-      <%= form.govuk_radio_button(:student_finance, false, label: { text: t("generic.no") }, checked: @receives_student_finance == false) %>
+
+      <%= form.govuk_radio_button(
+            :student_finance,
+            false,
+            label: { text: t("generic.no") },
+          ) %>
     <% end %>
     <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>

--- a/spec/forms/applicants/student_finance_form_spec.rb
+++ b/spec/forms/applicants/student_finance_form_spec.rb
@@ -1,0 +1,190 @@
+require "rails_helper"
+
+RSpec.describe Applicants::StudentFinanceForm, type: :form do
+  subject(:instance) { described_class.new(params) }
+
+  let(:applicant) { create(:applicant, student_finance: nil, student_finance_amount: nil) }
+  let(:legal_aid_application) { create(:legal_aid_application, applicant:) }
+
+  describe ".model_name" do
+    it 'is "Applicant"' do
+      expect(described_class.model_name).to eq("Applicant")
+    end
+  end
+
+  describe "#save" do
+    subject(:call_save) { instance.save }
+
+    context "with yes chosen and valid amount provided" do
+      let(:params) { { model: applicant, student_finance: "true", student_finance_amount: "1001.11" } }
+
+      it "updates student_finance and student_finance_amount" do
+        expect { call_save }.to change { applicant.attributes.symbolize_keys }
+          .from(hash_including(student_finance: nil, student_finance_amount: nil))
+          .to(hash_including(student_finance: true, student_finance_amount: 1_001.11))
+      end
+    end
+
+    context "with yes chosen and amount NOT provided" do
+      let(:params) { { model: applicant, student_finance: "true", student_finance_amount: "" } }
+
+      before { call_save }
+
+      it { expect(instance).not_to be_valid }
+
+      it "adds custom blank error message" do
+        error_messages = instance.errors.messages.values.flatten
+        expect(error_messages).to include("Student loan amount must be an amount of money, like 10,000")
+      end
+    end
+
+    context "with yes chosen and valid number provided with too many decimals" do
+      let(:params) { { model: applicant, student_finance: "true", student_finance_amount: "1001.123" } }
+
+      before { call_save }
+
+      it { expect(instance).not_to be_valid }
+
+      it "adds custom too many decimals error message" do
+        error_messages = instance.errors.messages.values.flatten
+        expect(error_messages).to include("Student loan amount must be an amount of money, like 10,000")
+      end
+    end
+
+    context "with yes chosen and amount with invalid chars" do
+      let(:params) { { model: applicant, student_finance: "true", student_finance_amount: "foobar" } }
+
+      before { call_save }
+
+      it { expect(instance).not_to be_valid }
+
+      it "adds custom invalid error message" do
+        error_messages = instance.errors.messages.values.flatten
+        expect(error_messages).to include("Student loan amount must be an amount of money, like 10,000")
+      end
+    end
+
+    context "with yes chosen and negative amount" do
+      let(:params) { { model: applicant, student_finance: "true", student_finance_amount: "-1001.11" } }
+
+      before { call_save }
+
+      it { expect(instance).not_to be_valid }
+
+      it "adds custom invalid error message" do
+        error_messages = instance.errors.messages.values.flatten
+        expect(error_messages).to include("Student loan amount must be an amount of money, like 10,000")
+      end
+    end
+
+    context "with no chosen" do
+      let(:params) { { model: applicant, student_finance: "false" } }
+
+      context "when no answer previously chosen" do
+        before { applicant.update!(student_finance: nil, student_finance_amount: nil) }
+
+        it "updates student_finance and student_finance_amount" do
+          expect { call_save }.to change { applicant.attributes.symbolize_keys }
+            .from(hash_including(student_finance: nil, student_finance_amount: nil))
+            .to(hash_including(student_finance: false, student_finance_amount: nil))
+        end
+      end
+
+      context "when yes previously chosen" do
+        before { applicant.update!(student_finance: true, student_finance_amount: 1_001.11) }
+
+        it "updates student_finance to false" do
+          expect { call_save }.to change(applicant, :student_finance).from(true).to(false)
+        end
+
+        it "updates student_finance_amount to nil" do
+          expect { call_save }.to change(applicant, :student_finance_amount).from(1_001.11).to(nil)
+        end
+      end
+    end
+
+    context "with no answer chosen" do
+      let(:params) { { student_finance: "", model: applicant } }
+
+      it "is invalid" do
+        call_save
+        expect(instance).not_to be_valid
+      end
+
+      it "adds custom blank error message" do
+        call_save
+        error_messages = instance.errors.messages.values.flatten
+        expect(error_messages).to include("Select yes if your client receives student finance")
+      end
+    end
+  end
+
+  describe "#save_as_draft" do
+    subject(:save_as_draft) { instance.save_as_draft }
+
+    context "with yes chosen and valid amount provided" do
+      let(:params) { { model: applicant, student_finance: "true", student_finance_amount: "1001.11" } }
+
+      it "updates student_finance and student_finance_amount" do
+        expect { save_as_draft }.to change { applicant.attributes.symbolize_keys }
+          .from(hash_including(student_finance: nil, student_finance_amount: nil))
+          .to(hash_including(student_finance: true, student_finance_amount: 1_001.11))
+      end
+
+      it "is valid" do
+        save_as_draft
+        expect(instance).to be_valid
+      end
+    end
+
+    context "with yes chosen and amount NOT provided" do
+      let(:params) { { model: applicant, student_finance: "true", student_finance_amount: "" } }
+
+      it "updates student_finance and student_finance_amount" do
+        expect { save_as_draft }.to change { applicant.attributes.symbolize_keys }
+          .from(hash_including(student_finance: nil, student_finance_amount: nil))
+          .to(hash_including(student_finance: true, student_finance_amount: nil))
+      end
+
+      it "is valid" do
+        save_as_draft
+        expect(instance).to be_valid
+      end
+    end
+
+    context "with no chosen" do
+      let(:params) { { model: applicant, student_finance: "false" } }
+
+      context "when no answer previously chosen" do
+        before { applicant.update!(student_finance: nil, student_finance_amount: nil) }
+
+        it "updates student_finance and student_finance_amount" do
+          expect { save_as_draft }.to change { applicant.attributes.symbolize_keys }
+            .from(hash_including(student_finance: nil, student_finance_amount: nil))
+            .to(hash_including(student_finance: false, student_finance_amount: nil))
+        end
+      end
+
+      context "when yes previously chosen" do
+        before { applicant.update!(student_finance: true, student_finance_amount: 1_001.11) }
+
+        it "updates student_finance to false" do
+          expect { save_as_draft }.to change(applicant, :student_finance).from(true).to(false)
+        end
+
+        it "updates student_finance_amount to nil" do
+          expect { save_as_draft }.to change(applicant, :student_finance_amount).from(1_001.11).to(nil)
+        end
+      end
+    end
+
+    context "with no answer chosen" do
+      let(:params) { { model: applicant, student_finance: "" } }
+
+      it "is valid" do
+        save_as_draft
+        expect(instance).to be_valid
+      end
+    end
+  end
+end

--- a/spec/forms/partners/student_finance_form_spec.rb
+++ b/spec/forms/partners/student_finance_form_spec.rb
@@ -1,0 +1,190 @@
+require "rails_helper"
+
+RSpec.describe Partners::StudentFinanceForm, type: :form do
+  subject(:instance) { described_class.new(params) }
+
+  let(:partner) { create(:partner, student_finance: nil, student_finance_amount: nil) }
+  let(:legal_aid_application) { create(:legal_aid_application, partner:) }
+
+  describe ".model_name" do
+    it 'is "Partner"' do
+      expect(described_class.model_name).to eq("Partner")
+    end
+  end
+
+  describe "#save" do
+    subject(:call_save) { instance.save }
+
+    context "with yes chosen and valid amount provided" do
+      let(:params) { { model: partner, student_finance: "true", student_finance_amount: "1001.11" } }
+
+      it "updates student_finance and student_finance_amount" do
+        expect { call_save }.to change { partner.attributes.symbolize_keys }
+          .from(hash_including(student_finance: nil, student_finance_amount: nil))
+          .to(hash_including(student_finance: true, student_finance_amount: 1_001.11))
+      end
+    end
+
+    context "with yes chosen and amount NOT provided" do
+      let(:params) { { model: partner, student_finance: "true", student_finance_amount: "" } }
+
+      before { call_save }
+
+      it { expect(instance).not_to be_valid }
+
+      it "adds custom blank error message" do
+        error_messages = instance.errors.messages.values.flatten
+        expect(error_messages).to include("Student loan amount must be an amount of money, like 10,000")
+      end
+    end
+
+    context "with yes chosen and valid number provided with too many decimals" do
+      let(:params) { { model: partner, student_finance: "true", student_finance_amount: "1001.123" } }
+
+      before { call_save }
+
+      it { expect(instance).not_to be_valid }
+
+      it "adds custom too many decimals error message" do
+        error_messages = instance.errors.messages.values.flatten
+        expect(error_messages).to include("Student loan amount must be an amount of money, like 10,000")
+      end
+    end
+
+    context "with yes chosen and amount with invalid chars" do
+      let(:params) { { model: partner, student_finance: "true", student_finance_amount: "foobar" } }
+
+      before { call_save }
+
+      it { expect(instance).not_to be_valid }
+
+      it "adds custom invalid error message" do
+        error_messages = instance.errors.messages.values.flatten
+        expect(error_messages).to include("Student loan amount must be an amount of money, like 10,000")
+      end
+    end
+
+    context "with yes chosen and negative amount" do
+      let(:params) { { model: partner, student_finance: "true", student_finance_amount: "-1001.11" } }
+
+      before { call_save }
+
+      it { expect(instance).not_to be_valid }
+
+      it "adds custom invalid error message" do
+        error_messages = instance.errors.messages.values.flatten
+        expect(error_messages).to include("Student loan amount must be an amount of money, like 10,000")
+      end
+    end
+
+    context "with no chosen" do
+      let(:params) { { model: partner, student_finance: "false" } }
+
+      context "when no answer previously chosen" do
+        before { partner.update!(student_finance: nil, student_finance_amount: nil) }
+
+        it "updates student_finance and student_finance_amount" do
+          expect { call_save }.to change { partner.attributes.symbolize_keys }
+            .from(hash_including(student_finance: nil, student_finance_amount: nil))
+            .to(hash_including(student_finance: false, student_finance_amount: nil))
+        end
+      end
+
+      context "when yes previously chosen" do
+        before { partner.update!(student_finance: true, student_finance_amount: 1_001.11) }
+
+        it "updates student_finance to false" do
+          expect { call_save }.to change(partner, :student_finance).from(true).to(false)
+        end
+
+        it "updates student_finance_amount to nil" do
+          expect { call_save }.to change(partner, :student_finance_amount).from(1_001.11).to(nil)
+        end
+      end
+    end
+
+    context "with no answer chosen" do
+      let(:params) { { student_finance: "", model: partner } }
+
+      it "is invalid" do
+        call_save
+        expect(instance).not_to be_valid
+      end
+
+      it "adds custom blank error message" do
+        call_save
+        error_messages = instance.errors.messages.values.flatten
+        expect(error_messages).to include("Select yes if your partner receives student finance")
+      end
+    end
+  end
+
+  describe "#save_as_draft" do
+    subject(:save_as_draft) { instance.save_as_draft }
+
+    context "with yes chosen and valid amount provided" do
+      let(:params) { { model: partner, student_finance: "true", student_finance_amount: "1001.11" } }
+
+      it "updates student_finance and student_finance_amount" do
+        expect { save_as_draft }.to change { partner.attributes.symbolize_keys }
+          .from(hash_including(student_finance: nil, student_finance_amount: nil))
+          .to(hash_including(student_finance: true, student_finance_amount: 1_001.11))
+      end
+
+      it "is valid" do
+        save_as_draft
+        expect(instance).to be_valid
+      end
+    end
+
+    context "with yes chosen and amount NOT provided" do
+      let(:params) { { model: partner, student_finance: "true", student_finance_amount: "" } }
+
+      it "updates student_finance and student_finance_amount" do
+        expect { save_as_draft }.to change { partner.attributes.symbolize_keys }
+          .from(hash_including(student_finance: nil, student_finance_amount: nil))
+          .to(hash_including(student_finance: true, student_finance_amount: nil))
+      end
+
+      it "is valid" do
+        save_as_draft
+        expect(instance).to be_valid
+      end
+    end
+
+    context "with no chosen" do
+      let(:params) { { model: partner, student_finance: "false" } }
+
+      context "when no answer previously chosen" do
+        before { partner.update!(student_finance: nil, student_finance_amount: nil) }
+
+        it "updates student_finance and student_finance_amount" do
+          expect { save_as_draft }.to change { partner.attributes.symbolize_keys }
+            .from(hash_including(student_finance: nil, student_finance_amount: nil))
+            .to(hash_including(student_finance: false, student_finance_amount: nil))
+        end
+      end
+
+      context "when yes previously chosen" do
+        before { partner.update!(student_finance: true, student_finance_amount: 1_001.11) }
+
+        it "updates student_finance to false" do
+          expect { save_as_draft }.to change(partner, :student_finance).from(true).to(false)
+        end
+
+        it "updates student_finance_amount to nil" do
+          expect { save_as_draft }.to change(partner, :student_finance_amount).from(1_001.11).to(nil)
+        end
+      end
+    end
+
+    context "with no answer chosen" do
+      let(:params) { { model: partner, student_finance: "" } }
+
+      it "is valid" do
+        save_as_draft
+        expect(instance).to be_valid
+      end
+    end
+  end
+end

--- a/spec/requests/providers/partners/student_finances_controller_spec.rb
+++ b/spec/requests/providers/partners/student_finances_controller_spec.rb
@@ -86,12 +86,31 @@ RSpec.describe Providers::Partners::StudentFinancesController do
       end
 
       context "when the provider selects `No`" do
+        let(:student_finance) { "false" }
+
         it "updates the partner" do
           login_as provider
           request
 
           expect(partner.reload.student_finance).to be false
           expect(partner.reload.student_finance_amount).to be_nil
+        end
+      end
+
+      context "when the provider selects `No` after previously selecting `Yes` and adding an amount" do
+        before do
+          partner.update!(student_finance: true, student_finance_amount: 1_000.22)
+        end
+
+        let(:student_finance) { "false" }
+        let(:student_finance_amount) { 1_000.22 }
+
+        it "updates the partner" do
+          login_as provider
+
+          expect { request }.to change { partner.reload.attributes.symbolize_keys }
+            .from(hash_including(student_finance: true, student_finance_amount: 1_000.22))
+            .to(hash_including(student_finance: false, student_finance_amount: nil))
         end
       end
 


### PR DESCRIPTION
## What
Fix: nullify student_finance_amount when provider selects "Yes" with amount then amends to "No" 

[Came out of looking at](https://dsdmoj.atlassian.net/browse/AP-5496)

Currently saying yes, adding an amount then coming back and answering No 
will not nullify the student_finance_amount. This is because while it updates the
record it subsequently saves the form values from the form params, which still
contain the `student_finance_amount` value.

### In addition
This refactors the form and partial to transparently use the `student_finance` boolean attribute, via the BaseForm pattern, value rather than use a specific instance variable, `@receives_student_finance`, to set the radio option - taken from `has_national_insurance_number_form` controller and forms pattern.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
