### PR TITLE
AP-5085: Add DAPO exclusion to start page

### DIFF
--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1697,7 +1697,7 @@ en:
         use_service:
           list_title: "You can use it for one, or a combination of these applications:"
           list:
-            - domestic abuse
+            - domestic abuse, except DAPO (domestic abuse protection orders)
             - section 8
         dont_use_service:
           list_title: "But do not use this service if:"


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5085)

Civil Apply will not be making the changes related to Domestic Abuse Protection Orders, so the start page needed to be updated with some wording to make users aware. 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
