### PR TITLE
AP-5647: Update proceeding captions

### DIFF
--- a/app/controllers/providers/change_of_names_controller.rb
+++ b/app/controllers/providers/change_of_names_controller.rb
@@ -1,14 +1,14 @@
 module Providers
   class ChangeOfNamesController < ProviderBaseController
     def show
-      @proceeding = legal_aid_application.proceedings.last
+      @proceeding = legal_aid_application.proceedings.order(:created_at).last
       form
     end
 
     def update
       return continue_or_draft if draft_selected?
 
-      @proceeding = legal_aid_application.proceedings.last
+      @proceeding = legal_aid_application.proceedings.order(:created_at).last
       if form.valid?
         return redirect_to providers_legal_aid_application_change_of_names_interrupt_path(legal_aid_application) if form.change_of_name?
 

--- a/app/controllers/providers/proceedings_sca/child_subjects_controller.rb
+++ b/app/controllers/providers/proceedings_sca/child_subjects_controller.rb
@@ -4,14 +4,14 @@ module Providers
       prefix_step_with :proceedings_sca
 
       def show
-        @proceeding = legal_aid_application.proceedings.last
+        @proceeding = legal_aid_application.proceedings.order(:created_at).last
         form
       end
 
       def update
         return continue_or_draft if draft_selected?
 
-        @proceeding = legal_aid_application.proceedings.last
+        @proceeding = legal_aid_application.proceedings.order(:created_at).last
         if form.valid?
           return redirect_to providers_legal_aid_application_sca_interrupt_path(legal_aid_application, "child_subject") unless form.child_subject?
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5467)

Switch from proceedings.last to proceedings.order(:created_at).last

Because we use GUIDs as the id, there is no value in a plain .last call as it orders by GUID text.  Adding the order allows us to get the most recently created proceeding, which is what is expected, without having to make the URLs and routing more complex by adding specific proceeding IDs into the routes.

This also matches the existing use in the ProceedingIssueStatusesController

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
