### PR TITLE
AP-5685: PLF non means tested routing

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -187,6 +187,10 @@ class LegalAidApplication < ApplicationRecord
     proceedings.any? { |proceeding| proceeding.ccms_matter_code.eql?("KSEC8") }
   end
 
+  def plf_non_means_tested_proceeding?
+    proceedings.any? { |proceeding| proceeding.ccms_code.in?(%w[PBM40 PBM40E PBM45 PBM45E]) }
+  end
+
   def special_children_act_proceedings?
     proceedings.any? { |proceeding| proceeding.ccms_matter_code.eql?("KPBLW") }
   end
@@ -371,7 +375,7 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def non_means_tested?
-    applicant&.no_means_test_required? || special_children_act_proceedings?
+    applicant&.no_means_test_required? || special_children_act_proceedings? || plf_non_means_tested_proceeding?
   end
 
   def benefit_check_result_needs_updating?

--- a/app/views/providers/confirm_non_means_tested_applications/show.html.erb
+++ b/app/views/providers/confirm_non_means_tested_applications/show.html.erb
@@ -1,6 +1,8 @@
 <%= page_template(page_title: t(".tab_title"), template: :basic, column_width: "full") do %>
   <% heading = if @legal_aid_application.special_children_act_proceedings?
                  t(".title.sca_proceeding")
+               elsif @legal_aid_application.plf_non_means_tested_proceeding?
+                 t(".title.plf_non_means_tested")
                elsif @legal_aid_application.used_delegated_functions?
                  t(".title.under_18_when_delegated_functions_used")
                else

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -257,6 +257,7 @@ en:
             You do not need to do a means test as your client was under 18
             when you first used delegated functions on this case
           sca_proceeding: You do not need to do a means test for special children act proceedings
+          plf_non_means_tested: You do not need to do a means test for parental placement and adoption cases under public law family
         tab_title: No means test required
     check_client_details:
       show:

--- a/spec/factories/proceedings.rb
+++ b/spec/factories/proceedings.rb
@@ -438,4 +438,23 @@ FactoryBot.define do
     client_involvement_type_ccms_code { "A" }
     client_involvement_type_description { "Applicant/Claimant/Petitioner" }
   end
+
+  trait :pbm40 do
+    lead_proceeding { false }
+    ccms_code { "PBM40" }
+    meaning { "Placement order - parent or parental responsibility" }
+    description { "To represent a parent or person with parental responsibility on an application for a placement order." }
+    substantive_cost_limitation { 5000 }
+    delegated_functions_cost_limitation { 2250 }
+    used_delegated_functions { nil }
+    used_delegated_functions_on { nil }
+    used_delegated_functions_reported_on { nil }
+    name { "placement_order_parent_or_parental_responsibility_plf" }
+    matter_type { "public law family (PLF)" }
+    category_of_law { "Family" }
+    category_law_code { "MAT" }
+    ccms_matter_code { "KPBLB" }
+    client_involvement_type_ccms_code { "A" }
+    client_involvement_type_description { "Applicant/Claimant/Petitioner" }
+  end
 end

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1648,6 +1648,30 @@ RSpec.describe LegalAidApplication do
     end
   end
 
+  describe "#plf_non_means_tested_proceeding?" do
+    context "with a plf non means tested proceeding" do
+      let(:laa) do
+        create(:legal_aid_application,
+               :with_proceedings,
+               explicit_proceedings: %i[pbm40],
+               set_lead_proceeding: :pbm40)
+      end
+
+      it "returns true" do
+        expect(laa.plf_non_means_tested_proceeding?).to be true
+      end
+    end
+
+    context "without special children act proceedings" do
+      let(:laa) { create(:legal_aid_application) }
+
+      it "returns false" do
+        create(:proceeding, :da001, legal_aid_application: laa)
+        expect(laa.plf_non_means_tested_proceeding?).to be false
+      end
+    end
+  end
+
   describe "#online_current_accounts_balance" do
     let(:laa) { create(:legal_aid_application, :with_applicant) }
 

--- a/spec/services/flow/steps/provider_start/check_provider_answers_step_spec.rb
+++ b/spec/services/flow/steps/provider_start/check_provider_answers_step_spec.rb
@@ -52,5 +52,17 @@ RSpec.describe Flow::Steps::ProviderStart::CheckProviderAnswersStep, type: :requ
         expect(legal_aid_application.state_machine.type).to eq "SpecialChildrenActStateMachine"
       end
     end
+
+    context "when the application has a non means tested PLF proceeding" do
+      let(:legal_aid_application) do
+        create(:legal_aid_application,
+               :with_proceedings,
+               explicit_proceedings: %i[pbm40],
+               set_lead_proceeding: :pbm40,
+               applicant:)
+      end
+
+      it { is_expected.to eq :confirm_non_means_tested_applications }
+    end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5685)

Add routing for non-means-tested PLF proceedings
I know we discussed extracting this logic to a service class, but the small additions to the LegalAidApplication made a lot of sense... refactoring would have involved a lot more work at this stage and it didn't seem valuable when the change was so small... happy to discuss


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
