### PR TITLE
AP-5524: Change access denied status to 403

### DIFF
--- a/app/controllers/admin_users/omniauth_callbacks_controller.rb
+++ b/app/controllers/admin_users/omniauth_callbacks_controller.rb
@@ -12,12 +12,7 @@ module AdminUsers
     end
 
     def failure(reason: "Process cancelled")
-      begin
-        set_flash_message(:error, :failure, kind: "Google", reason:)
-        raise AuthController::AuthorizationError, "Kind: Google, reason: #{reason}"
-      rescue StandardError => e
-        AlertManager.capture_exception(e)
-      end
+      set_flash_message(:error, :failure, kind: "Google", reason:)
       redirect_to error_path(:access_denied)
     end
 

--- a/app/controllers/applicants/omniauth_callbacks_controller.rb
+++ b/app/controllers/applicants/omniauth_callbacks_controller.rb
@@ -2,14 +2,12 @@
 # Note that you may need to restart the server to apply changes to this file.
 module Applicants
   class OmniauthCallbacksController < Devise::OmniauthCallbacksController
-    class MissingApplicantError < StandardError; end
     before_action :authenticate_applicant!, only: [:true_layer]
     skip_back_history_for :true_layer, :failure
 
     def true_layer
       unless applicant
         set_flash_message(:error, :failure, kind: "TrueLayer", reason: "Unable to find matching application")
-        AlertManager.capture_exception(MissingApplicantError.new("Unable to find applicant on return from TrueLayer"))
         redirect_to citizens_consent_path
         return
       end

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,18 +1,10 @@
 class AuthController < ApplicationController
   include Devise::Controllers::Rememberable
 
-  class AuthorizationError < StandardError; end
-
   def failure
     # redirect to consents page if it was an applicant failing to login at his bank
     #
-    AlertManager.capture_message("Omniauth failure #{params.to_unsafe_hash.inspect}")
     if auth_error_during_bank_login?
-      begin
-        raise AuthorizationError, "Redirecting to access denied page - unexpected origin: '#{origin}'"
-      rescue StandardError => e
-        AlertManager.capture_exception(e)
-      end
       redirect_to error_path(:access_denied)
     else
       redirect_to citizens_consent_path(auth_failure: true)

--- a/app/controllers/concerns/providers/authorizable.rb
+++ b/app/controllers/concerns/providers/authorizable.rb
@@ -33,7 +33,7 @@ module Providers
             if current_policy.show_submitted_application?
               redirect_to_show_path
             else
-              redirect_to_auth_error_path
+              redirect_to error_path(:access_denied)
             end
           end
         end
@@ -43,15 +43,6 @@ module Providers
         redirect_to providers_legal_aid_application_submitted_application_path(legal_aid_application)
       end
 
-      def redirect_to_auth_error_path
-        begin
-          raise AuthController::AuthorizationError, "Provider not authorised"
-        rescue StandardError => e
-          AlertManager.capture_exception(e)
-        end
-        redirect_to error_path(:access_denied)
-      end
-
       def current_policy
         Pundit.policy pundit_user, legal_aid_application
       end
@@ -59,11 +50,6 @@ module Providers
       def authorize_portal_user?
         return false if current_provider.portal_enabled?
 
-        begin
-          raise AuthController::AuthorizationError, "Provider not enabled on the portal"
-        rescue StandardError => e
-          AlertManager.capture_exception(e)
-        end
         redirect_to error_path(:access_denied)
       end
 

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -45,7 +45,7 @@ private
   def supported_errors
     {
       page_not_found: :not_found,
-      access_denied: :ok,
+      access_denied: :forbidden,
       assessment_already_completed: :ok,
       internal_server_error: :internal_server_error,
     }

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe ErrorsController, :show_exceptions do
     let(:get_invalid_id) { get feedback_path(SecureRandom.uuid) }
 
     before do
-      allow(Feedback).to receive(:find).and_raise { ArgumentError.new("dummy arg to emulate 500 internal server error") }
+      allow(Feedback).to receive(:find).and_raise { ArgumentError.new("dummy error to emulate 500 internal server error") }
     end
 
     context "with default locale" do
@@ -77,6 +77,27 @@ RSpec.describe ErrorsController, :show_exceptions do
         get feedback_path(SecureRandom.uuid, locale: :cy)
         expect(page)
           .to have_css("h1", text: "ecivres ruo htiw gnorw tnew gnihtemos ,yrroS")
+      end
+    end
+  end
+
+  context "when access denied/403 due to attempt to access another providers application" do
+    let(:not_their_application) { create(:legal_aid_application, provider: create(:provider)) }
+    let(:get_unauthorized) { get providers_legal_aid_application_previous_references_path(not_their_application) }
+
+    before do
+      sign_in create(:provider)
+      get_unauthorized
+      follow_redirect! # required because currently handled via a redirect
+    end
+
+    context "with default locale" do
+      it "responds with expected http status" do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "renders access denied" do
+        expect(response).to render_template("errors/show/_access_denied")
       end
     end
   end
@@ -141,9 +162,9 @@ RSpec.describe ErrorsController, :show_exceptions do
   describe "GET /error/access_denied" do
     subject(:get_error) { get error_path(:access_denied) }
 
-    it "responds with ok/200 status" do
+    it "responds with forbidden/403 status" do
       get_error
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:forbidden)
     end
 
     it "renders assessment_already_completed" do


### PR DESCRIPTION
## What
Change status code for the access_denied page redirect to 403

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5524)

So the response status matches the intended behaviour of being
forbidden/403 for the current user.

A subsequent commit removes sentry capturing of details of failures
because the originating PR suggests doing so and there does not appear
to have been any action taken on these, if they are still occuring (which I cannot
see).

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
