### PR TITLE
Revert "AP-5177: Switch to new PDA after login"

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@ RSpec/AnyInstance:
     - 'spec/requests/admin/legal_aid_applications/submissions_controller_spec.rb'
     - 'spec/requests/providers/uploaded_evidence_collection_spec.rb'
     - 'spec/requests/providers/use_ccms_controller_spec.rb'
-    - 'spec/requests/saml_sessions_controller_spec.rb'
+    - 'spec/requests/saml_sessions_spec.rb'
     - 'spec/services/ccms/attribute_configuration_spec.rb'
     - 'spec/services/ccms/manual_review_determiner_spec.rb'
     - 'spec/services/ccms/payload_generators/entity_attributes_generator_spec.rb'

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -21,7 +21,7 @@ class Provider < ApplicationRecord
   end
 
   def update_details_directly
-    PDA::ProviderDetailsCreator.call(self)
+    ProviderDetailsCreator.call(self)
   end
 
   def sca_permissions?

--- a/app/services/provider_after_login_service.rb
+++ b/app/services/provider_after_login_service.rb
@@ -27,11 +27,11 @@ private
   end
 
   def call_provider_details_api
-    PDA::ProviderDetailsCreator.call(@provider)
+    ProviderDetailsCreator.call(@provider)
     @provider.clear_invalid_login!
-  rescue PDA::ProviderDetailsRetriever::ApiRecordNotFoundError
+  rescue ProviderDetailsRetriever::ApiRecordNotFoundError
     @provider.update!(invalid_login_details: "api_details_user_not_found")
-  rescue PDA::ProviderDetailsRetriever::ApiError
+  rescue ProviderDetailsRetriever::ApiError
     @provider.update!(invalid_login_details: "provider_details_api_error")
   end
 end

--- a/app/services/provider_details_retriever.rb
+++ b/app/services/provider_details_retriever.rb
@@ -13,18 +13,14 @@ class ProviderDetailsRetriever
   end
 
   def call
-    # :nocov:
     Rails.logger.info "**** Using #{self.class} to retrieve Provider Details" unless Rails.env.test?
-    # :nocov:
     provider_details
   end
 
 private
 
   def provider_details
-    # :nocov:
     raise_record_not_found_error if response.is_a?(Net::HTTPNotFound)
-    # :nocov:
 
     raise_error unless response.is_a?(Net::HTTPOK)
 
@@ -54,8 +50,6 @@ private
   end
 
   def raise_record_not_found_error
-    # :nocov:
     raise ApiRecordNotFoundError, "Retrieval Failed: #{response.message} (#{response.code}) #{response.body}"
-    # :nocov:
   end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Provider do
   describe "#update_details" do
     context "when firm exists" do
       it "does not call provider details creator immediately" do
-        expect(PDA::ProviderDetailsCreator).not_to receive(:call).with(provider)
+        expect(ProviderDetailsCreator).not_to receive(:call).with(provider)
         provider.update_details
       end
 

--- a/spec/services/provider_after_login_service_spec.rb
+++ b/spec/services/provider_after_login_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ProviderAfterLoginService do
       let(:provider) { create(:provider, :created_by_devise, :with_ccms_apply_role, invalid_login_details: "provider_details_api_error") }
 
       context "and the provider cannot be found on Provider Details API" do
-        before { allow(PDA::ProviderDetailsCreator).to receive(:call).and_raise(PDA::ProviderDetailsRetriever::ApiRecordNotFoundError) }
+        before { allow(ProviderDetailsCreator).to receive(:call).and_raise(ProviderDetailsRetriever::ApiRecordNotFoundError) }
 
         it "updates the provider invalid login details" do
           call
@@ -30,7 +30,7 @@ RSpec.describe ProviderAfterLoginService do
       end
 
       context "and the provider found on Provider Details API" do
-        before { allow(PDA::ProviderDetailsCreator).to receive(:call).with(provider) }
+        before { allow(ProviderDetailsCreator).to receive(:call).with(provider) }
 
         it "does not update invalid login details" do
           call
@@ -39,7 +39,7 @@ RSpec.describe ProviderAfterLoginService do
       end
 
       context "and the provider details API not available" do
-        before { allow(PDA::ProviderDetailsCreator).to receive(:call).and_raise(PDA::ProviderDetailsRetriever::ApiError) }
+        before { allow(ProviderDetailsCreator).to receive(:call).and_raise(ProviderDetailsRetriever::ApiError) }
 
         it "updates the provider invalid login details" do
           call


### PR DESCRIPTION
Reverting due to unmatched firms, this is caused by a provider residing within multiple firms.

Further analysis required, to understand impact to providers and the Apply service.