### PR TITLE
Chore: remove ignored_column following it having been dropped

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -2,11 +2,6 @@ class LegalAidApplication < ApplicationRecord
   include Discard::Model
   include DelegatedFunctions
 
-  # This column was moved to applicant and partner models/tables so needs dropping.
-  # ignoring for now so we can test and deploy code to confirm impact without losing
-  # data..
-  self.ignored_columns += %w[student_finance]
-
   ProceedingStruct = Struct.new(:name, :meaning, :matter_type, :category_of_law, :proceeding)
 
   SHARED_OWNERSHIP_YES_REASONS = %w[partner_or_ex_partner housing_assocation_or_landlord friend_family_member_or_other_individual].freeze


### PR DESCRIPTION
## What
Remove ignored_column reference for student_finance

Column was dropped im previous PR that has now been deployed.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
