### PR TITLE
AP-4435 fix form grouping accessibility error

### DIFF
--- a/app/views/shared/forms/_applicant_form.html.erb
+++ b/app/views/shared/forms/_applicant_form.html.erb
@@ -13,7 +13,6 @@
         form:,
       ) do %>
 
-    <div class="govuk-!-padding-bottom-2"></div>
     <%= form.govuk_fieldset legend: { text: t(".name") },
                             "aria-label": t(".aria_label") do %>
       <%= form.govuk_text_field :first_name, label: { text: "First name" }, width: "three-quarters" %>
@@ -27,11 +26,9 @@
       <% end %>
       <%= form.govuk_radio_button :changed_last_name, false, label: { text: t("generic.no") } %>
     <% end %>
-    <div class="govuk-!-padding-bottom-4"></div>
+
     <%= form.govuk_date_field :date_of_birth, legend: { text: t("shared.forms.date_input_fields.date_of_birth_label") },
                                               hint: { text: t("shared.forms.date_input_fields.date_of_birth_hint") } %>
-
-    <div class="govuk-!-padding-bottom-2"></div>
 
     <%= next_action_buttons(show_draft: true, form:) %>
   <% end %>

--- a/app/views/shared/forms/_applicant_form.html.erb
+++ b/app/views/shared/forms/_applicant_form.html.erb
@@ -14,7 +14,8 @@
       ) do %>
 
     <div class="govuk-!-padding-bottom-2"></div>
-    <%= form.govuk_fieldset legend: { text: t(".name") } do %>
+    <%= form.govuk_fieldset legend: { text: t(".name") },
+                            "aria-label": t(".aria_label") do %>
       <%= form.govuk_text_field :first_name, label: { text: "First name" }, width: "three-quarters" %>
       <%= form.govuk_text_field :last_name, label: { text: "Last name" }, width: "three-quarters" %>
     <% end %>

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -722,6 +722,7 @@ en:
       applicant_form:
         page_title: Enter your client's details
         name: Name
+        aria_label: Client's name
         email_label: Email address
         changed_last_name: Has your client ever changed their last name?
         changed_last_name_hint: For example, through marriage or deed poll


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4435)

Add an aria-label to the `Name` group on the client details page to make it clear to screen-reader users that the fields `First name` and `Last name` refer to the client name

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
