### PR TITLE
Chore: drop the unused `legal_aid_application.student_finance` attribute

### DIFF
--- a/db/migrate/20241210160206_remove_student_finance_from_legal_aid_application.rb
+++ b/db/migrate/20241210160206_remove_student_finance_from_legal_aid_application.rb
@@ -1,0 +1,5 @@
+class RemoveStudentFinanceFromLegalAidApplication < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured { remove_column :legal_aid_applications, :student_finance, :boolean }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_06_121926) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_10_160206) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -634,7 +634,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_06_121926) do
     t.boolean "no_credit_transaction_types_selected"
     t.boolean "no_debit_transaction_types_selected"
     t.boolean "provider_received_citizen_consent"
-    t.boolean "student_finance"
     t.datetime "discarded_at", precision: nil
     t.datetime "merits_submitted_at", precision: nil
     t.boolean "in_scope_of_laspo"

--- a/features/step_definitions/review_and_print_steps.rb
+++ b/features/step_definitions/review_and_print_steps.rb
@@ -104,7 +104,6 @@ Given("I have completed truelayer application with merits and no student finance
   )
 
   @legal_aid_application.applicant.update!(student_finance: false, student_finance_amount: nil)
-
   create :legal_framework_merits_task_list, :da002_da006_as_applicant, legal_aid_application: @legal_aid_application
 
   login_as @legal_aid_application.provider


### PR DESCRIPTION
## What
Drop unused column.

[Link to related story](https://dsdmoj.atlassian.net/browse/AP-5387)

Column was migrated to applicant and partner models 16 months ago. This is the second step
that drops it. Subsequent PR to remove ignore line once we deploy this.

[Removing a column in strong-migrations gem](https://github.com/ankane/strong_migrations?tab=readme-ov-file#removing-a-column)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
