### PR TITLE
Fix: Flickering CCMS case requestor test

### DIFF
--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -101,7 +101,7 @@ module CCMS
             request_hash = Hash.from_xml(request_xml).deep_symbolize_keys!
             expected_request_hash = Hash.from_xml(expected_request_xml).deep_symbolize_keys!
 
-            expect(request_hash).to match(expected_request_hash)
+            expect(request_hash.as_json).to match_json_expression(expected_request_hash.as_json)
           end
         end
 
@@ -114,7 +114,7 @@ module CCMS
               request_hash = Hash.from_xml(request_xml).deep_symbolize_keys!
               expected_request_hash = Hash.from_xml(expected_request_xml).deep_symbolize_keys!
 
-              expect(request_hash).to match(expected_request_hash)
+              expect(request_hash.as_json).to match_json_expression(expected_request_hash.as_json)
             end
           end
         end
@@ -130,8 +130,7 @@ module CCMS
             travel_to(request_created_at) do
               request_hash = Hash.from_xml(request_xml).deep_symbolize_keys!
               expected_request_hash = Hash.from_xml(expected_request_xml).deep_symbolize_keys!
-
-              expect(request_hash).to match(expected_request_hash)
+              expect(request_hash.as_json).to match_json_expression(expected_request_hash.as_json)
             end
           end
         end
@@ -145,7 +144,7 @@ module CCMS
                 request_hash = Hash.from_xml(request_xml).deep_symbolize_keys!
                 expected_request_hash = Hash.from_xml(expected_request_xml).deep_symbolize_keys!
 
-                expect(request_hash).to match(expected_request_hash)
+                expect(request_hash.as_json).to match_json_expression(expected_request_hash.as_json)
               end
             end
           end
@@ -164,7 +163,7 @@ module CCMS
                 request_hash = Hash.from_xml(request_xml).deep_symbolize_keys!
                 expected_request_hash = Hash.from_xml(expected_request_xml).deep_symbolize_keys!
 
-                expect(request_hash).to match(expected_request_hash)
+                expect(request_hash.as_json).to match_json_expression(expected_request_hash.as_json)
               end
             end
           end


### PR DESCRIPTION
## What

This is caused by the set-up creating many opponents and a race condition meaning they sometimes get created in a different sequence.

By converting the two hashes into json we can run a, sequence idempotent, match_json_expression comparison

This ensures the payloads match, regardless of sequence

### How?
To track this down I re-created a failing CircleCI run

Adding the tests from the split job and re-using the same seed value.  Then, with a binding.pry, ensured the test woudl fail and then tried different match methods until I could consistently get it to pass

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
