### PR TITLE
Chore: Remove extraneous parameter

### DIFF
--- a/spec/requests/providers/change_of_names_interrupts_controller_spec.rb
+++ b/spec/requests/providers/change_of_names_interrupts_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Providers::ChangeOfNamesInterruptsController do
   let(:provider) { legal_aid_application.provider }
 
   describe "GET /providers/applications/:id/change_of_names_interrupts" do
-    subject(:get_request) { get providers_legal_aid_application_change_of_names_interrupt_path(legal_aid_application, display) }
+    subject(:get_request) { get providers_legal_aid_application_change_of_names_interrupt_path(legal_aid_application) }
 
     context "when the provider is not authenticated" do
       before { get_request }


### PR DESCRIPTION

## What

I think the `display` parameter was copy pasted from another controller test.  As it was empty in this test, it caused debug output to be added to the test run, e.g.


........#<RSpec::ExampleGroups::ProvidersChangeOfNamesInterruptsController::GETProvidersApplicationsIdChangeOfNamesInterrupts::WhenTheProviderIsNotAuthenticated::BehavesLikeAProviderNotAuthenticated:0x000000013e0a8450>.#<RSpec::ExampleGroups::ProvidersChangeOfNamesInterruptsController::GETProvidersApplicationsIdChangeOfNamesInterrupts::WhenTheProviderIsAuthenticated:0x000000013db62ae0>.....



## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
