### PR TITLE
AP-5524 extension: handle invalid format request with 404

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -7,7 +7,10 @@
 class ErrorsController < ApplicationController
   before_action :update_locale, :set_error_name
   def show
-    render :show, status: status_for(@error_name)
+    respond_to do |format|
+      format.html { render :show, status: status_for(@error_name) }
+      format.all { render plain: "Not found", status: :not_found }
+    end
   end
 
 private

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ErrorsController, :show_exceptions do
     let(:get_invalid_path) { get("/unknown/path") }
 
     context "with default locale" do
-      it "responds with http status" do
+      it "responds with expected http status" do
         get_invalid_path
         expect(response).to have_http_status(:not_found)
       end
@@ -25,6 +25,30 @@ RSpec.describe ErrorsController, :show_exceptions do
         get("/unknown/path", params: { locale: :cy })
         expect(page)
           .to have_css("h1", text: "dnuof ton egaP")
+      end
+    end
+  end
+
+  context "when page not found due to non-html format" do
+    let(:get_invalid_path) { get("/unknown/path.xml") }
+
+    context "with default locale" do
+      it "responds with expected http status" do
+        get_invalid_path
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "renders not found plain text" do
+        get_invalid_path
+        expect(response.body).to eq("Not found")
+      end
+    end
+
+    context "with Welsh locale", :use_welsh_locale do
+      it "displays the correct content" do
+        get("/unknown/path.xml", params: { locale: :cy })
+
+        expect(response.body).to eq("Not found")
       end
     end
   end


### PR DESCRIPTION


## What
Handle invalid format request with 404

[Extension to story](https://dsdmoj.atlassian.net/browse/AP-5524)

Scripted probing attacks may use format modifiers on their
request. This handles them with a 404. The advatage
of this to not give the attacker info on what is a server
error and to not raise this an actual error in the code base.

We have an alert for 404s (exceeding 100) in a 24 hour period
which will alert us to a serious probing attack in any event.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
