### PR TITLE
Chore: Remove next_action_link helper method

### DIFF
--- a/app/helpers/flow_helper.rb
+++ b/app/helpers/flow_helper.rb
@@ -44,9 +44,4 @@ module FlowHelper
       container_class: ["govuk-button-group", container_class].compact.join(" "),
     )
   end
-
-  def next_action_link(continue_id: :continue, continue_text: t("generic.save_and_continue"), html_class: nil)
-    klasses = ["govuk-button", html_class].compact.join(" ")
-    govuk_link_to(continue_text, forward_path, id: continue_id, class: klasses)
-  end
 end

--- a/app/views/citizens/accounts/index.html.erb
+++ b/app/views/citizens/accounts/index.html.erb
@@ -44,7 +44,7 @@
     <p><%= govuk_link_to t(".link_other_account"), citizens_banks_path %></p>
 
     <div class="govuk-!-padding-top-3">
-      <%= next_action_link(continue_text: t("generic.continue")) %>
+      <%= govuk_button_link_to(t("generic.continue"), forward_path) %>
     </div>
   </div>
 </div>

--- a/app/views/providers/submitted_applications/show.html.erb
+++ b/app/views/providers/submitted_applications/show.html.erb
@@ -11,6 +11,5 @@
 
   <%= render "shared/review_application/questions_and_answers" %>
 
-  <%= next_action_link continue_text: t(".back_home"), html_class: "govuk-button--secondary no-print" %>
-
+  <%= govuk_button_link_to(t(".back_home"), forward_path, secondary: true, class: "no-print") %>
 <% end %>

--- a/app/views/shared/_worker_complete.html.erb
+++ b/app/views/shared/_worker_complete.html.erb
@@ -4,14 +4,10 @@
 <% continue_text = locals[:continue_text] || nil %>
 
 <%= page_template page_title: heading do %>
-  <p>
-    <%= intro_text %>
-  </p>
-  <p>
-    <%= balance_text %>
-  </p>
-  <div class="govuk-!-padding-top-3">
-    <%= next_action_link(continue_text:) %>
-  </div>
+  <p class="govuk-body"><%= intro_text %></p>
+  <p class="govuk-body"><%= balance_text %></p>
+
+  <%= govuk_button_link_to(continue_text, forward_path) %>
+
   <span role="status" id="complete"></span>
 <% end %>


### PR DESCRIPTION
## What

Remove next_action_link as the functionality can just as easily be provided with the govuk_button_link_to method from the govuk_components gem

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
