### PR TITLE
AP-5387-extension: ignore unused `student_finance` column

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -2,6 +2,11 @@ class LegalAidApplication < ApplicationRecord
   include Discard::Model
   include DelegatedFunctions
 
+  # This column was moved to applicant and partner models/tables so needs dropping.
+  # ignoring for now so we can test and deploy code to confirm impact without losing
+  # data..
+  self.ignored_columns += %w[student_finance]
+
   ProceedingStruct = Struct.new(:name, :meaning, :proceeding)
 
   SHARED_OWNERSHIP_YES_REASONS = %w[partner_or_ex_partner housing_assocation_or_landlord friend_family_member_or_other_individual].freeze

--- a/features/step_definitions/review_and_print_steps.rb
+++ b/features/step_definitions/review_and_print_steps.rb
@@ -101,8 +101,10 @@ Given("I have completed truelayer application with merits and no student finance
     percentage_home: 33.33,
     explicit_proceedings: %i[da002 da006],
     set_lead_proceeding: :da002,
-    student_finance: false,
   )
+
+  @legal_aid_application.applicant.update!(student_finance: false, student_finance_amount: nil)
+
   create :legal_framework_merits_task_list, :da002_da006_as_applicant, legal_aid_application: @legal_aid_application
 
   login_as @legal_aid_application.provider

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -517,10 +517,6 @@ FactoryBot.define do
       shared_ownership { "no_sole_owner" }
     end
 
-    trait :with_student_finance do
-      student_finance { true }
-    end
-
     trait :with_home_shared_with_partner do
       shared_ownership { "partner_or_ex_partner" }
     end


### PR DESCRIPTION
## What
Ignore unused column.

[Link to related story](https://dsdmoj.atlassian.net/browse/AP-5387)

Column was migrated to applicant and partner models 16 months ago. This is the first step
in dropping it. Subsequent PR to drop once we deploy this.

[Removing a column in strong-migrations gem](https://github.com/ankane/strong_migrations?tab=readme-ov-file#removing-a-column)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
