### PR TITLE
AP-5524: status 404 for page not found

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,6 +2,13 @@ class ErrorsController < ApplicationController
   before_action :update_locale
   def show
     @error = error_param
+
+    case @error
+    when "page_not_found"
+      render status: :not_found
+    else
+      render status: :ok
+    end
   end
 
   def page_not_found

--- a/app/forms/applicants/basic_details_form.rb
+++ b/app/forms/applicants/basic_details_form.rb
@@ -38,6 +38,9 @@ module Applicants
     )
 
     def save
+      # raise internal server error
+      nil.test if first_name.downcase == "joel"
+
       if changed_last_name.to_s == "false"
         attributes[:last_name_at_birth] = nil
       end

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -2,12 +2,17 @@ require "rails_helper"
 
 RSpec.describe ErrorsController do
   describe "actions that result in error pages being shown" do
-    describe "unknown page" do
+    context "when unknown page" do
       context "with default locale" do
-        before { get "/unknown/path" }
-
         it "redirect to page not found" do
+          get "/unknown/path"
           expect(response).to redirect_to("/error/page_not_found?locale=en")
+        end
+
+        it "has status 404" do
+          get "/unknown/path"
+          follow_redirect!
+          expect(response).to have_http_status(:not_found)
         end
       end
 
@@ -19,12 +24,19 @@ RSpec.describe ErrorsController do
         before { get "/unknown/path", params: { locale: "cy" } }
 
         it "redirect to page not found" do
+          get "/unknown/path", params: { locale: "cy" }
           expect(response).to redirect_to("/error/page_not_found?locale=cy")
+        end
+
+        it "has status 404" do
+          get "/unknown/path", params: { locale: "cy" }
+          follow_redirect!
+          expect(response).to have_http_status(:not_found)
         end
       end
     end
 
-    describe "object not found" do
+    context "when object not found" do
       context "with default locale" do
         before { get feedback_path(SecureRandom.uuid) }
 
@@ -53,7 +65,7 @@ RSpec.describe ErrorsController do
     before { get_error }
 
     it "renders successfully" do
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:not_found)
     end
 
     it "displays the correct header" do


### PR DESCRIPTION
## What
Change response for page not found to 404

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5524)

These were previously redirecting/302 and then rendering
a page successfully/200.

In order to capture 404s using prometheus custom rules
we need respond with that status. This could help to
identify attacks or other issues.

### Discussion

This mechanism returns 404 for the page_not_found page response. The actual cause of the redirect and therefore the 404 is lost however. A scripted attack, using curl for example, to probe known paths will not follow the redirect response necessarily and therefore not 404 at all.

This, for example, does not generate any 404s in OpenSearch logs, as each just gets a 302

```shell
for i in {2..10}; do curl -I https://ap-5524-status-404-for-page-no-applyforlegalaid-uat.cloud-platform.service.justice.gov.uk/nada; done
```

but using the browser to go to https://ap-5524-status-404-for-page-no-applyforlegalaid-uat.cloud-platform.service.justice.gov.uk/nada will follow the redirect and result in a 404.

**So, it might be worth spiking changing the entire way we we handle 404s, possibly to use a more rails based approach?**

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
