### PR TITLE
Chore: Fix Welsh locale flicker

### DIFF
--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ErrorsController, :show_exceptions do
       end
     end
 
-    context "with Welsh locale" do
+    context "with Welsh locale", :use_welsh_locale do
       it "displays the correct content" do
         get("/unknown/path", params: { locale: :cy })
         expect(page)
@@ -44,7 +44,7 @@ RSpec.describe ErrorsController, :show_exceptions do
       end
     end
 
-    context "with Welsh locale" do
+    context "with Welsh locale", :use_welsh_locale do
       it "displays the correct content" do
         get feedback_path(SecureRandom.uuid, locale: :cy)
         expect(page)
@@ -72,7 +72,7 @@ RSpec.describe ErrorsController, :show_exceptions do
       end
     end
 
-    context "with Welsh locale" do
+    context "with Welsh locale", :use_welsh_locale do
       it "displays the correct content" do
         get feedback_path(SecureRandom.uuid, locale: :cy)
         expect(page)
@@ -102,7 +102,7 @@ RSpec.describe ErrorsController, :show_exceptions do
         .and have_content("If you pasted the web address, check you copied the entire address.")
     end
 
-    context "with Welsh locale" do
+    context "with Welsh locale", :use_welsh_locale do
       it "displays the correct content" do
         get error_path(:page_not_found, locale: :cy)
         expect(page)
@@ -129,7 +129,7 @@ RSpec.describe ErrorsController, :show_exceptions do
       expect(page).to have_css("h1", text: "You've already shared your financial information")
     end
 
-    context "with Welsh locale" do
+    context "with Welsh locale", :use_welsh_locale do
       it "displays the correct content" do
         get error_path(:assessment_already_completed, locale: :cy)
         expect(page)
@@ -156,7 +156,7 @@ RSpec.describe ErrorsController, :show_exceptions do
       expect(page).to have_css("h1", text: "Access denied")
     end
 
-    context "with Welsh locale" do
+    context "with Welsh locale", :use_welsh_locale do
       it "displays the correct content" do
         get error_path(:access_denied, locale: :cy)
         expect(page)
@@ -184,7 +184,7 @@ RSpec.describe ErrorsController, :show_exceptions do
         .to have_css("h1", text: "Sorry, something went wrong with our service")
     end
 
-    context "with Welsh locale" do
+    context "with Welsh locale", :use_welsh_locale do
       it "displays the correct content" do
         get error_path(:internal_server_error, locale: :cy)
         expect(page)

--- a/spec/support/welsh_language.rb
+++ b/spec/support/welsh_language.rb
@@ -1,0 +1,9 @@
+RSpec.configure do |config|
+  config.around do |example|
+    if example.metadata[:use_welsh_locale] == true
+      I18n.with_locale(:cy) { example.run }
+    else
+      example.run
+    end
+  end
+end


### PR DESCRIPTION
## What

A recent change to the error controller removed the around block for the welsh language checks.  This was needed as, otherwise, it leaves the locale set to CY for subsequent tests.  This caused flickers in CI.

This PR creates a new rspec flag, :use_welsh_locale, to reduce the noise in individual rspec files, while still allowing the locale to be set for an individual group of tests

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
