### PR TITLE
AP-5387: Remove student loan

### DIFF
--- a/app/forms/providers/base_regular_income_form.rb
+++ b/app/forms/providers/base_regular_income_form.rb
@@ -5,7 +5,6 @@ module Providers
       friends_or_family
       maintenance_in
       property_or_lodger
-      student_loan
       pension
     ].freeze
 

--- a/app/models/transaction_type.rb
+++ b/app/models/transaction_type.rb
@@ -10,7 +10,6 @@ class TransactionType < ApplicationRecord
       friends_or_family
       maintenance_in
       property_or_lodger
-      student_loan
       pension
     ],
     debit: %i[
@@ -30,7 +29,6 @@ class TransactionType < ApplicationRecord
     friends_or_family
     maintenance_in
     property_or_lodger
-    student_loan
     pension
   ].freeze
 

--- a/app/services/populators/transaction_type_populator.rb
+++ b/app/services/populators/transaction_type_populator.rb
@@ -34,16 +34,15 @@ module Populators
     # "deactivation/archiving" this would mean the test environment and UAT branches would not reflect the
     # real world data, as they would not be seeded with that transaction type at all. Archiving a type explicitly,
     # aside from being clearer, therefore allows us identify test suite failures and manually test on UAT with
-    # like-real-world data as well as enable use to conditional logic for existing applications with that transaction
-    # tyoe that we may want to handle differently
+    # like-real-world data as well as enable use of conditional logic for existing applications with that transaction
+    # type that we may want to handle differently.
     #
-    # After a period of time and once we are confident the impact would be minimal we could then remove the transaction type
+    # After a period of time, once we are confident the impact would be minimal, we could then remove the transaction type
     # from the TransactionType::NAMES constant AND possibly delete the old transaction type (and associated bank transactions??)
     #
     def mark_old_as_archived
       TransactionType.active.where.not(name: TransactionType::NAMES.values.flatten).update!(archived_at: Time.current)
 
-      TransactionType.active.find_by(name: "student_loan")&.update!(archived_at: Time.current)
       TransactionType.active.find_by(name: "excluded_benefits")&.update!(archived_at: Time.current)
     end
 

--- a/app/views/providers/capital_income_assessment_results/_other_income.html.erb
+++ b/app/views/providers/capital_income_assessment_results/_other_income.html.erb
@@ -31,7 +31,7 @@
           row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.mei_property_or_lodger(partner:)))
         end
         body.with_row do |row|
-          row.with_cell(header: true, text: t(".student_loan_or_grant"))
+          row.with_cell(header: true, text: t(".student_finance"))
           row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.mei_student_loan(partner:)))
         end
         body.with_row do |row|

--- a/config/locales/cy/activemodel.yml
+++ b/config/locales/cy/activemodel.yml
@@ -57,7 +57,6 @@ cy:
           friends_or_family: ylimaf ro sdneirf morf pleh laicnaniF
           maintenance_in: stnemyap ecnanetniaM
           property_or_lodger: regdol ro ytreporp morf emocnI
-          student_loan: tnarg ro naol tnedutS
           pension: noisneP
           rent_or_mortgage: stnemyap gnisuoH
           child_care: stnemyap eracdlihC

--- a/config/locales/cy/transaction_types.yml
+++ b/config/locales/cy/transaction_types.yml
@@ -14,7 +14,6 @@ cy:
         property_or_lodger: regdol ro ytreporp a morf emocnI
         rent_or_mortgage: stnemyap gnisuoH
         salary: segaw ro yralaS
-        student_loan: tnarg ro naol tnedutS
       providers:
         benefits: stifeneB
         child_care: stnemyap eracdlihC
@@ -27,7 +26,6 @@ cy:
         property_or_lodger: regdol ro ytreporp a morf emocnI
         rent_or_mortgage: stnemyap gnisuoH
         salary: segaw ro yralaS
-        student_loan: tnarg ro naol tnedutS
     table_label:
       benefits: stifeneB
       child_care: eracdlihC
@@ -40,7 +38,6 @@ cy:
       property_or_lodger: ytreporP
       rent_or_mortgage: gnisuoH
       salary: yralaS
-      student_loan: naol tnedutS
     page_titles:
       benefits: stnemyap stifeneb tceleS
       child_care: stnemyap eracdlihc tceleS
@@ -52,7 +49,6 @@ cy:
       property_or_lodger: regdol ro ytreporp a morf stnemyap tceleS
       rent_or_mortgage: stnemyap gnisuoh tceleS
       salary: stnemyap egaw ro yralas tceleS
-      student_loan: stnemyap tnarg ro naol tneduts tceleS
       excluded_benefits: stnemyap stifeneb dedragersid tceleS
     benefits:
       inset_paras: |
@@ -91,9 +87,6 @@ cy:
         ruoy tnemyap yreve tceleS"
     rent_or_mortgage:
       inset_text: ".shtnom 3 tsap eht ni edam tneilc ruoy tnemyap gnisuoh yreve tceleS"
-    student_loan:
-      inset_text: ".shtnom 3 tsap eht ni deviecer tneilc ruoy tnemyap tnarg ro naol
-        tneduts yreve tceleS"
     pension:
       inset_text: ".shtnom 3 tsap eht ni deviecer tneilc ruoy tnemyap noisnep yreve
         tceleS"

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -66,7 +66,6 @@ en:
           friends_or_family: Financial help
           maintenance_in: Maintenance
           property_or_lodger: Property
-          student_loan: Student loan or grant
           pension: Pension
           rent_or_mortgage: Housing
           child_care: Childcare

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -133,7 +133,7 @@ en:
         friends_or_family: Financial help from friends or family
         maintenance: Maintenance payments from a former partner
         property_or_lodger: Income from property or lodger
-        student_loan_or_grant: Student finance
+        student_finance: Student finance
         pension: Pension
         total: Total
         table_caption: Income

--- a/config/locales/en/transaction_types.yml
+++ b/config/locales/en/transaction_types.yml
@@ -16,7 +16,6 @@ en:
         property_or_lodger: Income from a property or lodger
         rent_or_mortgage: Housing payments
         salary: Salary or wages
-        student_loan: Student loan or grant
       providers:
         benefits: Benefits, charitable or government payments
         child_care: Childcare payments
@@ -30,7 +29,6 @@ en:
         property_or_lodger: Income from a property or lodger
         rent_or_mortgage: Housing payments
         salary: Salary or wages
-        student_loan: Student loan or grant
       error_message:
         benefits: in benefits
         friends_or_family: from friends or family
@@ -59,7 +57,6 @@ en:
       property_or_lodger: Property
       rent_or_mortgage: Housing
       salary: Salary
-      student_loan: Student loan
     page_titles:
       benefits: Select any benefits, charitable or government payments
       child_care: Select childcare payments
@@ -71,7 +68,6 @@ en:
       property_or_lodger: Select payments from a property or lodger
       rent_or_mortgage: Select housing payments
       salary: Select salary or wage payments
-      student_loan: Select student loan or grant payments
       excluded_benefits: Select Government Cost of Living Payments and disregarded benefits
     benefits:
       inset_paras: |
@@ -101,7 +97,5 @@ en:
       inset_text: Select every payment your client received from property or a lodger in the past 3 months.
     rent_or_mortgage:
       inset_text: Select every housing payment your client made in the past 3 months.
-    student_loan:
-      inset_text: Select every student loan or grant payment your client received in the past 3 months.
     pension:
       inset_text: Select every pension payment your client received in the past 3 months.

--- a/db/migrate/20241206121926_destroy_student_loan_transaction_type.rb
+++ b/db/migrate/20241206121926_destroy_student_loan_transaction_type.rb
@@ -1,0 +1,27 @@
+class DestroyStudentLoanTransactionType < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def up
+    TransactionType.find_by(name: 'student_loan')&.destroy!
+
+    # reset sort_order attribute of all transaction types
+    Populators::TransactionTypePopulator.call
+  end
+
+  def down
+    # Irreversible data migration. You will need the transaction_type_id of any child records to reverse this!
+    # attribute values from production at time of writing:
+    #
+    #  "id"=>"a9de405c-74f7-45de-956f-4a602e994450"
+    #  "name"=>"student_loan",
+    #  "operation"=>"credit",
+    #  "created_at"=>Mon, 29 Jul 2019 13:10:16.836407000 BST +01:00,
+    #  "updated_at"=>Wed, 09 Oct 2024 07:32:36.113001000 BST +01:00,
+    #  "sort_order"=>60,
+    #  "archived_at"=>Wed, 09 Oct 2024 07:32:36.112851000 BST +01:00,
+    #  "other_income"=>true,
+    #  "parent_id"=>nil
+    #
+    nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_02_152952) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_06_121926) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -329,7 +329,7 @@ end
 Given("I start the merits application with student finance") do
   @legal_aid_application = create(
     :application,
-    :with_applicant_with_student_loan,
+    :with_applicant_with_student_finance,
     :with_proceedings,
     :with_non_passported_state_machine,
     :provider_assessing_means,

--- a/features/step_definitions/review_and_print_steps.rb
+++ b/features/step_definitions/review_and_print_steps.rb
@@ -40,7 +40,7 @@ Given("I have completed truelayer application with merits") do
   @legal_aid_application = create(
     :legal_aid_application,
     :with_proceedings,
-    :with_applicant_with_student_loan,
+    :with_applicant_with_student_finance,
     :with_non_passported_state_machine,
     :with_restrictions,
     :with_vehicle,

--- a/spec/factories/bank_transactions.rb
+++ b/spec/factories/bank_transactions.rb
@@ -69,11 +69,6 @@ FactoryBot.define do
       transaction_type { TransactionType.where(name: "property_or_lodger").first || create(:transaction_type, :property_or_lodger) }
     end
 
-    trait :student_loan do
-      operation { "credit" }
-      transaction_type { TransactionType.where(name: "student_loan").first || create(:transaction_type, :student_loan) }
-    end
-
     trait :pension do
       operation { "credit" }
       transaction_type { TransactionType.where(name: "pension").first || create(:transaction_type, :pension) }

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -71,7 +71,7 @@ FactoryBot.define do
       applicant { build(:applicant, :with_address, with_bank_accounts:, same_correspondence_and_home_address: true, has_partner: false) }
     end
 
-    trait :with_applicant_with_student_loan do
+    trait :with_applicant_with_student_finance do
       transient do
         with_bank_accounts { 0 }
       end

--- a/spec/models/transaction_type_spec.rb
+++ b/spec/models/transaction_type_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe TransactionType do
     it "returns all other_income type TransactionTypes" do
       Populators::TransactionTypePopulator.call
       names = described_class.other_income.pluck(:name)
-      expect(names).to eq %w[friends_or_family maintenance_in property_or_lodger student_loan pension]
+      expect(names).to eq %w[friends_or_family maintenance_in property_or_lodger pension]
     end
   end
 
@@ -194,8 +194,8 @@ RSpec.describe TransactionType do
 
     describe "active" do
       it "does not return records with a date in archived at" do
-        described_class.find_by(name: "student_loan").update!(archived_at: Time.current)
-        expect(described_class.active.pluck(:name)).not_to include("student_loan")
+        described_class.find_by(name: "excluded_benefits").update!(archived_at: Time.current)
+        expect(described_class.active.pluck(:name)).not_to include("excluded_benefits")
       end
     end
   end

--- a/spec/services/cfe_civil/components/other_income_spec.rb
+++ b/spec/services/cfe_civil/components/other_income_spec.rb
@@ -27,9 +27,6 @@ RSpec.describe CFECivil::Components::OtherIncome do
     let!(:maintenance_week_ago) { create(:bank_transaction, :maintenance_in, bank_account:, amount: 125.0, happened_at: 1.week.ago) }
     let!(:friends_today) { create(:bank_transaction, :friends_or_family, bank_account:, amount: 60.0, happened_at: Time.zone.today) }
     let!(:friends_week_ago) { create(:bank_transaction, :friends_or_family, bank_account:, amount: 60.0, happened_at: 1.week.ago) }
-    let!(:student_loan_today) { create(:bank_transaction, :student_loan, bank_account:, amount: 355.66, happened_at: Time.zone.today) }
-    let!(:student_loan_week_ago) { create(:bank_transaction, :student_loan, bank_account:, amount: 355.67, happened_at: 1.week.ago) }
-    let!(:student_loan_two_week_ago) { create(:bank_transaction, :student_loan, bank_account:, amount: 355.68, happened_at: 2.weeks.ago) }
     let(:today) { Time.zone.today.strftime("%Y-%m-%d") }
     let(:one_week_ago) { 1.week.ago.strftime("%Y-%m-%d") }
     let(:two_weeks_ago) { 2.weeks.ago.strftime("%Y-%m-%d") }
@@ -49,14 +46,6 @@ RSpec.describe CFECivil::Components::OtherIncome do
             payments: [
               { date: one_week_ago, amount: 125.0, client_id: maintenance_week_ago.id },
               { date: today, amount: 250.0, client_id: maintenance_today.id },
-            ],
-          },
-          {
-            source: "Student loan",
-            payments: [
-              { date: two_weeks_ago, amount: 355.68, client_id: student_loan_two_week_ago.id },
-              { date: one_week_ago, amount: 355.67, client_id: student_loan_week_ago.id },
-              { date: today, amount: 355.66, client_id: student_loan_today.id },
             ],
           },
         ],

--- a/spec/services/populators/transaction_type_populator_spec.rb
+++ b/spec/services/populators/transaction_type_populator_spec.rb
@@ -9,7 +9,7 @@ module Populators
       let(:credit_names) { names[:credit] }
       let(:debit_names) { names[:debit] }
       let(:total) { credit_names.length + debit_names.length }
-      let(:archived_credit_names) { %i[student_loan excluded_benefits] }
+      let(:archived_credit_names) { %i[excluded_benefits] }
 
       it "creates instances from names" do
         expect { call }.to change(TransactionType, :count).by(total)
@@ -45,16 +45,6 @@ module Populators
           }.to change(TransactionType, :count).by(total)
         end
 
-        it "does not set archived_at for aleady deactivated student_loan" do
-          travel_to(yesterday) do
-            described_class.call
-            expect(TransactionType.find_by(name: "student_loan").archived_at).to be_within(1.second).of(yesterday)
-          end
-
-          described_class.call
-          expect(TransactionType.find_by(name: "student_loan").archived_at).to be_within(1.second).of(yesterday)
-        end
-
         it "does not set archived_at for aleady deactivated excluded_benefits" do
           travel_to(yesterday) do
             described_class.call
@@ -74,11 +64,6 @@ module Populators
         it "sets the archived_at date" do
           call
           expect(TransactionType.find_by(name: "council_tax").archived_at).not_to be_nil
-        end
-
-        it "explicitly sets the archived_at date for student_loan" do
-          call
-          expect(TransactionType.find_by(name: "student_loan").archived_at).not_to be_nil
         end
 
         it "explicitly sets the archived_at date for excluded_benefits" do


### PR DESCRIPTION
## What
Remove old transaction type -`student_loan`

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5387)

Was replaced by `[applicant|partner].student_finance` attribute and functionality
2+ years ago and no data currently exists on staging or production for this transaction type.


## TODO

- [X] remove student loan vestiges
- [X] delete student loan transaction_type database record
- [ ] ~~[optional] rename any `mei_student_loan` too?!~~
- [X] drop `legal_aid_applications.student_finance` column (migrated to applicant/partner 16 months ago) - all data nil or false - _separate PR_

## Manual Testing

have run through applications using HMHO/bank-statement-upload and truelayer journey before and after code changes and data migration added without incident.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
