### PR TITLE
Chore: Remove Settings home_address column

### DIFF
--- a/db/migrate/20241115143002_remove_home_address_from_settings.rb
+++ b/db/migrate/20241115143002_remove_home_address_from_settings.rb
@@ -1,0 +1,5 @@
+class RemoveHomeAddressFromSettings < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured { remove_column :settings, :home_address, :boolean }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_15_143002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -1004,7 +1004,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_092712) do
     t.datetime "cfe_compare_run_at"
     t.boolean "linked_applications", default: false, null: false
     t.boolean "collect_hmrc_data", default: false, null: false
-    t.boolean "home_address", default: false, null: false
     t.boolean "special_childrens_act", default: false, null: false
     t.boolean "means_test_review_a", default: false, null: false
     t.boolean "public_law_family", default: false, null: false

--- a/features/providers/check_provider_answers.feature
+++ b/features/providers/check_provider_answers.feature
@@ -19,7 +19,7 @@ Feature: Checking client details answers backwards and forwards
       | Home address | Transport For London\n98 Petty France\nLondon\nSW1H 9EA |
       | National Insurance number | JA293483A |
       | Does your client have a partner | No |
-  
+
   @javascript
   Scenario: Send client's mail to another residential address
     Given I complete the passported journey as far as check your answers and send correspondence to another uk residential address
@@ -159,8 +159,7 @@ Feature: Checking client details answers backwards and forwards
 
   @javascript @vcr
   Scenario: I am able to return and amend the client's overseas home address
-    Given the feature flag for home_address is enabled
-    And I complete the passported journey as far as check your answers with an overseas address
+    Given  I complete the passported journey as far as check your answers with an overseas address
     And the "Client details" check your answers section should contain:
       | question | answer |
       | Correspondence address | Transport For London\n98 Petty France\nLondon\nSW1H 9EA |
@@ -202,7 +201,7 @@ Feature: Checking client details answers backwards and forwards
     And I enter Last name "Surname"
     And I click "Save and continue"
     Then I should be on a page with title "Does your client have a home address"
-    
+
     When I choose "Yes"
     And I click "Save and continue"
     Then I should be on a page with title "Find your client's home address"

--- a/features/providers/linked_applications/back_button.feature
+++ b/features/providers/linked_applications/back_button.feature
@@ -3,7 +3,6 @@ Feature: Linking cases back button use
   Scenario: Complete flow reversion with back button
     Given I have created and submitted an application with the application reference 'L-123-456'
     And the feature flag for linked_applications is enabled
-    And the feature flag for home_address is enabled
 
     When I visit the application service
     And I click link "Sign in"


### PR DESCRIPTION


## What

The setting was removed over the summer but the column was left behind in the database

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
