### PR TITLE
Chore: split rubocop from bulk dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,10 +20,14 @@ updates:
         versions:
           - ">= 8.0.0"
     groups:
-      bundler:
+      rubocop:
         patterns:
           - "rubocop*"
+      bundler:
+        patterns:
           - "*"
+        exclude-patterns:
+          - "rubocop*"
     open-pull-requests-limit: 10
     reviewers:
       - "ministryofjustice/laa-apply-for-legal-aid"


### PR DESCRIPTION
## What

V3 🙄 
The rubocop changes block so many other gems, we agreed to try splitting liek this and see if it allows us to work on rubocop fixes without delaying other gems

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
