### PR TITLE
Chore: remove helper govuk_fieldset_header

### DIFF
--- a/app/helpers/gov_uk_form_helper.rb
+++ b/app/helpers/gov_uk_form_helper.rb
@@ -16,30 +16,6 @@ module GovUkFormHelper
     ]
   end
 
-  # Either passing in the heading text and let this method sort out its formatting,
-  # or define the heading content manually by wrapping this method around a formated header.
-  # So:
-  #   <%= govuk_fieldset_header 'My Heading' %>
-  #
-  # or
-  #
-  #   <%= govuk_fieldset_header do %>
-  #     <h1 class="govuk-fieldset__heading">My Heading</h1>
-  #   <% end %>
-  #
-  # Both result in the same output
-
-  def govuk_fieldset_header(text = nil, size: "xl", padding_below: nil, &)
-    heading = text ? content_tag(:h1, text, class: "govuk-fieldset__heading") : capture(&)
-    padding_class = padding_below && "govuk-!-padding-bottom-#{padding_below}"
-    render(
-      "shared/forms/fieldset_header",
-      heading:,
-      size:,
-      padding_class:,
-    )
-  end
-
   def govuk_error_message(text, args = {})
     return if text.blank?
 

--- a/app/views/admin/user_dashboard/index.html.erb
+++ b/app/views/admin/user_dashboard/index.html.erb
@@ -1,10 +1,8 @@
-<%= govuk_fieldset_header do %>
-  <h1 class="govuk-fieldset__heading">
-    <%= label_tag(t(".heading_1"), page_title) %>
-  </h1>
+<%= page_template page_title: t(".heading_1"), back_link: :none do %>
+
+  <%= govuk_list [
+        govuk_link_to(t(".firm_permissions"), admin_roles_path, class: "govuk-heading-m", id: "firm_permissions", method: :get),
+        govuk_link_to(t(".firms"), admin_firms_path, class: "govuk-heading-m", id: "firm_permissions", method: :get),
+      ] %>
+
 <% end %>
-
-<br>
-
-<%= govuk_link_to t(".firm_permissions"), admin_roles_path, class: "govuk-heading-m", id: "firm_permissions", method: :get %>
-<%= govuk_link_to t(".firms"), admin_firms_path, class: "govuk-heading-m", id: "firm_permissions", method: :get %>

--- a/app/views/providers/applicant_bank_accounts/show.html.erb
+++ b/app/views/providers/applicant_bank_accounts/show.html.erb
@@ -6,7 +6,9 @@
     ) do |form| %>
   <%= page_template page_title: t(".heading"), template: :basic, form: do %>
 
-    <%= govuk_fieldset_header page_title %>
+    <h1 class="govuk-heading-xl">
+      <%= page_title %>
+    </h1>
 
     <p class="govuk-body"><%= t(".previously_told") %></p>
 

--- a/app/views/providers/applicant_bank_accounts/show.html.erb
+++ b/app/views/providers/applicant_bank_accounts/show.html.erb
@@ -12,26 +12,20 @@
 
     <p class="govuk-body"><%= t(".previously_told") %></p>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <% @applicant_accounts.each do |applicant_account| %>
-          <% applicant_account.bank_accounts.each do |bank_account| %>
-            <ul class="govuk-list govuk-!-margin-bottom-4">
-              <li>
-                <strong><%= t(".account") %>: </strong>
-                <%= bank_account.bank_and_account_name %>
-              </li>
-              <li>
-                <strong><%= t(".balance") %>: </strong>
-                <%= value_with_currency_unit(bank_account.balance, bank_account.currency) %>
-              </li>
-            </ul>
-          <% end %>
-      <% end %>
-      </div>
-    </div>
-
-    <div class="govuk-!-padding-bottom-4"></div>
+    <%= govuk_summary_list(actions: false, borders: false) do |summary_list|
+          @applicant_accounts.each do |applicant_account|
+            applicant_account.bank_accounts.each do |bank_account|
+              summary_list.with_row do |row|
+                row.with_key { t(".account") }
+                row.with_value { bank_account.bank_and_account_name }
+              end
+              summary_list.with_row do |row|
+                row.with_key { t(".balance") }
+                row.with_value { value_with_currency_unit(bank_account.balance, bank_account.currency) }
+              end
+            end
+          end
+        end %>
 
     <%= form.govuk_radio_buttons_fieldset :applicant_bank_account,
                                           legend: { size: "m", tag: "h2", text: t(".offline_savings_accounts") },

--- a/app/views/shared/forms/_fieldset_header.html.erb
+++ b/app/views/shared/forms/_fieldset_header.html.erb
@@ -1,3 +1,0 @@
-<legend class="govuk-fieldset__legend govuk-fieldset__legend--<%= size %> <%= padding_class %>">
-  <%= heading %>
-</legend>


### PR DESCRIPTION
## What

Remaining references to helper method `govuk_fieldset_header` being used for headings
Replace these with actual Heading Ones
Remove helper `govuk_fieldset_header`

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
