### PR TITLE
AP-5143: initiate state machine after create

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -70,6 +70,8 @@ class LegalAidApplication < ApplicationRecord
   before_save :set_open_banking_consent_choice_at
   before_create :create_app_ref
 
+  after_create { find_or_create_state_machine }
+
   validate :validate_document_categories
 
   delegate :bank_transactions, :under_18?, to: :applicant, allow_nil: true
@@ -501,6 +503,7 @@ class LegalAidApplication < ApplicationRecord
     end
     state_machine
   end
+  alias_method :find_or_create_state_machine, :state_machine_proxy
 
   def change_state_machine_type(state_machine_type)
     save!

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -398,41 +398,96 @@ RSpec.describe LegalAidApplication do
   end
 
   describe "state machine" do
-    subject(:legal_aid_application) { create(:legal_aid_application) }
+    let(:legal_aid_application) { create(:legal_aid_application) }
 
-    it 'is created with a default state of "initiated"' do
-      expect(legal_aid_application.state).to eq("initiated")
-    end
+    describe "#state" do
+      it 'is created with a default state of "initiated"' do
+        expect(legal_aid_application.state).to eq("initiated")
+      end
 
-    context "when initialising a new object" do
-      it "instantiates the default state machine" do
-        expect(legal_aid_application.state_machine_proxy.type).to eq "PassportedStateMachine"
-        expect(legal_aid_application.state).to eq "initiated"
+      context "when advancing state" do
+        it "advances state and saves" do
+          expect { legal_aid_application.enter_applicant_details! }
+            .to change(legal_aid_application, :state)
+              .from("initiated")
+              .to("entering_applicant_details")
+        end
+      end
+
+      context "when loading an existing record and advancing state" do
+        before { legal_aid_application.enter_applicant_details! }
+
+        it "is in the expected state and can be advanced" do
+          expect(legal_aid_application.state).to eq "entering_applicant_details"
+          legal_aid_application.check_applicant_details!
+          expect(legal_aid_application.state).to eq "checking_applicant_details"
+        end
       end
     end
 
-    context "with advancing state" do
-      it "advances state and saves" do
-        legal_aid_application.enter_applicant_details!
-        expect(legal_aid_application.state).to eq "entering_applicant_details"
+    describe "#find_or_create_state_machine" do
+      context "without a state machine relation" do
+        let(:legal_aid_application) { build(:legal_aid_application) }
+
+        it "creates the default state_machine relation" do
+          expect { legal_aid_application.find_or_create_state_machine }
+            .to change(legal_aid_application, :state_machine)
+              .from(nil)
+              .to(instance_of(PassportedStateMachine))
+        end
+      end
+
+      context "with an existing state machine relation" do
+        let(:legal_aid_application) { create(:legal_aid_application, :with_non_passported_state_machine) }
+
+        it "returns the state_machine relation" do
+          expect { legal_aid_application.find_or_create_state_machine }
+          .not_to change(legal_aid_application, :state_machine)
+            .from(instance_of(NonPassportedStateMachine))
+        end
       end
     end
 
-    context "when loading an existing record and advancing state" do
-      before { legal_aid_application.enter_applicant_details! }
+    describe "#state_machine_proxy" do
+      context "without a state machine relation" do
+        let(:legal_aid_application) { build(:legal_aid_application) }
 
-      it "is in the expected state and can be advanced" do
-        expect(legal_aid_application.state).to eq "entering_applicant_details"
-        legal_aid_application.check_applicant_details!
-        expect(legal_aid_application.state).to eq "checking_applicant_details"
+        it "creates the default state_machine relation" do
+          expect { legal_aid_application.state_machine_proxy }
+            .to change(legal_aid_application, :state_machine)
+              .from(nil)
+              .to(instance_of(PassportedStateMachine))
+        end
       end
-    end
 
-    context "when switching state machines" do
-      it "switches to the new state machine" do
-        expect(legal_aid_application.state_machine).to be_instance_of(PassportedStateMachine)
-        legal_aid_application.change_state_machine_type("NonPassportedStateMachine")
-        expect(legal_aid_application.state_machine).to be_instance_of(NonPassportedStateMachine)
+      context "with an existing state machine relation" do
+        let(:legal_aid_application) { create(:legal_aid_application, :with_non_passported_state_machine) }
+
+        it "returns the state_machine relation" do
+          expect { legal_aid_application.state_machine_proxy }
+          .not_to change(legal_aid_application, :state_machine)
+            .from(instance_of(NonPassportedStateMachine))
+        end
+      end
+
+      describe "#change_state_machine_type" do
+        it "switches to the new state machine" do
+          expect { legal_aid_application.change_state_machine_type("NonPassportedStateMachine") }
+          .to change(legal_aid_application, :state_machine)
+            .from(instance_of(PassportedStateMachine))
+            .to(instance_of(NonPassportedStateMachine))
+        end
+      end
+
+      describe "#after_create" do
+        let(:legal_aid_application) { build(:legal_aid_application) }
+
+        it "creates the default state_machine relation" do
+          expect { legal_aid_application.save! }
+            .to change(legal_aid_application, :state_machine)
+              .from(nil)
+              .to(instance_of(PassportedStateMachine))
+        end
       end
     end
   end


### PR DESCRIPTION
## What
Initiate state machine after application creation

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5143)

With the removal of this hook an inadvertent side effect has been
removed
```
  after_create do
    ActiveSupport::Notifications.instrument "dashboard.application_created", id:, state:
  end
````

The calling of the `state` method in this code means it actually calls
`state_machine_proxy` method, which creates a `state_machine` relation
on the application if it does not have one. Its removal therefore opens
up issues both in tests and possibly functioning of the app.

By replacing it with an explicit call to `state_machine_proxy` we avoid
the issue.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
