### PR TITLE
Ap 5564 capital discretionary disregards bug

### DIFF
--- a/db/migrate/20241202152952_change_capital_disregards_index.rb
+++ b/db/migrate/20241202152952_change_capital_disregards_index.rb
@@ -1,0 +1,8 @@
+class ChangeCapitalDisregardsIndex < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    remove_index(:capital_disregards, name: :index_capital_disregards_on_legal_aid_application_id_and_name)
+    add_index(:capital_disregards, [:legal_aid_application_id, :name, :mandatory], unique: true, algorithm: :concurrently)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_15_143002) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_02_152952) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -303,7 +303,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_15_143002) do
     t.string "account_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["legal_aid_application_id", "name"], name: "index_capital_disregards_on_legal_aid_application_id_and_name", unique: true
+    t.index ["legal_aid_application_id", "name", "mandatory"], name: "idx_on_legal_aid_application_id_name_mandatory_f4f47d6261", unique: true
     t.index ["legal_aid_application_id"], name: "index_capital_disregards_on_legal_aid_application_id"
   end
 

--- a/spec/forms/providers/means/capital_disregards/discretionary_form_spec.rb
+++ b/spec/forms/providers/means/capital_disregards/discretionary_form_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe Providers::Means::CapitalDisregards::DiscretionaryForm do
           expect(application.discretionary_capital_disregards.count).to eq 0
         end
       end
+
+      context "with an existing mandatory disregard for backdated benefits" do
+        let(:mandatory_capital_disregard) { create(:capital_disregard, :mandatory, name: "backdated_benefits") }
+
+        before { application.capital_disregards << mandatory_capital_disregard }
+
+        it "updates the capital_discretionary_disregards" do
+          expect(application.discretionary_capital_disregards.count).to eq 2
+          expect(application.mandatory_capital_disregards.count).to eq 1
+          expect(application.capital_disregards.pluck(:name)).to match_array(%w[backdated_benefits backdated_benefits national_emergencies_trust])
+        end
+      end
     end
 
     context "when the form is not valid" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5564)

This error was occuring because it was possible to add both a mandatory and a discretionary capital disregard with  name backdated benefits but there was a unique index on the capital_disregards table for legal_aid_application and name.

This pr adds mandatory to the the index so that it is possible to add both a discretionary and a mandatory capital disregard with name backdated_benefits.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
