### PR TITLE
AP-5648: Fix bug on merits CYA page

### DIFF
--- a/app/views/admin/roles/permissions/show.html.erb
+++ b/app/views/admin/roles/permissions/show.html.erb
@@ -11,7 +11,7 @@
         local: true,
       ) do |form| %>
 
-    <div class="govuk-!-margin-top-0govuk-!-padding-bottom-2">
+    <div class="govuk-!-margin-top-0 govuk-!-padding-bottom-2">
       <fieldset class="govuk-fieldset">
         <div class="govuk-checkboxes">
           <div class="govuk-grid-row govuk-!-margin-top-0">

--- a/app/views/shared/check_answers/_merits_proceeding_section.html.erb
+++ b/app/views/shared/check_answers/_merits_proceeding_section.html.erb
@@ -50,7 +50,7 @@
                 ) %>
           <% end %>
         <% end %>
-        <% if proceeding.section8? || (proceeding.special_childrens_act? && proceeding.client_involvement_type_ccms_code == "D") %>
+        <% if proceeding.section8? || (proceeding.special_childrens_act? && proceeding.client_involvement_type_ccms_code.in?(["A", "D"])) %>
           <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{proceeding.id}_linked_children" }) do |row| %>
             <%= row.with_key(text: t(".linked_children"), classes: "govuk-!-width-one-half") %>
             <%= row.with_value(text: linked_children_names(proceeding)) %>


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5648)

Update conditional to add additional client involvement type. This means that if a special children act proceeding has a client involvement type of applicant, the correct info will now be shown on the check your answers page

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
