### PR TITLE
Chore: simplify panel markup on citizen journey

### DIFF
--- a/app/views/citizens/means_test_results/show.html.erb
+++ b/app/views/citizens/means_test_results/show.html.erb
@@ -1,24 +1,7 @@
 <% content_for(:panel) do %>
   <%= govuk_panel(title_text: t(".completed_financial_assessment")) do %>
-    <dl class="govuk-summary-list govuk-summary-list--no-border govuk-list inline-list">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= t(".name") %>:
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @applicant.full_name %>
-        </dd>
-      </div>
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= t(".reference_number") %>:
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @legal_aid_application.application_ref %>
-        </dd>
-      </div>
-    </dl>
+    <strong><%= t(".name") %></strong>: <%= @applicant.full_name %><br>
+    <strong><%= t(".reference_number") %></strong>: <%= @legal_aid_application.application_ref %>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
## What

Panel markup on citizen journey was previously unnecessarily complex. Simplify this to keep in line with rest of the codebase and use default spacing.

## Screenshots

### Before
<img width="1204" alt="image" src="https://github.com/user-attachments/assets/82118a60-9eac-4c75-baa0-378bc7bdcbc7" />

### After
<img width="1203" alt="image" src="https://github.com/user-attachments/assets/64123e69-2b50-4d04-b3eb-3be2f579b61e" />

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
