### PR TITLE
Chore: Improve Grover set up for developers

### DIFF
--- a/config/initializers/grover.rb
+++ b/config/initializers/grover.rb
@@ -1,10 +1,4 @@
 Grover.configure do |config|
-  protocol = if Rails.env.development?
-               "http://"
-             else
-               "https://"
-             end
-
   config.options = {
     format: "A4",
     emulate_media: "print",
@@ -12,7 +6,7 @@ Grover.configure do |config|
     bypass_csp: true,
     cache: false,
     wait_until: "networkidle2",
-    display_url: protocol + ENV.fetch("HOST", "localhost:3002"),
+    display_url: Rails.configuration.x.application.host_url,
     margin: {
       top: "10mm",
       bottom: "10mm",


### PR DESCRIPTION
## What

Switches the display_url in the grover initializer to use the Rails.configuration.x.application.host_url, the previous version tried to replicate this setting but needed extra values to be present in .ENV files.

This change should allow developers with a `PORT` value in their `.env` file to view to render PDF files locally while not affecting the generation on deployed environments; UAT, Staging and Production

## branch merits report
![image](https://github.com/user-attachments/assets/3a67f70a-824b-49b6-b3a3-47e11ac4aa1f)

## branch merits report
![image](https://github.com/user-attachments/assets/dcf608d7-dae5-4dd8-8703-aaef5ea18ac0)


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
