### PR TITLE
Chore: Update PDA endpoints

### DIFF
--- a/app/services/pda/current_contracts.rb
+++ b/app/services/pda/current_contracts.rb
@@ -27,7 +27,7 @@ module PDA
   private
 
     def url
-      @url ||= "#{Rails.configuration.x.pda.url}/provider-office/#{@office_code}/office-contract-details"
+      @url ||= "#{Rails.configuration.x.pda.url}/provider-offices/#{@office_code}/office-contract-details"
     end
 
     def headers

--- a/app/services/pda/provider_details_retriever.rb
+++ b/app/services/pda/provider_details_retriever.rb
@@ -47,7 +47,7 @@ module PDA
     def provider_offices
       return @provider_offices if @provider_offices
 
-      response = conn.get("/provider-user/#{encoded_username}/provider-offices")
+      response = conn.get("/provider-users/#{encoded_username}/provider-offices")
       handle_errors(response)
 
       @provider_offices = JSON.parse(response.body)

--- a/spec/cassettes/PDA_ProviderDetailsRetriever/_call/with_a_non_existent_user/returns_an_error.yml
+++ b/spec/cassettes/PDA_ProviderDetailsRetriever/_call/with_a_non_existent_user/returns_an_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://laa-provider-details-api-uat.apps.live.cloud-platform.service.justice.gov.uk/provider-user/dummy_user/provider-offices
+    uri: https://laa-provider-details-api-uat.apps.live.cloud-platform.service.justice.gov.uk/provider-users/dummy_user/provider-offices
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/PDA_ProviderDetailsRetriever/_call/with_an_existing_user/returns_provider_details.yml
+++ b/spec/cassettes/PDA_ProviderDetailsRetriever/_call/with_an_existing_user/returns_provider_details.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://laa-provider-details-api-uat.apps.live.cloud-platform.service.justice.gov.uk/provider-user/DT_SCRIPT_USER1/provider-offices
+    uri: https://laa-provider-details-api-uat.apps.live.cloud-platform.service.justice.gov.uk/provider-users/DT_SCRIPT_USER1/provider-offices
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/services/pda/current_contracts_spec.rb
+++ b/spec/services/pda/current_contracts_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PDA::CurrentContracts do
     subject(:call) { described_class.call(office_code) }
 
     before do
-      stub_request(:get, "#{Rails.configuration.x.pda.url}/provider-office/#{office_code}/office-contract-details")
+      stub_request(:get, "#{Rails.configuration.x.pda.url}/provider-offices/#{office_code}/office-contract-details")
         .to_return(body:, status:)
     end
 

--- a/spec/services/pda/provider_details_request_stubs.rb
+++ b/spec/services/pda/provider_details_request_stubs.rb
@@ -2,7 +2,7 @@
 # provider offices
 ###################
 def stub_provider_offices
-  stub_request(:get, %r{#{Rails.configuration.x.pda.url}/provider-user/test-user/provider-offices})
+  stub_request(:get, %r{#{Rails.configuration.x.pda.url}/provider-users/test-user/provider-offices})
     .to_return(
       status: 200,
       body: provider_offices_json,
@@ -31,7 +31,7 @@ def provider_offices_json
 end
 
 def stub_other_provider_offices
-  stub_request(:get, %r{#{Rails.configuration.x.pda.url}/provider-user/other-user/provider-offices})
+  stub_request(:get, %r{#{Rails.configuration.x.pda.url}/provider-users/other-user/provider-offices})
     .to_return(
       status: 200,
       body: other_provider_offices_json,
@@ -96,11 +96,11 @@ end
 # errors
 #################
 def stub_provider_details_retriever_record_not_found(provider:)
-  stub_request(:get, "#{Rails.configuration.x.pda.url}/provider-user/#{provider.username}/provider-offices")
+  stub_request(:get, "#{Rails.configuration.x.pda.url}/provider-users/#{provider.username}/provider-offices")
     .to_return(body: nil, status: 204)
 end
 
 def stub_provider_details_retriever_api_error(provider:)
-  stub_request(:get, "#{Rails.configuration.x.pda.url}/provider-user/#{provider.username}/provider-offices")
+  stub_request(:get, "#{Rails.configuration.x.pda.url}/provider-users/#{provider.username}/provider-offices")
     .to_return(body: "An error has occurred", status: 500)
 end

--- a/spec/services/pda/provider_details_retriever_spec.rb
+++ b/spec/services/pda/provider_details_retriever_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe PDA::ProviderDetailsRetriever, :vcr do
 
     context "when there is an error calling the api" do
       before do
-        stub_request(:get, "#{Rails.configuration.x.pda.url}/provider-user/#{username}/provider-offices")
+        stub_request(:get, "#{Rails.configuration.x.pda.url}/provider-users/#{username}/provider-offices")
           .to_return(body: "An error has occurred", status: 500)
       end
 
@@ -40,7 +40,7 @@ RSpec.describe PDA::ProviderDetailsRetriever, :vcr do
 
     context "when api returns no content" do
       before do
-        stub_request(:get, "#{Rails.configuration.x.pda.url}/provider-user/#{username}/provider-offices")
+        stub_request(:get, "#{Rails.configuration.x.pda.url}/provider-users/#{username}/provider-offices")
           .to_return(body: nil, status: 204)
       end
 


### PR DESCRIPTION



## What

The Provider Details API has deprecated a number of endpoints, replacing singular names with pluralised, 
e.g. provider_user -> provider_users

This PR updates the `provider_user` and `provider_office` uses in our service to use the new names


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
