### PR TITLE
Revert "TEMP: Use UAT portal login"

### DIFF
--- a/helm_deploy/apply-for-legal-aid/values-uat.yaml
+++ b/helm_deploy/apply-for-legal-aid/values-uat.yaml
@@ -103,7 +103,7 @@ laa_portal:
   idpSsoTargetUrl: "https://portal.uat.legalservices.gov.uk/oamfed/idp/samlv20"
   idpSloTargetUrl: "https://portal.uat.legalservices.gov.uk/oam/server/logout"
   idpCertFingerprintAlgorithm: "<idp-cert-fingerprint-alg-goes-here>"
-  mockSaml: "false"
+  mockSaml: "true"
 
 provider_details:
   url: "https://ccms-pda.stg.legalservices.gov.uk/api/providerDetails"


### PR DESCRIPTION
## What

This reverts commit fec1668f79855f3b33280bafbc8dab062cc58329.

It was merged by mistake while testing the CWA PDA cut-over

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
