### PR TITLE
Revert changes to schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
-  create_table "active_storage_attachments", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.uuid "record_id", null: false
     t.string "record_type", null: false
@@ -24,7 +24,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "active_storage_blobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -42,7 +42,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "actor_permissions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "actor_permissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "permittable_type"
     t.uuid "permittable_id"
     t.uuid "permission_id"
@@ -52,7 +52,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["permittable_type", "permittable_id"], name: "index_actor_permissions_on_permittable_type_and_permittable_id"
   end
 
-  create_table "addresses", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "addresses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "address_line_one"
     t.string "address_line_two"
     t.string "city"
@@ -76,12 +76,12 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["applicant_id"], name: "index_addresses_on_applicant_id"
   end
 
-  create_table "admin_reports", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "admin_reports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "admin_users", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "admin_users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "username", default: "", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -96,7 +96,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "allegations", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "allegations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.boolean "denies_all"
     t.string "additional_information"
@@ -105,7 +105,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["legal_aid_application_id"], name: "index_allegations_on_legal_aid_application_id"
   end
 
-  create_table "applicants", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "applicants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "first_name"
     t.date "date_of_birth"
     t.datetime "created_at", precision: nil, null: false
@@ -147,7 +147,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["unlock_token"], name: "index_applicants_on_unlock_token", unique: true
   end
 
-  create_table "application_digests", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "application_digests", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.string "firm_name", null: false
     t.string "provider_username", null: false
@@ -192,7 +192,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["legal_aid_application_id"], name: "index_application_digests_on_legal_aid_application_id", unique: true
   end
 
-  create_table "attachments", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.string "attachment_type"
     t.uuid "pdf_attachment_id"
@@ -202,7 +202,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.text "original_filename"
   end
 
-  create_table "attempts_to_settles", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "attempts_to_settles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "attempts_made"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -210,7 +210,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["proceeding_id"], name: "index_attempts_to_settles_on_proceeding_id"
   end
 
-  create_table "bank_account_holders", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "bank_account_holders", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "bank_provider_id", null: false
     t.json "true_layer_response"
     t.string "full_name"
@@ -221,7 +221,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["bank_provider_id"], name: "index_bank_account_holders_on_bank_provider_id"
   end
 
-  create_table "bank_accounts", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "bank_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "bank_provider_id", null: false
     t.json "true_layer_response"
     t.json "true_layer_balance_response"
@@ -237,7 +237,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["bank_provider_id"], name: "index_bank_accounts_on_bank_provider_id"
   end
 
-  create_table "bank_errors", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "bank_errors", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "applicant_id", null: false
     t.string "bank_name"
     t.text "error"
@@ -246,13 +246,13 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["applicant_id"], name: "index_bank_errors_on_applicant_id"
   end
 
-  create_table "bank_holidays", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "bank_holidays", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "dates"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "bank_providers", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "bank_providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "applicant_id", null: false
     t.json "true_layer_response"
     t.string "credentials_id"
@@ -264,7 +264,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["true_layer_provider_id", "applicant_id"], name: "index_bank_providers_on_true_layer_provider_id_and_applicant_id", unique: true
   end
 
-  create_table "bank_transactions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "bank_transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "bank_account_id", null: false
     t.json "true_layer_response"
     t.string "true_layer_id"
@@ -284,7 +284,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["transaction_type_id"], name: "index_bank_transactions_on_transaction_type_id"
   end
 
-  create_table "benefit_check_results", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "benefit_check_results", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.string "result"
     t.string "dwp_ref"
@@ -307,7 +307,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["legal_aid_application_id"], name: "index_capital_disregards_on_legal_aid_application_id"
   end
 
-  create_table "cash_transactions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "cash_transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "legal_aid_application_id"
     t.decimal "amount"
     t.date "transaction_date"
@@ -321,13 +321,13 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["owner_type", "owner_id"], name: "index_cash_transactions_on_owner"
   end
 
-  create_table "ccms_opponent_ids", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "ccms_opponent_ids", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.integer "serial_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "ccms_submission_documents", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "ccms_submission_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "submission_id"
     t.string "status"
     t.string "document_type"
@@ -337,7 +337,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.uuid "attachment_id"
   end
 
-  create_table "ccms_submission_histories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "ccms_submission_histories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "submission_id", null: false
     t.string "from_state"
     t.string "to_state"
@@ -350,7 +350,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["submission_id"], name: "index_ccms_submission_histories_on_submission_id"
   end
 
-  create_table "ccms_submissions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "ccms_submissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.string "applicant_ccms_reference"
     t.string "case_ccms_reference"
@@ -364,7 +364,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["legal_aid_application_id"], name: "index_ccms_submissions_on_legal_aid_application_id"
   end
 
-  create_table "cfe_results", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "cfe_results", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.uuid "submission_id"
     t.text "result"
@@ -373,7 +373,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.string "type", default: "CFE::V1::Result"
   end
 
-  create_table "cfe_submission_histories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "cfe_submission_histories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "submission_id"
     t.string "url"
     t.string "http_method"
@@ -386,7 +386,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "cfe_submissions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "cfe_submissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.uuid "assessment_id"
     t.string "aasm_state"
@@ -397,7 +397,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["legal_aid_application_id"], name: "index_cfe_submissions_on_legal_aid_application_id"
   end
 
-  create_table "chances_of_successes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "chances_of_successes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.text "application_purpose"
@@ -408,7 +408,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["proceeding_id"], name: "index_chances_of_successes_on_proceeding_id"
   end
 
-  create_table "citizen_access_tokens", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "citizen_access_tokens", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.string "token", default: "", null: false
     t.date "expires_on", null: false
@@ -417,7 +417,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["legal_aid_application_id"], name: "index_citizen_access_tokens_on_legal_aid_application_id"
   end
 
-  create_table "debugs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "debugs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "debug_type"
     t.string "legal_aid_application_id"
     t.string "session_id"
@@ -431,7 +431,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.string "browser_details"
   end
 
-  create_table "dependants", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "dependants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.integer "number"
     t.string "name"
@@ -447,7 +447,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["legal_aid_application_id"], name: "index_dependants_on_legal_aid_application_id"
   end
 
-  create_table "document_categories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "document_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.boolean "submit_to_ccms", default: false, null: false
     t.string "ccms_document_type"
@@ -459,7 +459,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.string "description"
   end
 
-  create_table "domestic_abuse_summaries", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "domestic_abuse_summaries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.boolean "warning_letter_sent"
     t.text "warning_letter_sent_details"
@@ -472,7 +472,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["legal_aid_application_id"], name: "index_domestic_abuse_summaries_on_legal_aid_application_id"
   end
 
-  create_table "dwp_overrides", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "dwp_overrides", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.text "passporting_benefit"
     t.boolean "has_evidence_of_benefit"
@@ -481,7 +481,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["legal_aid_application_id"], name: "index_dwp_overrides_on_legal_aid_application_id", unique: true
   end
 
-  create_table "employment_payments", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "employment_payments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "employment_id"
     t.date "date", null: false
     t.decimal "gross", default: "0.0", null: false
@@ -494,7 +494,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["employment_id"], name: "index_employment_payments_on_employment_id"
   end
 
-  create_table "employments", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "employments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -505,7 +505,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["owner_type", "owner_id"], name: "index_employments_on_owner"
   end
 
-  create_table "feedbacks", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "feedbacks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.boolean "done_all_needed"
     t.integer "satisfaction"
     t.text "improvement_suggestion"
@@ -521,7 +521,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.uuid "legal_aid_application_id"
   end
 
-  create_table "final_hearings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "final_hearings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "proceeding_id", null: false
     t.integer "work_type"
     t.boolean "listed", null: false
@@ -533,14 +533,14 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["proceeding_id"], name: "index_final_hearings_on_proceeding_id"
   end
 
-  create_table "firms", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "firms", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "ccms_id"
     t.string "name"
   end
 
-  create_table "gateway_evidences", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "gateway_evidences", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.uuid "provider_uploader_id"
     t.datetime "created_at", null: false
@@ -549,7 +549,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["provider_uploader_id"], name: "index_gateway_evidences_on_provider_uploader_id"
   end
 
-  create_table "hmrc_responses", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "hmrc_responses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "submission_id"
     t.string "use_case"
     t.json "response"
@@ -563,7 +563,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["owner_type", "owner_id"], name: "index_hmrc_responses_on_owner"
   end
 
-  create_table "incidents", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "incidents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.date "occurred_on"
     t.text "details"
     t.uuid "legal_aid_application_id"
@@ -573,14 +573,14 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["legal_aid_application_id"], name: "index_incidents_on_legal_aid_application_id"
   end
 
-  create_table "individuals", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "individuals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "involved_children", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "involved_children", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.string "full_name"
     t.date "date_of_birth"
@@ -590,7 +590,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["legal_aid_application_id"], name: "index_involved_children_on_legal_aid_application_id"
   end
 
-  create_table "legal_aid_application_transaction_types", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "legal_aid_application_transaction_types", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.uuid "transaction_type_id"
     t.datetime "created_at", precision: nil, null: false
@@ -602,7 +602,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["transaction_type_id"], name: "laa_trans_type_on_transaction_type_id"
   end
 
-  create_table "legal_aid_applications", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "legal_aid_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "application_ref"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
@@ -664,7 +664,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["provider_id"], name: "index_legal_aid_applications_on_provider_id"
   end
 
-  create_table "legal_framework_merits_task_lists", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "legal_framework_merits_task_lists", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.text "serialized_data"
     t.datetime "created_at", null: false
@@ -672,7 +672,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["legal_aid_application_id"], name: "idx_lfa_merits_task_lists_on_legal_aid_application_id"
   end
 
-  create_table "legal_framework_submission_histories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "legal_framework_submission_histories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "submission_id"
     t.string "url"
     t.string "http_method"
@@ -685,7 +685,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "legal_framework_submissions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "legal_framework_submissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.uuid "request_id"
     t.string "error_message"
@@ -709,7 +709,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["target_application_id"], name: "index_linked_applications_on_target_application_id"
   end
 
-  create_table "malware_scan_results", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "malware_scan_results", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "uploader_type"
     t.uuid "uploader_id"
     t.boolean "virus_found", null: false
@@ -721,7 +721,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["uploader_type", "uploader_id"], name: "index_malware_scan_results_on_uploader_type_and_uploader_id"
   end
 
-  create_table "matter_oppositions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "matter_oppositions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.text "reason", default: "", null: false
     t.datetime "created_at", null: false
@@ -729,7 +729,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["legal_aid_application_id"], name: "index_matter_oppositions_on_legal_aid_application_id"
   end
 
-  create_table "offices", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "offices", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "ccms_id"
@@ -745,7 +745,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["provider_id"], name: "index_offices_providers_on_provider_id"
   end
 
-  create_table "opponents", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "opponents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
@@ -757,7 +757,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["opposable_type", "opposable_id"], name: "index_opponents_on_opposable", unique: true
   end
 
-  create_table "opponents_applications", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "opponents_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "proceeding_id", null: false
     t.boolean "has_opponents_application"
     t.string "reason_for_applying"
@@ -766,7 +766,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["proceeding_id"], name: "index_opponents_applications_on_proceeding_id"
   end
 
-  create_table "organisations", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "organisations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.string "ccms_type_code", null: false
     t.string "ccms_type_text", null: false
@@ -774,7 +774,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "other_assets_declarations", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "other_assets_declarations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.decimal "second_home_value"
     t.decimal "second_home_mortgage"
@@ -791,7 +791,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["legal_aid_application_id"], name: "index_other_assets_declarations_on_legal_aid_application_id", unique: true
   end
 
-  create_table "parties_mental_capacities", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "parties_mental_capacities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.boolean "understands_terms_of_court_order"
     t.text "understands_terms_of_court_order_details"
@@ -800,7 +800,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["legal_aid_application_id"], name: "index_parties_mental_capacities_on_legal_aid_application_id"
   end
 
-  create_table "partners", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "partners", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
     t.date "date_of_birth"
@@ -824,13 +824,13 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["legal_aid_application_id"], name: "index_partners_on_legal_aid_application_id"
   end
 
-  create_table "permissions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "permissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "role"
     t.string "description"
     t.index ["role"], name: "index_permissions_on_role", unique: true
   end
 
-  create_table "policy_disregards", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "policy_disregards", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.boolean "england_infected_blood_support"
     t.boolean "vaccine_damage_payments"
     t.boolean "variant_creutzfeldt_jakob_disease"
@@ -845,7 +845,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["legal_aid_application_id"], name: "index_policy_disregards_on_legal_aid_application_id"
   end
 
-  create_table "proceedings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "proceedings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.integer "proceeding_case_id"
     t.boolean "lead_proceeding", default: false, null: false
@@ -880,7 +880,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["proceeding_case_id"], name: "index_proceedings_on_proceeding_case_id", unique: true
   end
 
-  create_table "proceedings_linked_children", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "proceedings_linked_children", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "proceeding_id"
     t.uuid "involved_child_id"
     t.datetime "created_at", null: false
@@ -889,7 +889,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["proceeding_id", "involved_child_id"], name: "index_proceeding_involved_child", unique: true
   end
 
-  create_table "prohibited_steps", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "prohibited_steps", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "proceeding_id", null: false
     t.boolean "uk_removal"
     t.string "details"
@@ -899,7 +899,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["proceeding_id"], name: "index_prohibited_steps_on_proceeding_id"
   end
 
-  create_table "providers", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "username", null: false
     t.string "type"
     t.text "roles"
@@ -926,7 +926,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["username"], name: "index_providers_on_username", unique: true
   end
 
-  create_table "regular_transactions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "regular_transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.uuid "transaction_type_id", null: false
     t.decimal "amount", null: false
@@ -941,7 +941,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["transaction_type_id"], name: "index_regular_transactions_on_transaction_type_id"
   end
 
-  create_table "savings_amounts", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "savings_amounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.decimal "offline_current_accounts"
     t.decimal "cash"
@@ -963,7 +963,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["legal_aid_application_id"], name: "index_savings_amounts_on_legal_aid_application_id"
   end
 
-  create_table "scheduled_mailings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "scheduled_mailings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.string "mailer_klass", null: false
     t.string "mailer_method", null: false
@@ -978,7 +978,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.string "govuk_message_id"
   end
 
-  create_table "scope_limitations", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "scope_limitations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "proceeding_id", null: false
     t.integer "scope_type"
     t.string "code", null: false
@@ -991,7 +991,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["proceeding_id"], name: "index_scope_limitations_on_proceeding_id"
   end
 
-  create_table "settings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "mock_true_layer_data", default: false, null: false
@@ -1010,7 +1010,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.boolean "public_law_family", default: false, null: false
   end
 
-  create_table "specific_issues", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "specific_issues", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "proceeding_id", null: false
     t.boolean "confirmed"
     t.string "details"
@@ -1019,7 +1019,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["proceeding_id"], name: "index_specific_issues_on_proceeding_id"
   end
 
-  create_table "state_machine_proxies", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "state_machine_proxies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.string "type"
     t.string "aasm_state"
@@ -1028,7 +1028,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.string "ccms_reason"
   end
 
-  create_table "statement_of_cases", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "statement_of_cases", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.text "statement"
     t.datetime "created_at", precision: nil, null: false
@@ -1046,7 +1046,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "transaction_types", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "transaction_types", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.string "operation"
     t.datetime "created_at", precision: nil, null: false
@@ -1058,13 +1058,13 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["parent_id"], name: "index_transaction_types_on_parent_id"
   end
 
-  create_table "true_layer_banks", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "true_layer_banks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "banks"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "undertakings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "undertakings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.boolean "offered"
     t.string "additional_information"
@@ -1073,7 +1073,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["legal_aid_application_id"], name: "index_undertakings_on_legal_aid_application_id"
   end
 
-  create_table "uploaded_evidence_collections", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "uploaded_evidence_collections", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.uuid "provider_uploader_id"
     t.datetime "created_at", null: false
@@ -1082,7 +1082,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["provider_uploader_id"], name: "index_uploaded_evidence_collections_on_provider_uploader_id"
   end
 
-  create_table "urgencies", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "urgencies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.string "nature_of_urgency", null: false
     t.boolean "hearing_date_set"
@@ -1093,7 +1093,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["legal_aid_application_id"], name: "index_urgencies_on_legal_aid_application_id"
   end
 
-  create_table "vary_orders", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "vary_orders", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "proceeding_id", null: false
     t.string "details"
     t.datetime "created_at", null: false
@@ -1101,7 +1101,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.index ["proceeding_id"], name: "index_vary_orders_on_proceeding_id"
   end
 
-  create_table "vehicles", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "vehicles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.decimal "estimated_value"
     t.decimal "payment_remaining"
     t.date "purchased_on"
@@ -1146,8 +1146,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
   add_foreign_key "legal_aid_applications", "providers"
   add_foreign_key "legal_framework_merits_task_lists", "legal_aid_applications", on_delete: :cascade
   add_foreign_key "legal_framework_submissions", "legal_aid_applications"
-  add_foreign_key "linked_applications", "legal_aid_applications", column: "associated_application_id", validate: false
-  add_foreign_key "linked_applications", "legal_aid_applications", column: "lead_application_id", validate: false
+  add_foreign_key "linked_applications", "legal_aid_applications", column: "associated_application_id"
+  add_foreign_key "linked_applications", "legal_aid_applications", column: "lead_application_id"
   add_foreign_key "matter_oppositions", "legal_aid_applications", on_delete: :cascade
   add_foreign_key "offices", "firms"
   add_foreign_key "offices_providers", "offices"


### PR DESCRIPTION


## What
Revert changes to schema.rb

Inadvertently added using by this [commit](https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/7428/commits/08c4e0e929505d2a2ce41d7cb19f7194a4ba8e0c)
due to local restore of a production database and a migration run locally.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
