### PR TITLE
AP-5515: Update the SCA Interrupt pages

### DIFF
--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1829,7 +1829,7 @@ en:
               - go back and change your answer
               - use legal help
             options: "You can do one of the following:"
-            proceedings: Select a different proceeding or matter type
+            proceedings: Remove the proceeding and select a new one
           heard_as_alternatives:
             <<: *default
             title_html: You cannot submit this application under special children act

--- a/spec/requests/providers/proceedings_sca/interrupts_controller_spec.rb
+++ b/spec/requests/providers/proceedings_sca/interrupts_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Providers::ProceedingsSCA::InterruptsController do
 
       it "shows text for a supervision order and a button to select a different proceeding" do
         expect(response.body).to include("For special children act, a supervision order cannot be varied, discharged or extended")
-        expect(response.body).to include("Select a different proceeding or matter type")
+        expect(response.body).to include("Remove the proceeding and select a new one")
       end
 
       context "when passed an unknown type" do
@@ -37,7 +37,7 @@ RSpec.describe Providers::ProceedingsSCA::InterruptsController do
 
         it "shows default text and a button to select a different proceeding" do
           expect(response.body).to include("You cannot choose a special children act proceeding if it has not been issued")
-          expect(response.body).to include("Select a different proceeding or matter type")
+          expect(response.body).to include("Remove the proceeding and select a new one")
         end
       end
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5515)

The text for the button needed to be updated to ensure the user was aware they were taking a 'destructive' action.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
