### PR TITLE
AP-5529: Add  Join our research panel link to the footer

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,6 +70,7 @@ module ApplicationHelper
     {
       t("layouts.application.footer.contact") => contact_path,
       t("layouts.application.footer.feedback") => new_feedback_path,
+      t("layouts.application.footer.research_panel") => ENV.fetch("RESEARCH_PANEL_FORM_LINK", root_path),
       # Currently we can only update and store cookie preferences for the provider, citizen users are shown the generic GOV.UK cookies page
       t("layouts.application.footer.cookies") => (current_provider ? providers_cooky_path(current_provider) : "https://www.gov.uk/help/cookies"),
       t("layouts.application.footer.privacy_policy") => privacy_policy_index_path,

--- a/config/locales/cy/layouts.yml
+++ b/config/locales/cy/layouts.yml
@@ -18,6 +18,7 @@ cy:
         digital_services_html: secivreS latigiD >rbba/<JOM>'ecitsuJ fo yrtsiniM'=eltit
           rbba<
         feedback: kcabdeeF
+        research_panel: lenap hcraeser ruo noiJ
         open_gov_link_text: 0.3v ecneciL tnemnrevoG nepO
         privacy_policy: ycilop ycavirP
         span_text_1: eht rednu elbaliava si tnetnoc llA

--- a/config/locales/en/layouts.yml
+++ b/config/locales/en/layouts.yml
@@ -17,6 +17,7 @@ en:
         copyright: Crown copyright
         digital_services_html: MOJ Digital Services
         feedback: Feedback
+        research_panel: Join our research panel
         open_gov_link_text: Open Government Licence v3.0
         privacy_policy: Privacy policy
         span_text_1: All content is available under the

--- a/helm_deploy/apply-for-legal-aid/templates/_envs.tpl
+++ b/helm_deploy/apply-for-legal-aid/templates/_envs.tpl
@@ -373,6 +373,11 @@ env:
       secretKeyRef:
         name: laa-apply-for-legalaid-secrets
         key: googleDataStudioUrl
+  - name: RESEARCH_PANEL_FORM_LINK
+    valueFrom:
+      secretKeyRef:
+        name: laa-apply-for-legalaid-secrets
+        key: researchLink
   - name: ENCRYPTION_PRIMARY_KEY
     valueFrom:
       secretKeyRef:


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5529)

This was raised by the central UR team.  They have requested that the url be hidden from github crawlers, so the form link is stored in AWS Secret Manager for each environment.

It is then loaded in _ENVS.tpl and passed to the footer meta items.

This routes to root_path if the value is missing, this should only affect devs without a RESEARCH_PANEL_FORM_LINK in their .env files, as each environment has the value set

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
