### PR TITLE
LnD: investigation into restart submission report generation

### DIFF
--- a/app/controllers/admin/ccms_queues_controller.rb
+++ b/app/controllers/admin/ccms_queues_controller.rb
@@ -2,6 +2,7 @@ module Admin
   class CCMSQueuesController < AdminBaseController
     def index
       @in_progress = CCMS::Submission.where.not(aasm_state: %w[completed abandoned]).order(created_at: :desc)
+      @paused = BaseStateMachine.where(aasm_state: :submission_paused).order(:created_at).map(&:legal_aid_application)
     end
 
     def show

--- a/app/models/concerns/base_state_machine.rb
+++ b/app/models/concerns/base_state_machine.rb
@@ -8,6 +8,10 @@ class BaseStateMachine < ApplicationRecord
     EnableCCMSSubmission.call || ENV.fetch("LOCAL_CCMS_OVERRIDE", "false") == "true"
   end
 
+  def log_status_change
+    Rails.logger.info "Log::Status::Change laa: #{legal_aid_application.id} event: #{aasm.current_event} from: #{aasm.from_state} to: #{aasm.to_state}"
+  end
+
   VALID_CCMS_REASONS = %i[
     no_online_banking
     no_applicant_consent
@@ -42,6 +46,8 @@ class BaseStateMachine < ApplicationRecord
     state :assessment_submitted
     state :use_ccms
     state :delegated_functions_used
+
+    after_all_transitions :log_status_change
 
     event :enter_applicant_details do
       transitions from: %i[

--- a/app/models/concerns/base_state_machine.rb
+++ b/app/models/concerns/base_state_machine.rb
@@ -9,7 +9,7 @@ class BaseStateMachine < ApplicationRecord
   end
 
   def log_status_change
-    Rails.logger.info "Log::Status::Change laa: #{legal_aid_application.id} event: #{aasm.current_event} from: #{aasm.from_state} to: #{aasm.to_state}"
+    Rails.logger.info "BaseStateMachine::StateChange, laa_id: #{legal_aid_application.id}, event: #{aasm.current_event}, from: #{aasm.from_state}, to: #{aasm.to_state}"
   end
 
   VALID_CCMS_REASONS = %i[

--- a/app/views/admin/ccms_queues/index.html.erb
+++ b/app/views/admin/ccms_queues/index.html.erb
@@ -3,8 +3,9 @@
       back_link: :none,
     ) %>
 
+<h2 class="govuk-heading-m"><%= t(".progress_queue.heading") %></h2>
 <% if @in_progress.empty? %>
-  <h2 class="govuk-heading-m">Queue is empty</h2>
+  <h3 class="govuk-heading-s"><%= t(".progress_queue.empty") %></h3>
 <% else %>
 
   <div class="govuk-grid-row">
@@ -31,6 +32,42 @@
                   row.with_cell(text: submission.aasm_state)
                   row.with_cell(text: l(submission.legal_aid_application.created_at, format: :long_date_time))
                   row.with_cell(text: t(".sidekiq.#{submission.sidekiq_running?}"))
+                end
+              end
+            end
+          end %>
+
+    </div>
+  </div>
+
+<% end %>
+
+<h2 class="govuk-heading-m"><%= t(".paused_submission.heading") %></h2>
+<% if @paused.empty? %>
+  <h3 class="govuk-heading-s"><%= t(".paused_submission.empty") %></h3>
+<% else %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+
+      <%= govuk_table do |table|
+            table.with_caption(html_attributes: { class: "govuk-visually-hidden" }, text: t(".page_title"))
+
+            table.with_head do |head|
+              head.with_row do |row|
+                row.with_cell(text: t(".case_reference"))
+                row.with_cell(text: t(".state"))
+                row.with_cell(text: t(".created_at"))
+              end
+            end
+
+            table.with_body do |body|
+              @paused.each do |application|
+                body.with_row do |row|
+                  row.with_cell do
+                    govuk_link_to(application.application_ref, admin_legal_aid_applications_submission_path(application))
+                  end
+                  row.with_cell(text: application.state.humanize)
+                  row.with_cell(text: l(application.created_at, format: :long_date_time))
                 end
               end
             end

--- a/app/workers/reports_creator_worker.rb
+++ b/app/workers/reports_creator_worker.rb
@@ -1,6 +1,7 @@
 class ReportsCreatorWorker
   include Sidekiq::Worker
   include Sidekiq::Status::Worker
+  sidekiq_options queue: :report_creator
 
   def perform(legal_aid_application_id)
     legal_aid_application = LegalAidApplication.find(legal_aid_application_id)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -15,6 +15,10 @@ end
 
 Sidekiq.configure_server do |config|
   config.redis = { url: redis_url }
+  config.capsule("report_capsule") do |cap|
+    cap.concurrency = 2
+    cap.queues = %w[report_creator]
+  end
 
   # accepts :expiration (optional)
   Sidekiq::Status.configure_server_middleware config, expiration: 30.minutes.to_i

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -35,8 +35,15 @@ en:
     ccms_queues:
       index:
         page_title: Incomplete CCMS Submissions
+        progress_queue:
+          heading: Processing queue
+          empty: The sidekiq queue is empty
+        paused_submission:
+          heading: Paused submissions
+          empty: There are no paused submissions
         applicant_name: Client's name
         references: CCMS & case reference
+        case_reference: Case reference
         created_at: Date started
         state: State
         sidekiq:

--- a/spec/requests/admin/ccms_queues_controller_spec.rb
+++ b/spec/requests/admin/ccms_queues_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Admin::CCMSQueuesController do
     context "when there are no applications on the queue" do
       it "displays a warning message" do
         get_index
-        expect(response.body).to include("Queue is empty")
+        expect(response.body).to include("The sidekiq queue is empty")
       end
     end
 
@@ -33,6 +33,22 @@ RSpec.describe Admin::CCMSQueuesController do
       it "has a link to the application" do
         get_index
         expect(response.body).to include(admin_ccms_queue_path(ccms_submission.id))
+      end
+    end
+
+    context "when there are no paused applications" do
+      it "displays a warning message" do
+        get_index
+        expect(response.body).to include("There are no paused submissions")
+      end
+    end
+
+    context "when there is a paused application" do
+      let!(:legal_aid_application) { create(:legal_aid_application, :submission_paused) }
+
+      it "has a link to the application" do
+        get_index
+        expect(response.body).to include(admin_legal_aid_applications_submission_path(legal_aid_application))
       end
     end
   end


### PR DESCRIPTION
## What

When CCMS submissions were restarted on the morning of 20 Dec the submissions restarted but the reports did not generate as expected.

This PR identified an issue where CCMS submissions have been paused during an evening downtime. Previously we had only seen 2 or 3 submissions maximum.  

On this occasion there were 10 applications to restart.  This turned out to be too many! 

I recreated the situation, 10 paused applications, and turned the submissions back on.  The first 5 (each sidekiq worker has 5 threads) requested a CCMS case reference and then tried to generate reports at the same time... the worker container ran out of memory and crashed.  When a new pod was spawned, the next 5 started.  This left all 10 applications trying to build reports and failing.

Working as a team we identified that Sidekiq Capsules should work for us, I restored a backup of the test branch with 10 paused applications and created a new report_creator queue with two threads.  This allowed two applications to build reports simultaneously and successfully cleared the paused submissions

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
