### PR TITLE
Chore: Amend /healthcheck endpoint to use database_exists?

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -53,9 +53,7 @@ private
   end
 
   def database_alive?
-    ActiveRecord::Base.connection.active?
-  rescue PG::ConnectionBad
-    false
+    ActiveRecord::Base.connection.database_exists?
   end
 
   def malware_scanner_positive


### PR DESCRIPTION
## What
Amend /healthcheck endpoint to use database_exists?

[Identified while working on](https://dsdmoj.atlassian.net/browse/AP-5668)

Inline with hmrc-interface app, at least, and best
practice since rails 7.2 as `active?` may be false
due to lazy loaded connections.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
