### PR TITLE
AP-5177: Switch to new PDA after login

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@ RSpec/AnyInstance:
     - 'spec/requests/admin/legal_aid_applications/submissions_controller_spec.rb'
     - 'spec/requests/providers/uploaded_evidence_collection_spec.rb'
     - 'spec/requests/providers/use_ccms_controller_spec.rb'
-    - 'spec/requests/saml_sessions_spec.rb'
+    - 'spec/requests/saml_sessions_controller_spec.rb'
     - 'spec/services/ccms/attribute_configuration_spec.rb'
     - 'spec/services/ccms/manual_review_determiner_spec.rb'
     - 'spec/services/ccms/payload_generators/entity_attributes_generator_spec.rb'

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -21,7 +21,7 @@ class Provider < ApplicationRecord
   end
 
   def update_details_directly
-    ProviderDetailsCreator.call(self)
+    PDA::ProviderDetailsCreator.call(self)
   end
 
   def sca_permissions?

--- a/app/services/provider_after_login_service.rb
+++ b/app/services/provider_after_login_service.rb
@@ -27,11 +27,11 @@ private
   end
 
   def call_provider_details_api
-    ProviderDetailsCreator.call(@provider)
+    PDA::ProviderDetailsCreator.call(@provider)
     @provider.clear_invalid_login!
-  rescue ProviderDetailsRetriever::ApiRecordNotFoundError
+  rescue PDA::ProviderDetailsRetriever::ApiRecordNotFoundError
     @provider.update!(invalid_login_details: "api_details_user_not_found")
-  rescue ProviderDetailsRetriever::ApiError
+  rescue PDA::ProviderDetailsRetriever::ApiError
     @provider.update!(invalid_login_details: "provider_details_api_error")
   end
 end

--- a/app/services/provider_details_retriever.rb
+++ b/app/services/provider_details_retriever.rb
@@ -13,14 +13,18 @@ class ProviderDetailsRetriever
   end
 
   def call
+    # :nocov:
     Rails.logger.info "**** Using #{self.class} to retrieve Provider Details" unless Rails.env.test?
+    # :nocov:
     provider_details
   end
 
 private
 
   def provider_details
+    # :nocov:
     raise_record_not_found_error if response.is_a?(Net::HTTPNotFound)
+    # :nocov:
 
     raise_error unless response.is_a?(Net::HTTPOK)
 
@@ -50,6 +54,8 @@ private
   end
 
   def raise_record_not_found_error
+    # :nocov:
     raise ApiRecordNotFoundError, "Retrieval Failed: #{response.message} (#{response.code}) #{response.body}"
+    # :nocov:
   end
 end

--- a/helm_deploy/apply-for-legal-aid/values-uat.yaml
+++ b/helm_deploy/apply-for-legal-aid/values-uat.yaml
@@ -103,7 +103,7 @@ laa_portal:
   idpSsoTargetUrl: "https://portal.uat.legalservices.gov.uk/oamfed/idp/samlv20"
   idpSloTargetUrl: "https://portal.uat.legalservices.gov.uk/oam/server/logout"
   idpCertFingerprintAlgorithm: "<idp-cert-fingerprint-alg-goes-here>"
-  mockSaml: "true"
+  mockSaml: "false"
 
 provider_details:
   url: "https://ccms-pda.stg.legalservices.gov.uk/api/providerDetails"

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Provider do
   describe "#update_details" do
     context "when firm exists" do
       it "does not call provider details creator immediately" do
-        expect(ProviderDetailsCreator).not_to receive(:call).with(provider)
+        expect(PDA::ProviderDetailsCreator).not_to receive(:call).with(provider)
         provider.update_details
       end
 

--- a/spec/requests/saml_sessions_controller_spec.rb
+++ b/spec/requests/saml_sessions_controller_spec.rb
@@ -70,10 +70,9 @@ RSpec.describe SamlSessionsController do
 
           it "updates the record with firm and offices" do
             post_request
-            firm = Firm.find_by(ccms_id: raw_details_response.dig(:firm, :ccmsFirmId))
-            expect(provider.firm_id).to eq firm.id
-            expect(firm.offices.size).to eq 1
-            expect(firm.offices.first.ccms_id).to eq raw_details_response[:officeCodes].first[:ccmsFirmOfficeId].to_s
+            expect(provider.firm.ccms_id).to eq "10835831"
+            expect(provider.firm.offices.size).to eq 1
+            expect(provider.firm.offices.first.ccms_id).to eq "34406595"
           end
 
           context "when mock_saml is activated" do
@@ -181,10 +180,9 @@ RSpec.describe SamlSessionsController do
 
           it "updates the record with firm and offices" do
             post_request
-            firm = Firm.find_by(ccms_id: raw_details_response.dig(:firm, :ccmsFirmId))
-            expect(provider.firm_id).to eq firm.id
-            expect(firm.offices.size).to eq 1
-            expect(firm.offices.first.ccms_id).to eq raw_details_response[:officeCodes].first[:ccmsFirmOfficeId].to_s
+            expect(provider.firm.ccms_id).to eq "10835831"
+            expect(provider.firm.offices.size).to eq 1
+            expect(provider.firm.offices.first.ccms_id).to eq "34406595"
           end
 
           it "displays the start page" do
@@ -226,25 +224,17 @@ RSpec.describe SamlSessionsController do
     {
       firm: {
         firmId: 3_959_183,
-        firmNumber: "50736",
         ccmsFirmId: 10_835_831,
-        firmName: "DT SCRIPT PROVIDER 1",
+        # trimmed for stub usage
       },
       user: {
-        userId: 454_031,
-        ccmsContactId: 0,
-        userLogin: "DT_SCRIPT_USER1",
-        name: "Dts User1",
-        emailAddress: "deepak.tanna@digital.justice.gov.uk",
-        portalStatus: "Active",
+        # trimmed for stub usage
       },
       officeCodes: [
         {
           firmOfficeId: 145_434,
           ccmsFirmOfficeId: 34_406_595,
-          firmOfficeCode: "2Q242F",
-          officeName: "2Q242F,1 Skyscraper",
-          officeCodeAlt: "DT Script Office 1",
+          # trimmed for stub usage
         },
       ],
     }
@@ -254,42 +244,14 @@ RSpec.describe SamlSessionsController do
     {
       firm: {
         firmId: 3_959_183,
-        firmNumber: "50736",
         ccmsFirmId: 10_835_831,
-        firmName: "DT SCRIPT PROVIDER 1",
+        # trimmed for stub usage
       },
       offices: [
         {
           firmOfficeId: 145_434,
           ccmsFirmOfficeId: 34_406_595,
-          firmOfficeCode: "2Q242F",
-          officeName: "2Q242F,1 Skyscraper",
-          officeCodeAlt: "DT Script Office 1",
-          addressLine1: "1 Skyscraper",
-          addressLine2: "1 Some Road",
-          addressLine3: "",
-          addressLine4: "",
-          city: "Metropolis",
-          county: "",
-          postCode: "LE1 1AA",
-          dxCentre: "",
-          dxNumber: "",
-          telephoneAreaCode: "01162",
-          telephoneNumber: "555124",
-          faxAreaCode: "",
-          faxNumber: "",
-          emailAddress: "me@email.uk",
-          vatRegistrationNumber: "",
-          type: "Legal Services Provider",
-          headOffice: "N/A",
-          creationDate: "2023-11-10",
-          lscRegion: "Midlands",
-          lscBidZone: "Leicester",
-          lscAreaOffice: "Nottingham",
-          cjsForceName: "Leicestershire",
-          localAuthority: "City of Leicester",
-          policeStationAreaName: "Leicester",
-          dutySolicitorAreaName: "Leicester",
+          # trimmed for stub usage
         },
       ],
     }

--- a/spec/requests/saml_sessions_controller_spec.rb
+++ b/spec/requests/saml_sessions_controller_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 require "sidekiq/testing"
 
-RSpec.describe "SamlSessionsController" do
+RSpec.describe SamlSessionsController do
   let(:firm) { create(:firm, offices: [office]) }
   let(:office) { create(:office) }
   let(:provider) { create(:provider, firm:, selected_office: office, offices: [office], username:) }
   let(:username) { "bob the builder" }
   let(:provider_details_api_url) { "#{Rails.configuration.x.provider_details.url}#{username.gsub(' ', '%20')}" }
-  let(:provider_details_api_reponse) { api_response.to_json }
+  let(:provider_details_api_response) { api_response.to_json }
   let(:enable_mock_saml) { false }
 
   before do
@@ -48,7 +48,7 @@ RSpec.describe "SamlSessionsController" do
 
     before do
       allow_any_instance_of(Warden::Proxy).to receive(:authenticate!).and_return(provider)
-      stub_request(:get, provider_details_api_url).to_return(body: provider_details_api_reponse, status:)
+      stub_request(:get, provider_details_api_url).to_return(body: provider_details_api_response, status:)
     end
 
     context "when on staging or production" do

--- a/spec/requests/saml_sessions_controller_spec.rb
+++ b/spec/requests/saml_sessions_controller_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe SamlSessionsController do
   let(:office) { create(:office) }
   let(:provider) { create(:provider, firm:, selected_office: office, offices: [office], username:) }
   let(:username) { "bob the builder" }
-  let(:provider_details_api_url) { "#{Rails.configuration.x.provider_details.url}#{username.gsub(' ', '%20')}" }
+  let(:firm_id) { "3959183" }
+  let(:provider_details_api_url) { "#{Rails.configuration.x.pda.url}/provider-users/#{username.gsub(' ', '%20')}/provider-offices" }
+  let(:provider_firms_api_url) { "#{Rails.configuration.x.pda.url}/provider-firms/#{firm_id}/provider-offices" }
   let(:provider_details_api_response) { api_response.to_json }
   let(:enable_mock_saml) { false }
 
@@ -49,6 +51,7 @@ RSpec.describe SamlSessionsController do
     before do
       allow_any_instance_of(Warden::Proxy).to receive(:authenticate!).and_return(provider)
       stub_request(:get, provider_details_api_url).to_return(body: provider_details_api_response, status:)
+      stub_request(:get, provider_firms_api_url).to_return(body: firm_response.to_json, status:)
     end
 
     context "when on staging or production" do
@@ -61,16 +64,16 @@ RSpec.describe SamlSessionsController do
           let(:provider) { create(:provider, :created_by_devise, :with_ccms_apply_role, username:) }
 
           it "calls the Provider details api" do
-            expect(ProviderDetailsCreator).to receive(:call).with(provider).and_call_original
+            expect(PDA::ProviderDetailsCreator).to receive(:call).with(provider).and_call_original
             post_request
           end
 
           it "updates the record with firm and offices" do
             post_request
-            firm = Firm.find_by(ccms_id: raw_details_response[:providerFirmId])
+            firm = Firm.find_by(ccms_id: raw_details_response.dig(:firm, :ccmsFirmId))
             expect(provider.firm_id).to eq firm.id
             expect(firm.offices.size).to eq 1
-            expect(firm.offices.first.ccms_id).to eq raw_details_response[:providerOffices].first[:id].to_s
+            expect(firm.offices.first.ccms_id).to eq raw_details_response[:officeCodes].first[:ccmsFirmOfficeId].to_s
           end
 
           context "when mock_saml is activated" do
@@ -96,7 +99,7 @@ RSpec.describe SamlSessionsController do
           before { allow(Rails.configuration.x.laa_portal).to receive(:mock_saml).and_return(false) }
 
           it "does not call the ProviderDetailsCreator" do
-            expect(ProviderDetailsCreator).not_to receive(:call)
+            expect(PDA::ProviderDetailsCreator).not_to receive(:call)
             post_request
           end
 
@@ -112,12 +115,12 @@ RSpec.describe SamlSessionsController do
         end
 
         context "and the provider does not exist on Provider details api" do
-          let(:api_response) { raw_404_response }
-          let(:status) { 404 }
+          let(:api_response) { blank_response }
+          let(:status) { 204 }
           let(:provider) { create(:provider, :created_by_devise, :with_ccms_apply_role, username:) }
 
           it "calls the Provider details creator" do
-            expect(ProviderDetailsCreator).to receive(:call).with(provider).and_call_original
+            expect(PDA::ProviderDetailsCreator).to receive(:call).with(provider).and_call_original
             post_request
           end
 
@@ -154,7 +157,7 @@ RSpec.describe SamlSessionsController do
         it "uses a worker to update details" do
           ProviderDetailsCreatorWorker.clear
           expect(ProviderDetailsCreatorWorker).to receive(:perform_async).with(provider.id).and_call_original
-          expect(ProviderDetailsCreator).to receive(:call).with(provider).and_call_original
+          expect(PDA::ProviderDetailsCreator).to receive(:call).with(provider).and_call_original
           post_request
           ProviderDetailsCreatorWorker.drain
         end
@@ -172,16 +175,16 @@ RSpec.describe SamlSessionsController do
           let(:provider) { create(:provider, :created_by_devise, :with_ccms_apply_role, username:) }
 
           it "calls the Provider details api" do
-            expect(ProviderDetailsCreator).to receive(:call).with(provider).and_call_original
+            expect(PDA::ProviderDetailsCreator).to receive(:call).with(provider).and_call_original
             post_request
           end
 
           it "updates the record with firm and offices" do
             post_request
-            firm = Firm.find_by(ccms_id: raw_details_response[:providerFirmId])
+            firm = Firm.find_by(ccms_id: raw_details_response.dig(:firm, :ccmsFirmId))
             expect(provider.firm_id).to eq firm.id
             expect(firm.offices.size).to eq 1
-            expect(firm.offices.first.ccms_id).to eq raw_details_response[:providerOffices].first[:id].to_s
+            expect(firm.offices.first.ccms_id).to eq raw_details_response[:officeCodes].first[:ccmsFirmOfficeId].to_s
           end
 
           it "displays the start page" do
@@ -200,7 +203,7 @@ RSpec.describe SamlSessionsController do
           it "does not schedule a job to update the provider details" do
             expect(provider).to receive(:update_details).and_call_original
             expect(ProviderDetailsCreatorWorker).not_to receive(:perform_async).with(provider.id)
-            expect(ProviderDetailsCreator).not_to receive(:call).with(provider)
+            expect(PDA::ProviderDetailsCreator).not_to receive(:call).with(provider)
             post_request
           end
         end
@@ -221,34 +224,74 @@ RSpec.describe SamlSessionsController do
 
   def raw_details_response
     {
-      providerFirmId: 22_381,
-      contactUserId: 29_562,
-      contacts: [
+      firm: {
+        firmId: 3_959_183,
+        firmNumber: "50736",
+        ccmsFirmId: 10_835_831,
+        firmName: "DT SCRIPT PROVIDER 1",
+      },
+      user: {
+        userId: 454_031,
+        ccmsContactId: 0,
+        userLogin: "DT_SCRIPT_USER1",
+        name: "Dts User1",
+        emailAddress: "deepak.tanna@digital.justice.gov.uk",
+        portalStatus: "Active",
+      },
+      officeCodes: [
         {
-          id: 568_352,
-          name: "SALLYCORNHILL",
-        },
-        {
-          id: 2_017_809,
-          name: username,
-        },
-      ],
-      providerOffices: [
-        {
-          id: 81_693,
-          name: "Test1 and Co",
+          firmOfficeId: 145_434,
+          ccmsFirmOfficeId: 34_406_595,
+          firmOfficeCode: "2Q242F",
+          officeName: "2Q242F,1 Skyscraper",
+          officeCodeAlt: "DT Script Office 1",
         },
       ],
     }
   end
 
-  def raw_404_response
+  def firm_response
     {
-      timestamp: "2020-10-27T12:15:13.639+0000",
-      status: 404,
-      error: "Not Found",
-      message: "No records found for [bob%20the%20builder]",
-      path: "/api/providerDetails/bob%20the%20builder",
+      firm: {
+        firmId: 3_959_183,
+        firmNumber: "50736",
+        ccmsFirmId: 10_835_831,
+        firmName: "DT SCRIPT PROVIDER 1",
+      },
+      offices: [
+        {
+          firmOfficeId: 145_434,
+          ccmsFirmOfficeId: 34_406_595,
+          firmOfficeCode: "2Q242F",
+          officeName: "2Q242F,1 Skyscraper",
+          officeCodeAlt: "DT Script Office 1",
+          addressLine1: "1 Skyscraper",
+          addressLine2: "1 Some Road",
+          addressLine3: "",
+          addressLine4: "",
+          city: "Metropolis",
+          county: "",
+          postCode: "LE1 1AA",
+          dxCentre: "",
+          dxNumber: "",
+          telephoneAreaCode: "01162",
+          telephoneNumber: "555124",
+          faxAreaCode: "",
+          faxNumber: "",
+          emailAddress: "me@email.uk",
+          vatRegistrationNumber: "",
+          type: "Legal Services Provider",
+          headOffice: "N/A",
+          creationDate: "2023-11-10",
+          lscRegion: "Midlands",
+          lscBidZone: "Leicester",
+          lscAreaOffice: "Nottingham",
+          cjsForceName: "Leicestershire",
+          localAuthority: "City of Leicester",
+          policeStationAreaName: "Leicester",
+          dutySolicitorAreaName: "Leicester",
+        },
+      ],
     }
   end
 

--- a/spec/services/provider_after_login_service_spec.rb
+++ b/spec/services/provider_after_login_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ProviderAfterLoginService do
       let(:provider) { create(:provider, :created_by_devise, :with_ccms_apply_role, invalid_login_details: "provider_details_api_error") }
 
       context "and the provider cannot be found on Provider Details API" do
-        before { allow(ProviderDetailsCreator).to receive(:call).and_raise(ProviderDetailsRetriever::ApiRecordNotFoundError) }
+        before { allow(PDA::ProviderDetailsCreator).to receive(:call).and_raise(PDA::ProviderDetailsRetriever::ApiRecordNotFoundError) }
 
         it "updates the provider invalid login details" do
           call
@@ -30,7 +30,7 @@ RSpec.describe ProviderAfterLoginService do
       end
 
       context "and the provider found on Provider Details API" do
-        before { allow(ProviderDetailsCreator).to receive(:call).with(provider) }
+        before { allow(PDA::ProviderDetailsCreator).to receive(:call).with(provider) }
 
         it "does not update invalid login details" do
           call
@@ -39,7 +39,7 @@ RSpec.describe ProviderAfterLoginService do
       end
 
       context "and the provider details API not available" do
-        before { allow(ProviderDetailsCreator).to receive(:call).and_raise(ProviderDetailsRetriever::ApiError) }
+        before { allow(PDA::ProviderDetailsCreator).to receive(:call).and_raise(PDA::ProviderDetailsRetriever::ApiError) }
 
         it "updates the provider invalid login details" do
           call


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5177)

This implements calls to the new, name-spaced PDA, versions of the provider classes, PDA::ProviderDetailsCreator

I had to add some `# :nocov:` tags to the old ProviderDetailsRetriever as it was only tested via other invocations. 
As the intention is to remove this class once we are happy with the new classes, this seemed like a small infraction.  
Feel free to argue in the comments! 😆  

I have tested locally by re-creating my database, re-seeding and deleting a test account, it's firm and the offices. Once pointed at a portal instance, it creates all three objects successfully.

This can be re-created on the branch for testing purposes

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
