### PR TITLE
AP-5490 add inset text to CYA pages

### DIFF
--- a/app/views/providers/check_capital_answers/show.html.erb
+++ b/app/views/providers/check_capital_answers/show.html.erb
@@ -2,6 +2,10 @@
 
 <%= page_template(page_title: t(".h1-heading")) do %>
 
+  <%= govuk_inset_text do %>
+    <p class="govuk-body govuk-!-padding-bottom-2"><%= t("generic.cya_inset_text") %></p>
+  <% end %>
+
   <h2 class="govuk-heading-l"><%= t(".capital-section-heading#{individual}") %></h2>
 
   <%= render "shared/check_answers/assets", individual: %>

--- a/app/views/providers/check_merits_answers/show.html.erb
+++ b/app/views/providers/check_merits_answers/show.html.erb
@@ -18,6 +18,10 @@
         form:,
       ) do %>
 
+    <%= govuk_inset_text do %>
+      <p class="govuk-body govuk-!-padding-bottom-2"><%= t("generic.cya_inset_text") %></p>
+    <% end %>
+
     <%= render(
           "shared/check_answers/merits",
           incident: @legal_aid_application.latest_incident,

--- a/app/views/providers/check_provider_answers/_shared.html.erb
+++ b/app/views/providers/check_provider_answers/_shared.html.erb
@@ -1,3 +1,7 @@
+<%= govuk_inset_text do %>
+  <p class="govuk-body govuk-!-padding-bottom-2"><%= t("generic.cya_inset_text") %></p>
+<% end %>
+
   <h2 class="govuk-heading-m"><%= t ".section_client.heading" %></h2>
 
   <%= render(

--- a/app/views/providers/means/check_income_answers/show.html.erb
+++ b/app/views/providers/means/check_income_answers/show.html.erb
@@ -6,6 +6,10 @@
 
 <%= page_template(page_title: t(".h1-heading")) do %>
 
+  <%= govuk_inset_text do %>
+    <p class="govuk-body govuk-!-padding-bottom-2"><%= t("generic.cya_inset_text") %></p>
+  <% end %>
+
   <%= render "providers/means/check_income_answers/applicant_income_assessment" %>
 
   <%= render "providers/means/check_income_answers/partner_income_assessment" if @legal_aid_application.applicant.has_partner_with_no_contrary_interest? %>

--- a/config/locales/en/generic.yml
+++ b/config/locales/en/generic.yml
@@ -19,6 +19,7 @@ en:
     confirm: Are you sure?
     create_test_applications: Create test applications
     cy: Cymraeg
+    cya_inset_text: You cannot change the answers on this page once you save and continue.
     destroy: Destroy
     edit: Edit
     en: English

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1344,6 +1344,7 @@ en:
     check_capital_answers:
       show:
         h1-heading: Check your answers
+        inset_text: You cannot change the answers on this page once you save and continue.
         capital-section-heading: Your client's capital
         capital-section-heading_with_partner: Your client's and their partner's capital
         what_happens_next:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1344,7 +1344,6 @@ en:
     check_capital_answers:
       show:
         h1-heading: Check your answers
-        inset_text: You cannot change the answers on this page once you save and continue.
         capital-section-heading: Your client's capital
         capital-section-heading_with_partner: Your client's and their partner's capital
         what_happens_next:

--- a/features/providers/check_provider_answers.feature
+++ b/features/providers/check_provider_answers.feature
@@ -2,6 +2,7 @@ Feature: Checking client details answers backwards and forwards
   @javascript
   Scenario: Send client's mail to their home address
     Given I complete the passported journey as far as check your answers for client details
+    Then I should see 'You cannot change the answers on this page once you save and continue.'
 
     Then the following sections should exist:
       | tag | section |


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5490)

Add inset text to inform users that they cannot go back once they have gone past a CYA page

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
