### PR TITLE
AP-4409: Add the related_orders page to the PLF proceeding loop

### DIFF
--- a/app/controllers/providers/proceeding_interrupts/related_orders_controller.rb
+++ b/app/controllers/providers/proceeding_interrupts/related_orders_controller.rb
@@ -1,0 +1,39 @@
+module Providers
+  module ProceedingInterrupts
+    class RelatedOrdersController < ProviderBaseController
+      before_action :proceeding
+      def show
+        @form = RelatedOrdersForm.new(model: proceeding)
+      end
+
+      def update
+        @form = RelatedOrdersForm.new(form_params)
+        return redirect_to providers_legal_aid_application_sca_interrupt_path(legal_aid_application, "plf_none_selected") if redirect_on_none_selected?
+
+        render :show, status: :unprocessable_content unless save_continue_or_draft(@form, proceeding:)
+      end
+
+    private
+
+      def redirect_on_none_selected?
+        form_params[:none_selected].present? && !params.key?(:draft_button)
+      end
+
+      def proceeding
+        @proceeding ||= Proceeding.find(proceeding_id_param)
+      end
+
+      def proceeding_id_param
+        params.require(:id)
+      end
+
+      def form_params
+        merge_with_model(proceeding) do
+          params
+            .require(:proceeding)
+            .permit(:none_selected, related_orders: [])
+        end
+      end
+    end
+  end
+end

--- a/app/forms/providers/proceeding_interrupts/related_orders_form.rb
+++ b/app/forms/providers/proceeding_interrupts/related_orders_form.rb
@@ -1,0 +1,63 @@
+module Providers
+  module ProceedingInterrupts
+    class RelatedOrdersForm < BaseForm
+      form_for Proceeding
+
+      ORDER_TYPES = %i[
+        care
+        supervision
+        secure_accommodation
+        placement
+        adoption
+        emergency_protection
+        child_assessment
+        parenting
+        child_safety
+      ].freeze
+
+      attr_accessor :none_selected, :related_orders
+
+      validate :validate_any_checkbox_checked, unless: :draft?
+      validate :validate_none_and_another_checkbox_not_both_checked, unless: :draft?
+
+      def exclude_from_model
+        [:none_selected]
+      end
+
+      def save_as_draft
+        @draft = true
+        save!
+      end
+
+    private
+
+      def any_checkbox_checked?
+        none_selected? || related_orders.flatten.compact_blank.any?
+      end
+
+      def none_and_another_checkbox_checked?
+        none_selected? && related_orders.flatten.compact_blank.any?
+      end
+
+      def none_selected?
+        none_selected == "true"
+      end
+
+      def validate_any_checkbox_checked
+        errors.add :related_orders, error_message_for_none_selected unless any_checkbox_checked?
+      end
+
+      def validate_none_and_another_checkbox_not_both_checked
+        errors.add :related_orders, error_message_for_none_and_another_option_selected if none_and_another_checkbox_checked?
+      end
+
+      def error_message_for_none_selected
+        I18n.t("activemodel.errors.models.related_orders.attributes.base.none_selected")
+      end
+
+      def error_message_for_none_and_another_option_selected
+        I18n.t("activemodel.errors.models.related_orders.attributes.base.none_and_another_option_selected")
+      end
+    end
+  end
+end

--- a/app/services/flow/flows/provider_proceeding_interrupts.rb
+++ b/app/services/flow/flows/provider_proceeding_interrupts.rb
@@ -1,0 +1,9 @@
+module Flow
+  module Flows
+    class ProviderProceedingInterrupts < FlowSteps
+      STEPS = {
+        related_orders: Steps::Provider::ProceedingInterrupts::RelatedOrdersStep,
+      }.freeze
+    end
+  end
+end

--- a/app/services/flow/provider_flow_service.rb
+++ b/app/services/flow/provider_flow_service.rb
@@ -1,6 +1,7 @@
 module Flow
   class ProviderFlowService < BaseFlowService
     steps = {}.deep_merge(Flows::ProviderStart::STEPS)
+              .deep_merge(Flows::ProviderProceedingInterrupts::STEPS)
               .deep_merge(Flows::ProviderPartner::STEPS)
               .deep_merge(Flows::ProviderMeansStateBenefits::STEPS)
               .deep_merge(Flows::ProviderProceedingLoop::STEPS)

--- a/app/services/flow/steps/provider/proceeding_interrupts/related_orders_step.rb
+++ b/app/services/flow/steps/provider/proceeding_interrupts/related_orders_step.rb
@@ -1,0 +1,23 @@
+module Flow
+  module Steps
+    module Provider
+      module ProceedingInterrupts
+        PROHIBITED_STEPS_OR_SPECIFIC_ISSUE_PLF_REGEXP = /^PBM(16|17|20|21)[AE]?$/
+
+        RelatedOrdersStep = Step.new(
+          path: lambda do |application, proceeding|
+            Steps.urls.providers_legal_aid_application_related_order_path(application, proceeding)
+          end,
+          forward: lambda do |_application, options|
+            proceeding = options.is_a?(Proceeding) ? options : options[:proceeding]
+            if PROHIBITED_STEPS_OR_SPECIFIC_ISSUE_PLF_REGEXP.match?(proceeding.ccms_code)
+              :change_of_names
+            else
+              :has_other_proceedings
+            end
+          end,
+        )
+      end
+    end
+  end
+end

--- a/app/services/flow/steps/provider_start/proceedings_types_step.rb
+++ b/app/services/flow/steps/provider_start/proceedings_types_step.rb
@@ -2,6 +2,7 @@ module Flow
   module Steps
     module ProviderStart
       PROHIBITED_STEPS_OR_SPECIFIC_ISSUE_REGEXP = /^SE00[3478](.*)\z/
+      PUBLIC_LAW_FAMILY_PROCEEDING_REGEXP = /^PBM(16|17|18|19|20|21|22)[AE]?$/
 
       ProceedingsTypesStep = Step.new(
         path: ->(application) { Steps.urls.providers_legal_aid_application_proceedings_types_path(application) },
@@ -12,6 +13,8 @@ module Flow
             :proceedings_sca_heard_togethers
           elsif PROHIBITED_STEPS_OR_SPECIFIC_ISSUE_REGEXP.match?(proceeding.ccms_code)
             :change_of_names
+          elsif PUBLIC_LAW_FAMILY_PROCEEDING_REGEXP.match?(proceeding.ccms_code)
+            :related_orders
           else
             :has_other_proceedings
           end

--- a/app/views/providers/proceeding_interrupts/related_orders/show.html.erb
+++ b/app/views/providers/proceeding_interrupts/related_orders/show.html.erb
@@ -1,0 +1,33 @@
+<%= form_with(
+      url: providers_legal_aid_application_related_order_path,
+      model: @form,
+      method: :patch,
+      local: true,
+    ) do |form| %>
+  <%= page_template page_title: t(".page_title"),
+                    template: :basic,
+                    form: do %>
+    <%= form.govuk_check_boxes_fieldset :related_orders,
+                                        legend: { text: t(".page_title"), size: "l", tag: "h1" },
+                                        caption: { text: @proceeding.meaning, size: "xl" },
+                                        form_group: { class: @form.errors.any? ? "govuk-form-group--error" : "" } do %>
+      <div class="govuk-hint"><%= t(".hint") %></div>
+      <div class="govuk-hint"><%= t("generic.select_all_that_apply") %></div>
+      <div class="deselect-group" data-deselect-ctrl="#proceeding-none-selected-true-field">
+        <% Providers::ProceedingInterrupts::RelatedOrdersForm::ORDER_TYPES.each_with_index do |order, index| %>
+          <%= form.govuk_check_box(
+                :related_orders,
+                order.to_s,
+                link_errors: index.zero?,
+                label: { text: t("providers.proceeding_interrupts.related_orders.show.orders.#{order}") },
+                hint: { text: t("providers.proceeding_interrupts.related_orders.show.orders.#{order}_hint", default: "") },
+              ) %>
+        <% end %>
+      </div>
+      <%= form.govuk_radio_divider %>
+      <%= form.govuk_check_box :none_selected, true, "", multiple: false, label: { text: t(".none_of_these") } %>
+    <% end %>
+
+    <%= next_action_buttons(show_draft: true, form:) %>
+  <% end %>
+<% end %>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -23,6 +23,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "HMRC"
   inflect.acronym "SCA"
   inflect.acronym "PDA"
+  inflect.acronym "PLF"
   inflect.acronym "S8"
   inflect.acronym "DA"
 end

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -755,6 +755,11 @@ en:
               too_many_decimals: Enter a number with no more than 2 decimal places
             frequency:
               inclusion: "Select how often %{party} gets the benefit"
+        related_orders:
+          attributes:
+            base:
+              none_selected: Select which orders the proceeding relates to
+              none_and_another_option_selected: The proceeding must either relate to one or more of these orders or none
         providers/means/regular_income_form:
           attributes: &regular_income_attributes
             benefits_amount:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1792,6 +1792,38 @@ en:
         page_title: Enter your client's email address
         label: Email address
         hint: We'll use this to send your client a link to the service.
+    proceeding_interrupts:
+      related_orders:
+        show:
+          page_title: Which of these orders does this proceeding relate to?
+          hint: These are orders set out in schedule 1, part 1, paragraph 1 of LASPO.
+          orders:
+            care: Care order under section 31 Children Act
+            supervision: Supervision order
+            secure_accommodation: Secure accommodation order
+            placement: Placement order
+            adoption: Adoption order
+            emergency_protection: Emergency protection order
+            child_assessment: Child assessment order
+            parenting: Parenting orders under section 8 of the Crime and Disorder Act 1998
+            child_safety: Child safety orders under section 11 of the Crime and Disorder Act 1998
+          none_of_these: None of these orders relate to this proceeding
+      interrupts:
+        show:
+          proceeding_issue_status: &default
+            title_html: This is not a public law family matter
+            paragraph: This is because it does not relate to an application or order set out in schedule 1, part 1, paragraph 1 of LASPO.
+            option_bullets_html:
+              - select a different proceeding or matter type
+              - go back and change your answer
+              - use legal help
+            options: "You can do one of the following:"
+            proceedings: Remove the proceeding and select a new one
+          none_selected:
+            <<: *default
+            title_html: This is not a public law family matter
+            paragraph: This is because it does not relate to an application or order set out in schedule 1, part 1, paragraph 1 of LASPO.
+            proceedings: Select a different proceeding
     proceedings_sca:
       heard_togethers:
         error: Select yes if this proceeding will be heard together with any special children act proceedings
@@ -1845,6 +1877,11 @@ en:
             option_bullets_html:
               - select a different proceeding or matter type
               - go back and change your answer
+          plf_none_selected:
+            <<: *default
+            title_html: This is not a public law family matter
+            paragraph: This is because it does not relate to an application or order set out in schedule 1, part 1, paragraph 1 of LASPO.
+            proceedings: Select a different proceeding
       child_subjects:
         error: Select yes if your client is the child subject of this proceeding
         show:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -286,6 +286,10 @@ Rails.application.routes.draw do
         resource :block, only: %i[show], path: "voided-application"
       end
 
+      scope module: :proceeding_interrupts do
+        resources :related_orders, only: %i[show update]
+      end
+
       scope module: :proceedings_sca do
         get "/interrupt/:type", to: "interrupts#show", as: "sca_interrupt"
         delete "/interrupt/:type", to: "interrupts#destroy"

--- a/db/migrate/20241209111158_add_related_orders_to_proceedings.rb
+++ b/db/migrate/20241209111158_add_related_orders_to_proceedings.rb
@@ -1,0 +1,5 @@
+class AddRelatedOrdersToProceedings < ActiveRecord::Migration[7.2]
+  def change
+    add_column :proceedings, :related_orders, :string, array: true, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -875,6 +875,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_10_160206) do
     t.boolean "accepted_substantive_defaults"
     t.string "sca_type"
     t.string "relationship_to_child"
+    t.string "related_orders", default: [], null: false, array: true
     t.index ["legal_aid_application_id"], name: "index_proceedings_on_legal_aid_application_id"
     t.index ["proceeding_case_id"], name: "index_proceedings_on_proceeding_case_id", unique: true
   end

--- a/spec/factories/proceedings.rb
+++ b/spec/factories/proceedings.rb
@@ -362,4 +362,42 @@ FactoryBot.define do
     client_involvement_type_description { "Applicant/Claimant/Petitioner" }
     sca_type { "core" }
   end
+
+  trait :pbm05 do
+    lead_proceeding { false }
+    ccms_code { "PBM05" }
+    meaning { "Contact with a child in care" }
+    description { "to be represented on an application for contact with a child in care." }
+    substantive_cost_limitation { 25_000 }
+    delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
+    used_delegated_functions { nil }
+    used_delegated_functions_on { nil }
+    used_delegated_functions_reported_on { nil }
+    name { "contact_with_child_in_care" }
+    matter_type { "public law family (PLF)" }
+    category_of_law { "Family" }
+    category_law_code { "MAT" }
+    ccms_matter_code { "KPBLB" }
+    client_involvement_type_ccms_code { "A" }
+    client_involvement_type_description { "Applicant/Claimant/Petitioner" }
+  end
+
+  trait :pbm16 do
+    lead_proceeding { false }
+    ccms_code { "PBM16" }
+    meaning { "Prohibited steps order" }
+    description { "to be represented on an application for a prohibited steps order." }
+    substantive_cost_limitation { 25_000 }
+    delegated_functions_cost_limitation { rand(1...1_000_000.0).round(2) }
+    used_delegated_functions { nil }
+    used_delegated_functions_on { nil }
+    used_delegated_functions_reported_on { nil }
+    name { "prohibited_steps_order_plf" }
+    matter_type { "public law family (PLF)" }
+    category_of_law { "Family" }
+    category_law_code { "MAT" }
+    ccms_matter_code { "KPBLB" }
+    client_involvement_type_ccms_code { "A" }
+    client_involvement_type_description { "Applicant/Claimant/Petitioner" }
+  end
 end

--- a/spec/forms/providers/proceeding_interrupts/related_orders_form_spec.rb
+++ b/spec/forms/providers/proceeding_interrupts/related_orders_form_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+RSpec.describe Providers::ProceedingInterrupts::RelatedOrdersForm do
+  subject(:form) { described_class.new(form_params) }
+
+  let(:proceeding) { create(:proceeding, :pbm05) }
+  let(:form_params) { params.merge(model: proceeding) }
+  let(:params) do
+    {
+      related_orders:,
+      none_selected:,
+    }
+  end
+
+  let(:related_orders) { [] }
+  let(:none_selected) { "" }
+
+  describe "#valid?" do
+    subject(:valid?) { form.valid? }
+
+    context "when a selection has been made" do
+      before { form.related_orders = %w[care] }
+
+      it { expect(form).to be_valid }
+    end
+
+    context "when multiple selections have been made" do
+      before { form.related_orders = %w[care adoption parenting] }
+
+      it { expect(form).to be_valid }
+    end
+
+    context "when the user has chosen none_selected" do
+      before do
+        form.related_orders = []
+        form.none_selected = "true"
+      end
+
+      it { expect(form).to be_valid }
+    end
+
+    context "when the user has chosen nothing" do
+      before do
+        form.related_orders = [""]
+        form.none_selected = ""
+      end
+
+      it { expect(form).not_to be_valid }
+    end
+
+    context "when the user has chosen none_selected and an order" do
+      before do
+        form.related_orders = %w[child_assessment]
+        form.none_selected = "true"
+      end
+
+      it { expect(form).not_to be_valid }
+    end
+  end
+
+  describe "#save!" do
+    subject(:form_save) { form.save! }
+
+    context "when a selection has been made" do
+      let(:related_orders) { %w[child_assessment] }
+
+      it "updates the related orders field" do
+        form_save
+        expect(proceeding.related_orders).to contain_exactly("child_assessment")
+      end
+    end
+
+    context "when multiple selections have been made" do
+      let(:related_orders) { %w[child_assessment child_safety] }
+
+      it "updates the related orders field" do
+        form_save
+        expect(proceeding.related_orders).to match_array(%w[child_assessment child_safety])
+      end
+    end
+
+    context "when 'none of the above' and another checkbox are selected" do
+      let(:related_orders) { %w[child_assessment] }
+      let(:none_selected) { "true" }
+
+      it "returns false" do
+        expect(form_save).to be false
+      end
+    end
+
+    context "when 'none of the above' is selected" do
+      let(:none_selected) { "true" }
+
+      it "returns true" do
+        expect(form_save).to be true
+      end
+    end
+  end
+
+  describe "save_as_draft" do
+    subject(:save_as_draft) { form.save_as_draft }
+
+    context "when the user has chosen nothing" do
+      before do
+        form.related_orders = []
+        form.none_selected = ""
+      end
+
+      it { expect(save_as_draft).to be true }
+    end
+  end
+end

--- a/spec/requests/providers/proceeding_interrupts/related_orders_controller_spec.rb
+++ b/spec/requests/providers/proceeding_interrupts/related_orders_controller_spec.rb
@@ -1,0 +1,125 @@
+require "rails_helper"
+
+RSpec.describe Providers::ProceedingInterrupts::RelatedOrdersController do
+  let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings, explicit_proceedings: %i[pbm16]) }
+  let(:provider) { legal_aid_application.provider }
+  let(:proceeding) { legal_aid_application.proceedings.find_by(ccms_code: "PBM16") }
+
+  describe "GET /providers/applications/:id/related_orders/:proceeding_id" do
+    subject(:get_request) { get providers_legal_aid_application_related_order_path(legal_aid_application, proceeding) }
+
+    context "when the provider is not authenticated" do
+      before { get_request }
+
+      it_behaves_like "a provider not authenticated"
+    end
+
+    context "when the provider is authenticated" do
+      before do
+        login_as provider
+        get_request
+      end
+
+      it "returns http success" do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe "PATCH /providers/applications/:id/related_orders/:proceeding_id" do
+    subject(:patch_request) { patch providers_legal_aid_application_related_order_path(legal_aid_application, proceeding, params:) }
+
+    let(:params) do
+      {
+        proceeding: {
+          none_selected:,
+          related_orders:,
+        },
+      }
+    end
+    let(:none_selected) { "" }
+    let(:related_orders) { [""] }
+
+    before do
+      login_as provider
+
+      patch_request
+    end
+
+    context "with form submitted using Save and continue button" do
+      context "when no choice is made" do
+        it "renders the same page with an error message" do
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response.body).to include("Select which orders the proceeding relates to").twice
+        end
+      end
+
+      context "when the user selects none of these" do
+        let(:none_selected) { "true" }
+
+        it "redirects to the interrupt page" do
+          expect(response).to have_http_status(:redirect)
+          expect(response).to redirect_to providers_legal_aid_application_sca_interrupt_path(legal_aid_application, "plf_none_selected")
+        end
+      end
+
+      context "when the user selects one checkbox" do
+        let(:related_orders) { %w[placement] }
+
+        it "redirects to the next page" do
+          expect(response).to have_http_status(:redirect)
+        end
+      end
+
+      context "when the user selects multiple checkboxes" do
+        let(:related_orders) { %w[placement parenting] }
+
+        it "redirects to the next page" do
+          expect(response).to have_http_status(:redirect)
+        end
+      end
+    end
+
+    context "when the form is submitted with save as draft" do
+      let(:params) do
+        {
+          proceeding: {
+            none_selected:,
+            related_orders:,
+          },
+          draft_button: "Save and come back later",
+        }
+      end
+
+      context "when no choice is made" do
+        it "redirects to the home page" do
+          expect(response).to redirect_to(submitted_providers_legal_aid_applications_path)
+        end
+      end
+
+      context "when the user selects none of these" do
+        let(:none_selected) { "true" }
+
+        it "redirects to the home page" do
+          expect(response).to redirect_to(submitted_providers_legal_aid_applications_path)
+        end
+      end
+
+      context "when the user selects one checkbox" do
+        let(:related_orders) { %w[placement] }
+
+        it "redirects to the home page" do
+          expect(response).to redirect_to(submitted_providers_legal_aid_applications_path)
+        end
+      end
+
+      context "when the user selects multiple checkboxes" do
+        let(:related_orders) { %w[placement parenting] }
+
+        it "redirects to the home page" do
+          expect(response).to redirect_to(submitted_providers_legal_aid_applications_path)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/flow/steps/provider/proceeding_interrupts/related_orders_step_spec.rb
+++ b/spec/services/flow/steps/provider/proceeding_interrupts/related_orders_step_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::Provider::ProceedingInterrupts::RelatedOrdersStep, type: :request do
+  let(:legal_aid_application) { build_stubbed(:legal_aid_application) }
+
+  describe "#path" do
+    subject { described_class.path.call(legal_aid_application) }
+
+    it { is_expected.to eq providers_legal_aid_application_related_orders_path(legal_aid_application) }
+  end
+
+  describe "#forward" do
+    subject { described_class.forward.call(legal_aid_application, proceeding) }
+
+    context "when proceeding should redirect" do
+      let(:proceeding) { build_stubbed(:proceeding, ccms_code: "PBM16E") }
+
+      it { is_expected.to be :change_of_names }
+    end
+
+    context "when proceeding should not redirect" do
+      let(:proceeding) { build_stubbed(:proceeding, ccms_code: "PBM03") }
+
+      it { is_expected.to be :has_other_proceedings }
+    end
+  end
+end

--- a/spec/services/flow/steps/provider/proceeding_interrupts/related_orders_step_spec.rb
+++ b/spec/services/flow/steps/provider/proceeding_interrupts/related_orders_step_spec.rb
@@ -4,9 +4,11 @@ RSpec.describe Flow::Steps::Provider::ProceedingInterrupts::RelatedOrdersStep, t
   let(:legal_aid_application) { build_stubbed(:legal_aid_application) }
 
   describe "#path" do
-    subject { described_class.path.call(legal_aid_application) }
+    subject { described_class.path.call(legal_aid_application, proceeding) }
 
-    it { is_expected.to eq providers_legal_aid_application_related_orders_path(legal_aid_application) }
+    let(:proceeding) { build_stubbed(:proceeding, ccms_code: "PBM016E") }
+
+    it { is_expected.to eq providers_legal_aid_application_related_order_path(legal_aid_application, proceeding) }
   end
 
   describe "#forward" do

--- a/spec/services/flow/steps/provider_start/proceedings_types_step_spec.rb
+++ b/spec/services/flow/steps/provider_start/proceedings_types_step_spec.rb
@@ -35,5 +35,17 @@ RSpec.describe Flow::Steps::ProviderStart::ProceedingsTypesStep, type: :request 
 
       it { is_expected.to eq :change_of_names }
     end
+
+    context "when the chosen proceeding is a PLF proceeding matching the list" do
+      let(:proceeding) { build_stubbed(:proceeding, ccms_code: "PBM18A") }
+
+      it { is_expected.to eq :related_orders }
+    end
+
+    context "when the chosen proceeding is a PLF proceeding that does not match the list" do
+      let(:proceeding) { build_stubbed(:proceeding, ccms_code: "PBM03") }
+
+      it { is_expected.to eq :has_other_proceedings }
+    end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4409)

Add new interrupt pages for PLF proceedings

This includes a new variety of proceeding interrupt pages.  I deliberately did not put them into the proceedings_sca namespace

Should we re-factor the other proceeding interrupts into a more generic namespace to keep them contained, but not tied explicitly to a certain proceeding type?


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
