### PR TITLE
Chore: Bump bundler 2.5.11 to 2.6.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -863,4 +863,4 @@ RUBY VERSION
    ruby 3.3.6p108
 
 BUNDLED WITH
-   2.5.11
+   2.6.2


### PR DESCRIPTION
## What
Bump bundler 2.5.11 to 2.6.2

see [changlog](https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
