### PR TITLE
Chore: Remove PLF routing TODOs

### DIFF
--- a/spec/requests/providers/application_merits_task/original_judge_levels_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/original_judge_levels_controller_spec.rb
@@ -79,9 +79,9 @@ RSpec.describe Providers::ApplicationMeritsTask::OriginalJudgeLevelsController d
               .to("district_judge")
         end
 
-        it "redirects to the next page", skip: "TODO: AP-5531/5532" do
+        it "redirects to the next page" do
           post_original_judge_level
-          expect(response).to redirect_to(:appeal_court_type)
+          expect(response).to redirect_to(flow_forward_path)
         end
       end
 

--- a/spec/requests/providers/application_merits_task/second_appeals_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/second_appeals_controller_spec.rb
@@ -70,9 +70,9 @@ RSpec.describe Providers::ApplicationMeritsTask::SecondAppealsController do
           expect(legal_aid_application.reload.appeal.second_appeal).to be true
         end
 
-        it "redirects to the next page", skip: "TODO: AP-5530" do
+        it "redirects to the next page" do
           post_second_appeal
-          expect(response).to redirect_to(:second_appeal_court)
+          expect(response).to redirect_to(providers_legal_aid_application_second_appeal_court_type_path)
         end
       end
 
@@ -88,9 +88,9 @@ RSpec.describe Providers::ApplicationMeritsTask::SecondAppealsController do
           expect(legal_aid_application.reload.appeal.second_appeal).to be false
         end
 
-        it "redirects to the next page", skip: "TODO: AP-5530" do
+        it "redirects to the next page" do
           post_second_appeal
-          expect(response).to redirect_to(:original_judge_level)
+          expect(response).to redirect_to(providers_legal_aid_application_original_judge_level_path)
         end
       end
 


### PR DESCRIPTION

## What

These were added while the individual pages were implemented and can now be removed

Remove the TODO and add the correct path to the expectations

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
