### PR TITLE
Chore: Remove rails-i18n from dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       - dependency-name: rails
         versions:
           - ">= 8.0.0"
+      - dependency-name: rails-i18n
+        versions:
+          - ">= 8.0.0"
       - dependency-name: railties
         versions:
           - ">= 8.0.0"


### PR DESCRIPTION
## What

the rails-i18n gem forces railties to 8+ and thus all of rails, this breaks the deploys and updates

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
