### PR TITLE
AP-5368 cash income and outgoings bug

### DIFF
--- a/app/controllers/providers/means/cash_incomes_controller.rb
+++ b/app/controllers/providers/means/cash_incomes_controller.rb
@@ -3,13 +3,16 @@ module Providers
     class CashIncomesController < ProviderBaseController
       before_action :setup_variables, only: %i[show update]
 
-      def show; end
+      def show
+        @none_selected = legal_aid_application.no_cash_income?
+      end
 
       def update
         if aggregated_cash_income.update(form_params)
           update_no_cash_income(form_params)
           go_forward
         else
+          @none_selected = form_params[:none_selected] == "true"
           render :show
         end
       end

--- a/app/controllers/providers/means/cash_outgoings_controller.rb
+++ b/app/controllers/providers/means/cash_outgoings_controller.rb
@@ -3,13 +3,16 @@ module Providers
     class CashOutgoingsController < ProviderBaseController
       before_action :setup_cash_outgoings, only: %i[show update]
 
-      def show; end
+      def show
+        @none_selected = legal_aid_application.no_cash_outgoings?
+      end
 
       def update
         if aggregated_cash_outgoings.update(form_params)
           update_no_cash_outgoings(form_params)
           go_forward
         else
+          @none_selected = form_params[:none_selected] == "true"
           render :show
         end
       end

--- a/app/views/shared/means/_cash_income.html.erb
+++ b/app/views/shared/means/_cash_income.html.erb
@@ -26,7 +26,7 @@
       </div>
 
       <%= form.govuk_radio_divider %>
-      <%= form.govuk_check_box :none_selected, true, "", multiple: false, label: { text: none_of_the_above }, checked: type.no_cash_income? %>
+      <%= form.govuk_check_box :none_selected, true, "", multiple: false, label: { text: none_of_the_above }, checked: @none_selected %>
     <% end %>
 
     <%= next_action_buttons(

--- a/app/views/shared/means/_cash_outgoing.html.erb
+++ b/app/views/shared/means/_cash_outgoing.html.erb
@@ -27,7 +27,7 @@
       </div>
 
       <%= form.govuk_radio_divider %>
-      <%= form.govuk_check_box :none_selected, true, "", multiple: false, label: { text: t("generic.none_of_the_above") }, checked: type.no_cash_outgoings? %>
+      <%= form.govuk_check_box :none_selected, true, "", multiple: false, label: { text: t("generic.none_of_the_above") }, checked: @none_selected %>
     <% end %>
 
     <%= next_action_buttons(


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5368)

Ensure none_selected value is retained when there is an error

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
