### PR TITLE
fix: remove debug block

### DIFF
--- a/app/views/providers/proceeding_loop/substantive_defaults/show.html.erb
+++ b/app/views/providers/proceeding_loop/substantive_defaults/show.html.erb
@@ -26,11 +26,7 @@
         <%= form.hidden_field :substantive_scope_limitation_description %>
         <%= form.hidden_field :substantive_scope_limitation_code %>
 
-        <%= form.govuk_radio_button :accepted_substantive_defaults, true, label: { text: t("generic.yes") }, link_errors: true do %>
-          <% if form.object.additional_params.present? %>
-            <%= pp form.object.additional_params %>
-          <% end %>
-        <% end %>
+        <%= form.govuk_radio_button :accepted_substantive_defaults, true, label: { text: t("generic.yes") }, link_errors: true %>
         <%= form.govuk_radio_button :accepted_substantive_defaults, false, label: { text: t("generic.no") } %>
       <% end %>
     <% end %>


### PR DESCRIPTION

## What
Remove debug block

left in accidentally


### Before

![Screenshot 2024-11-28 at 13 39 06](https://github.com/user-attachments/assets/e2eaeb33-598e-42af-bf00-0387920ccd13)


### After

![Screenshot 2024-11-28 at 18 45 34](https://github.com/user-attachments/assets/b1caf870-6e77-4685-9267-5e2ca13fbbd8)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
