### PR TITLE
AP-5602: Correct data query for CCMS student finance question

### DIFF
--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -37,7 +37,6 @@ module CCMS
                                 |proceeding
                                 |outgoing
                                 |savings_amount
-                                |income_type
                                 |vehicle
                                 )_(\S+)$}x
     APPLICANT_REGEX = /^applicant_(\S+)$/
@@ -54,7 +53,6 @@ module CCMS
     OTHER_PARTY = /^other_party_(\S+)$/
     PROCEEDING_REGEX = /^proceeding_(\S+)$/
     SAVINGS_AMOUNT = /^savings_amount_(\S+)$/
-    INCOME_TYPE_REGEX = /^income_type_(\S+)$/
     VEHICLE_REGEX = /^vehicle_(\S+)$/
     OUTGOING = /^outgoing_(\S+)$/
 
@@ -465,8 +463,6 @@ module CCMS
         options[:vehicle].__send__(Regexp.last_match(1))
       when PROCEEDING_REGEX
         options[:proceeding].__send__(Regexp.last_match(1))
-      when INCOME_TYPE_REGEX
-        legal_aid_application.transaction_types.for_income_type?(Regexp.last_match(1).chomp("?"))
       when OPPONENT
         options[:opponent].__send__(Regexp.last_match(1))
       when PARTIES_MENTAL_CAPACITY

--- a/config/ccms/attribute_block_configs/non_passported.yml
+++ b/config/ccms/attribute_block_configs/non_passported.yml
@@ -691,7 +691,7 @@ global_means:
     generate_block?: false
   GB_INPUT_B_9WP3_353A:
     generate_block?: true
-    value: '#income_type_student_loan?'
+    value: '#applicant_student_finance?'
     br100_meaning: 'Client Student Income: Receives a student loan/grant or bursary?'
     response_type: boolean
     user_defined: true

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -517,9 +517,16 @@ FactoryBot.define do
       shared_ownership { "no_sole_owner" }
     end
 
-    trait :with_student_finance do
-      student_finance { true }
-    end
+    # trait :with_student_finance do
+    #   transient do
+    #     student_finance_amount { nil }
+    #   end
+
+    #   after(:create) do |application, _evaluator|
+    #     applicant = find_or_create(:applicant, legal_aid_application: application)
+    #     applicant.update!(student_finance: true, student_finance_amount:)
+    #   end
+    # end
 
     trait :with_home_shared_with_partner do
       shared_ownership { "partner_or_ex_partner" }

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -517,17 +517,6 @@ FactoryBot.define do
       shared_ownership { "no_sole_owner" }
     end
 
-    # trait :with_student_finance do
-    #   transient do
-    #     student_finance_amount { nil }
-    #   end
-
-    #   after(:create) do |application, _evaluator|
-    #     applicant = find_or_create(:applicant, legal_aid_application: application)
-    #     applicant.update!(student_finance: true, student_finance_amount:)
-    #   end
-    # end
-
     trait :with_home_shared_with_partner do
       shared_ownership { "partner_or_ex_partner" }
     end

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
@@ -451,11 +451,9 @@ module CCMS
         end
 
         describe "GB_INPUT_B_9WP3_353A" do
-          context "when the applicant has a student loan/grant" do
-            let(:student_loan_income) { create(:transaction_type, :credit, name: "student_loan") }
-
+          context "when the applicant has student finance" do
             before do
-              create(:legal_aid_application_transaction_type, legal_aid_application:, transaction_type: student_loan_income)
+              legal_aid_application.applicant.update!(student_finance: true)
             end
 
             it "returns true" do
@@ -463,15 +461,17 @@ module CCMS
               expect(block).to have_boolean_response true
               expect(block).to be_user_defined
             end
+          end
 
-            context "when the applicant has no student loan/grant" do
-              before { legal_aid_application.transaction_types.delete_all }
+          context "when the applicant has no student finance" do
+            before do
+              legal_aid_application.applicant.update!(student_finance: false)
+            end
 
-              it "returns false" do
-                block = XmlExtractor.call(xml, :global_means, "GB_INPUT_B_9WP3_353A")
-                expect(block).to have_boolean_response false
-                expect(block).to be_user_defined
-              end
+            it "returns false" do
+              block = XmlExtractor.call(xml, :global_means, "GB_INPUT_B_9WP3_353A")
+              expect(block).to have_boolean_response false
+              expect(block).to be_user_defined
             end
           end
         end


### PR DESCRIPTION
## What
Correct data query for student finance CCMS question

> [!WARNING]  
> Test on UAT for impact and ask BA for input.
> _Tested and discussed - BA gives the go ahead to merge - see ticket for details_

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5602)

The student_loan transaction_type was archived 2+ years ago, having been replaced
by student_finance and student_finance_amount questions on applicant and partner.

However, our CCMS payload includes an attribute that is described as
'Client Student Income: Receives a student loan/grant or bursary?'
whose answer is generated from a lookup of data for the `student_loan`
`transaction_type`.It was, as a result, always false.

This should therefore be changed to use the correct data
Civil Apply stores, namely applicant.student_finance? .

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
