### PR TITLE
Chore: Pre Ruby 3.4 updates

### DIFF
--- a/spec/services/delegated_functions_date_service_spec.rb
+++ b/spec/services/delegated_functions_date_service_spec.rb
@@ -1,4 +1,3 @@
-require "rspec"
 require "rails_helper"
 
 RSpec.describe DelegatedFunctionsDateService do

--- a/spec/services/substantive_application_deadline_calculator_spec.rb
+++ b/spec/services/substantive_application_deadline_calculator_spec.rb
@@ -1,4 +1,3 @@
-require "rspec"
 require "rails_helper"
 
 RSpec.describe SubstantiveApplicationDeadlineCalculator, :vcr do


### PR DESCRIPTION
## What

I pulled down a release candidate of ruby 3.4 to see how "bad" the transition could be, and the only, obvious, issue was these two files requiring RSpec.

As they are a superfluous require and Rails was not able to open a console and rspec would not run with these present in 3.4, they can be removed now

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
