### PR TITLE
AP-5244: change access_denied status to 403

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -45,7 +45,7 @@ private
   def supported_errors
     {
       page_not_found: :not_found,
-      access_denied: :ok,
+      access_denied: :forbidden,
       assessment_already_completed: :ok,
       internal_server_error: :internal_server_error,
     }

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe ErrorsController, :show_exceptions do
     let(:get_invalid_id) { get feedback_path(SecureRandom.uuid) }
 
     before do
-      allow(Feedback).to receive(:find).and_raise { ArgumentError.new("dummy arg to emulate 500 internal server error") }
+      allow(Feedback).to receive(:find).and_raise { ArgumentError.new("dummy error to emulate 500 internal server error") }
     end
 
     context "with default locale" do
@@ -77,6 +77,27 @@ RSpec.describe ErrorsController, :show_exceptions do
         get feedback_path(SecureRandom.uuid, locale: :cy)
         expect(page)
           .to have_css("h1", text: "ecivres ruo htiw gnorw tnew gnihtemos ,yrroS")
+      end
+    end
+  end
+
+  context "when access denied/403 due to attempt to access another providers application" do
+    let(:not_their_application) { create(:legal_aid_application, provider: create(:provider)) }
+    let(:get_unauthorized) { get providers_legal_aid_application_previous_references_path(not_their_application) }
+
+    before do
+      sign_in create(:provider)
+      get_unauthorized
+      follow_redirect! # required because currently handled via a redirect
+    end
+
+    context "with default locale" do
+      it "responds with expected http status" do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "renders access denied" do
+        expect(response).to render_template("errors/show/_access_denied")
       end
     end
   end
@@ -141,9 +162,9 @@ RSpec.describe ErrorsController, :show_exceptions do
   describe "GET /error/access_denied" do
     subject(:get_error) { get error_path(:access_denied) }
 
-    it "responds with ok/200 status" do
+    it "responds with forbidden/403 status" do
       get_error
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "renders assessment_already_completed" do


### PR DESCRIPTION
## What
Change status code for the access_denied page redirect to 403

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5524)

So the response status matches the intended behaviour of being
forbidden/403 for the current user.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
