### PR TITLE
AP-5641: Fix issue on proceeding search page

### DIFF
--- a/app/javascript/src/modules/proceedings.js
+++ b/app/javascript/src/modules/proceedings.js
@@ -92,6 +92,7 @@ function searchOnUserInput (searchInputBox) {
     .querySelector('#clear-proceeding-search')
     .addEventListener('click', () => {
       searchInputBox.value = ''
+      deselectPreviousProceedingItem()
       hideProceeedingsItems()
       setTimeout(() => { document.querySelector('#screen-reader-messages').innerHTML = 'Search box has been cleared.' }, screenReaderMessageDelay)
     })


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5641)

Fix bug so "Clear search" link actually clears the search, and an error message is shown if the user tries to progress after clicking it

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
