### PR TITLE
Chore: Update URI gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,13 +102,6 @@ gem "view_component"
 # Catching unsafe migrations in development
 gem "strong_migrations"
 
-# TODO: Added on 12 Nov 2024 - CB - review as part of AP-5513
-# The 1.0.0+ version of URI deprecated certain URI pattern names
-# this in turn broke CookieJar, a deprecated gem, that is used in em-http-request, that is
-# required by puffing-billy.  Rather than strip out puffing-billy or wait weeks for the
-# maintainers of upstream gems to agree a path, we are locking this below the breaking change
-gem "uri", "< 1.0.0"
-
 group :development, :test do
   gem "awesome_print", "~> 1.9.2"
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -725,7 +725,7 @@ GEM
       tzinfo (>= 1.0.0)
     uber (0.1.0)
     unicode-display_width (2.6.0)
-    uri (0.13.1)
+    uri (1.0.2)
     useragent (0.16.10)
     vcr (6.3.1)
       base64
@@ -855,7 +855,6 @@ DEPENDENCIES
   super_diff
   table_print
   tzinfo-data
-  uri (< 1.0.0)
   vcr
   view_component
   webdack-uuid_migration (~> 1.5.0)

--- a/app/services/faraday/soap_call.rb
+++ b/app/services/faraday/soap_call.rb
@@ -34,7 +34,7 @@ module Faraday
   private
 
     def parse_url(input)
-      if input.match?(URI::DEFAULT_PARSER.regexp[:ABS_URI])
+      if input.match?(URI::ABS_URI)
         # if wsdl_url is a URL return it
         @url = input
       elsif File.file?(input)


### PR DESCRIPTION

## What

The URI gem jumped from 0.13.1 to 1.0.x a couple of times... It removed some regex patterns and renamed some.

This PR removes the lock below v1, updates the Gem and updates the URI pattern loader for the ABS_URI pattern

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
