### PR TITLE
Fix: substantive cost limit heading

### DIFF
--- a/app/views/providers/merits_reports/show.html.erb
+++ b/app/views/providers/merits_reports/show.html.erb
@@ -68,6 +68,7 @@
     <%= render(
           "shared/check_answers/substantive_costs",
           legal_aid_application: @legal_aid_application,
+          heading: t(".substantive_cost_limit"),
           read_only: true,
         ) %>
   <% end %>


### PR DESCRIPTION
## What

An error was being generated on production while trying to generate the merits report.

This PR updates the partial to use the same pattern as other invocations

When tested locally on an anonymised database, the merits report render switched from 
![image](https://github.com/user-attachments/assets/c33b9b7e-86d6-43d0-b594-1c2566c246c1)
to
![image](https://github.com/user-attachments/assets/d55e7bca-4ee4-4f22-987b-c181133a8ec6)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
