### PR TITLE
AP-5699 Fix incorrect PDA data

### DIFF
--- a/lib/tasks/fixes/ap_5699.rake
+++ b/lib/tasks/fixes/ap_5699.rake
@@ -1,0 +1,71 @@
+namespace :fixes do
+  desc "Fixes for AP-5699"
+  task :ap_5699, [:mock] => :environment do |_task, args|
+    args.with_defaults(mock: "true")
+    mock = args[:mock].to_s.downcase.strip != "false"
+
+    if mock
+      Rails.logger.info "----------------------------------------"
+      Rails.logger.info "MOCK run enabled."
+      Rails.logger.info "No actual changes will be made."
+      Rails.logger.info "----------------------------------------"
+    end
+
+    Rails.logger.info "----------------------------------------"
+    Rails.logger.info "Start of LLARNI"
+
+    potter_derby_application_ids = %w[
+      96c3f849-e2d5-4a71-b58f-8cddbb5a4f8a
+      a6e1ad6a-0875-4b00-a0eb-21f22723f743
+      1d2376e0-29a7-4e16-96ba-dbb4bafe252d
+      7206e8ab-938f-4f95-9ce2-813989ea3568
+    ]
+
+    # Transfer applications from POTTER DERBY LTD office 0M434D to WACE MORGAN SOLICITORS office 0H036Y
+    potter_derby_application_ids.each do |app_id|
+      Rake::Task["ptr_migrations:laa_transfer_office"].execute(mock: mock, app_id: app_id, office_id: "c2d4f6df-0a06-4ade-b1c8-1bba1406a874")
+    end
+
+    # Delete the firm and offices of POTTER DERBY LTD
+    Rake::Task["ptr_migrations:delete_firm_office"].execute(mock: mock, firm_id: "210ddca4-ad8c-4401-a981-1027efe7cf60")
+
+    Rails.logger.info "End of LLARNI"
+    Rails.logger.info "----------------------------------------"
+
+    Rails.logger.info "----------------------------------------"
+    Rails.logger.info "Start of DSYKES"
+
+    # Transfer applications from CAROLE BURGHER SOLICITORS office 0M895E to BUTCHER & BARLOW LLP office 0L189A
+    Rake::Task["ptr_migrations:laa_transfer_office"].execute(mock: mock, app_id: "6db37c7a-7350-4384-aa2d-c6a6ccfc22e9", office_id: "fe5dfac8-baa6-4a22-b0c9-681d97068508")
+
+    # Delete the firm and offices of CAROLE BURGHER SOLICITORS
+    Rake::Task["ptr_migrations:delete_firm_office"].execute(mock: mock, firm_id: "29bbd5ca-5820-4502-b74a-76b11e8bff64")
+
+    Rails.logger.info "End of DSYKES"
+    Rails.logger.info "----------------------------------------"
+
+    Rails.logger.info "----------------------------------------"
+    Rails.logger.info "Start of REFERRALS_FISHCO..."
+
+    # Transfer provider EFERRALS@FISHCO.. from firm KEITH PARK SOLICITORS to HARPER ASHBY BOWLES LTD, Office: 0B869G
+    Rake::Task["ptr_migrations:provider_transfer_firm"].execute(mock: mock, provider_id: "e4547a80-0621-44bf-a579-e7944ab5f947", firm_id: "142b3c71-87b9-4105-b607-2b14ffb34e7c")
+
+    # Delete the firm and offices of KEITH PARK SOLICITORS
+    Rake::Task["ptr_migrations:delete_firm_office"].execute(mock: mock, firm_id: "a4b2a3c3-9665-4723-989e-471effcfea3e")
+
+    Rails.logger.info "End of REFERRALS_FISHCO..."
+    Rails.logger.info "----------------------------------------"
+
+    Rails.logger.info "----------------------------------------"
+    Rails.logger.info "Start of HAZELBACON"
+
+    # Transfer provider HAZELBACON from firm MCARAS to CANTER LEVIN & BERG LTD, Office: 5T620Z
+    Rake::Task["ptr_migrations:provider_transfer_firm"].execute(mock: mock, provider_id: "03ec8aa6-56a4-494d-91e6-88d4974671db", firm_id: "02e2f920-c5fd-4e6c-9d6c-af1a16dfe7fc")
+
+    # Delete the firm and offices of MCARAS
+    Rake::Task["ptr_migrations:delete_firm_office"].execute(mock: mock, firm_id: "f16e1312-2118-4417-854d-316e504ebdfa")
+
+    Rails.logger.info "End of HAZELBACON"
+    Rails.logger.info "----------------------------------------"
+  end
+end

--- a/lib/tasks/provider_transfer/ptr_migrations.rake
+++ b/lib/tasks/provider_transfer/ptr_migrations.rake
@@ -1,0 +1,84 @@
+namespace :ptr_migrations do
+  desc "Transfer a LegalAidApplication from one Office to another"
+  task :laa_transfer_office, %i[mock app_id office_id] => :environment do |_task, args|
+    args.with_defaults(mock: "true")
+    mock = args[:mock].to_s.downcase.strip != "false"
+    laa = LegalAidApplication.find_by(id: args[:app_id])
+    office = Office.find_by(id: args[:office_id])
+
+    if laa.nil? || office.nil?
+      Rails.logger.info "LegalAidApplication or OFFICE does not exist"
+      next
+    end
+
+    if laa
+      Rails.logger.info "LegalAidApplication (#{laa.application_ref}) current office code: #{laa.office.code}"
+
+      laa.update!(office: office) unless mock
+
+      Rails.logger.info "LegalAidApplication (#{laa.application_ref}) successfully transferred to office code: #{laa.office.code}"
+    else
+      Rails.logger.info "LegalAidApplication not found"
+    end
+  end
+
+  desc "Transfer a Provider from one Firm to another"
+  task :provider_transfer_firm, %i[mock provider_id firm_id] => :environment do |_task, args|
+    args.with_defaults(mock: "true")
+    mock = args[:mock].to_s.downcase.strip != "false"
+    provider = Provider.find_by(id: args[:provider_id])
+    firm = Firm.find_by(id: args[:firm_id])
+
+    if provider.nil? || firm.nil?
+      Rails.logger.info "PROVIDER or FIRM does not exist"
+      next
+    end
+
+    if provider
+      Rails.logger.info "Provider (#{provider.email}) current firm #{provider.firm_name}"
+
+      provider.update!(firm: firm, selected_office_id: nil) unless mock
+
+      Rails.logger.info "Provider (#{provider.email}) successfully transferred to firm #{provider.firm_name}"
+    else
+      puts "Provider not found"
+    end
+  end
+
+  desc "Delete unused or incorrect Firm"
+  task :delete_firm_office, %i[mock firm_id] => :environment do |_task, args|
+    args.with_defaults(mock: "true")
+    mock = args[:mock].to_s.downcase.strip != "false"
+    firm = Firm.find_by(id: args[:firm_id])
+
+    if firm.nil?
+      Rails.logger.info "FIRM does not exist"
+      next
+    end
+
+    if firm
+      firm.offices.each do |office|
+        applications_in_office = LegalAidApplication.where(office: office).count
+
+        if applications_in_office.zero?
+          office.destroy! unless mock
+          Rails.logger.info "Firm (#{firm.name}), Office (#{office.code}) deleted successfully"
+        else
+          Rails.logger.info "Firm (#{firm.name}), Office (#{office.code}) has #{applications_in_office} legal aid application associated with it. Skipping!"
+        end
+      end
+
+      offices_in_firm = firm.offices.count
+
+      if offices_in_firm.positive?
+        Rails.logger.info "Firm (#{firm.name}) has #{offices_in_firm} office associated with it. Skipping!"
+      else
+        firm.destroy! unless mock
+
+        Rails.logger.info "Firm (#{firm.name}), deleted successfully"
+      end
+    else
+      Rails.logger.info "Firm not found"
+    end
+  end
+end

--- a/spec/lib/tasks/provider_transfer/ptr_migrations_spec.rb
+++ b/spec/lib/tasks/provider_transfer/ptr_migrations_spec.rb
@@ -1,0 +1,263 @@
+require "rails_helper"
+
+RSpec.describe "ptr_migrations:", type: :task do
+  before do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+    allow(Rails.logger).to receive(:info)
+  end
+
+  describe "ptr_migrations:laa_transfer_office" do
+    subject(:task) do
+      Rake::Task["ptr_migrations:laa_transfer_office"]
+    end
+
+    let(:initial_office) { create(:office) }
+    let(:new_office) { create(:office) }
+    let(:legal_aid_application) { create(:legal_aid_application, office: initial_office) }
+
+    context "when LegalAidApplication and Office exist" do
+      it "updates the office" do
+        expect {
+          task.execute(mock: "false", app_id: legal_aid_application.id, office_id: new_office.id)
+        }.to change { legal_aid_application.reload.office }
+        .from(initial_office).to(new_office)
+      end
+
+      it "logs an error message" do
+        task.execute(mock: "false", app_id: legal_aid_application.id, office_id: new_office.id)
+
+        expect(Rails.logger).to have_received(:info).with("LegalAidApplication (#{legal_aid_application.application_ref}) current office code: #{initial_office.code}")
+        expect(Rails.logger).to have_received(:info).with("LegalAidApplication (#{legal_aid_application.application_ref}) successfully transferred to office code: #{new_office.code}")
+      end
+    end
+
+    context "when LegalAidApplication does not exist" do
+      it "does not update the office" do
+        expect {
+          task.execute(mock: "false", app_id: nil, office_id: new_office.id)
+        }.not_to change { legal_aid_application.reload.office }
+        .from(initial_office)
+      end
+
+      it "logs an error message" do
+        task.execute(mock: "false", app_id: nil, office_id: new_office.id)
+
+        expect(Rails.logger).to have_received(:info).with("LegalAidApplication or OFFICE does not exist")
+      end
+    end
+
+    context "when Office does not exist" do
+      it "does not update the office" do
+        expect {
+          task.execute(mock: "false", app_id: legal_aid_application.id, office_id: nil)
+        }.not_to change { legal_aid_application.reload.office }
+        .from(initial_office)
+      end
+
+      it "logs an error message" do
+        task.execute(mock: "false", app_id: legal_aid_application.id, office_id: nil)
+
+        expect(Rails.logger).to have_received(:info).with("LegalAidApplication or OFFICE does not exist")
+      end
+    end
+
+    context "when both LegalAidApplication and Office do not exist" do
+      it "does not update the office" do
+        expect {
+          task.execute(mock: "false", app_id: nil, office_id: nil)
+        }.not_to change { legal_aid_application.reload.office }
+        .from(initial_office)
+      end
+
+      it "logs an error message" do
+        task.execute(mock: "false", app_id: nil, office_id: nil)
+
+        expect(Rails.logger).to have_received(:info).with("LegalAidApplication or OFFICE does not exist")
+      end
+    end
+
+    context "when mock is true" do
+      it "does not update the office" do
+        expect {
+          task.execute(mock: "true", app_id: legal_aid_application.id, office_id: new_office.id)
+        }.not_to change { legal_aid_application.reload.office }
+        .from(initial_office)
+      end
+
+      it "logs errors messages" do
+        task.execute(mock: "true", app_id: legal_aid_application.id, office_id: new_office.id)
+
+        expect(Rails.logger).to have_received(:info).with("LegalAidApplication (#{legal_aid_application.application_ref}) current office code: #{initial_office.code}")
+        expect(Rails.logger).to have_received(:info).with("LegalAidApplication (#{legal_aid_application.application_ref}) successfully transferred to office code: #{initial_office.code}")
+      end
+    end
+  end
+
+  describe "provider_transfer_firm" do
+    subject(:task) do
+      Rake::Task["ptr_migrations:provider_transfer_firm"]
+    end
+
+    let(:initial_firm) { create(:firm) }
+    let(:new_firm) { create(:firm) }
+    let(:provider) { create(:provider, firm: initial_firm) }
+
+    context "when Provider and Firm exist" do
+      it "updates the firm" do
+        expect {
+          task.execute(mock: "false", provider_id: provider.id, firm_id: new_firm.id)
+        }.to change { provider.reload.firm }
+        .from(initial_firm).to(new_firm)
+      end
+
+      it "logs a message" do
+        task.execute(mock: "false", provider_id: provider.id, firm_id: new_firm.id)
+
+        expect(Rails.logger).to have_received(:info).with("Provider (#{provider.email}) current firm #{initial_firm.name}")
+        expect(Rails.logger).to have_received(:info).with("Provider (#{provider.email}) successfully transferred to firm #{new_firm.name}")
+      end
+    end
+
+    context "when Provider does not exist" do
+      it "does not update the firm" do
+        expect {
+          task.execute(mock: "false", provider_id: nil, firm_id: new_firm.id)
+        }.not_to change { provider.reload.firm }
+        .from(initial_firm)
+      end
+
+      it "logs a message" do
+        task.execute(mock: "false", provider_id: nil, firm_id: new_firm.id)
+
+        expect(Rails.logger).to have_received(:info).with("PROVIDER or FIRM does not exist")
+      end
+    end
+
+    context "when Firm does not exist" do
+      it "does not update the firm" do
+        expect {
+          task.execute(mock: "false", provider_id: provider.id, firm_id: nil)
+        }.not_to change { provider.reload.firm }
+        .from(initial_firm)
+      end
+
+      it "logs an error message" do
+        task.execute(mock: "false", provider_id: provider.id, firm_id: nil)
+
+        expect(Rails.logger).to have_received(:info).with("PROVIDER or FIRM does not exist")
+      end
+    end
+
+    context "when both Provider and Firm do not exist" do
+      it "does not update the firm" do
+        expect {
+          task.execute(mock: "false", provider_id: nil, firm_id: nil)
+        }.not_to change { provider.reload.firm }
+        .from(initial_firm)
+      end
+
+      it "logs a message" do
+        task.execute(mock: "false", provider_id: nil, firm_id: nil)
+
+        expect(Rails.logger).to have_received(:info).with("PROVIDER or FIRM does not exist")
+      end
+    end
+
+    context "when mock is true" do
+      it "does not update the firm" do
+        expect {
+          task.execute(mock: "true", provider_id: provider.id, firm_id: new_firm.id)
+        }.not_to change { provider.reload.firm }
+        .from(initial_firm)
+      end
+
+      it "logs a message" do
+        task.execute(mock: "true", provider_id: provider.id, firm_id: new_firm.id)
+
+        expect(Rails.logger).to have_received(:info).with("Provider (#{provider.email}) current firm #{initial_firm.name}")
+        expect(Rails.logger).to have_received(:info).with("Provider (#{provider.email}) successfully transferred to firm #{initial_firm.name}")
+      end
+    end
+  end
+
+  describe "delete_firm_office" do
+    subject(:task) do
+      Rake::Task["ptr_migrations:delete_firm_office"]
+    end
+
+    let(:firm) { create(:firm) }
+    let(:office) { create(:office) }
+
+    before do
+      firm.offices << office
+    end
+
+    context "when Firm exist and has no associated LegalAidApplications" do
+      it "deletes the firm" do
+        expect {
+          task.execute(mock: "false", firm_id: firm.id)
+        }.to change { Firm.exists?(firm.id) }
+        .from(true).to(false)
+      end
+
+      it "logs a message" do
+        task.execute(mock: "false", firm_id: firm.id)
+
+        expect(Rails.logger).to have_received(:info).with("Firm (#{firm.name}), Office (#{office.code}) deleted successfully")
+        expect(Rails.logger).to have_received(:info).with("Firm (#{firm.name}), deleted successfully")
+      end
+    end
+
+    context "when Firm exist and Office has associated LegalAidApplications" do
+      before do
+        create(:legal_aid_application, office: office)
+        create(:legal_aid_application, office: office)
+      end
+
+      it "does not delete the firm" do
+        expect {
+          task.execute(mock: "false", firm_id: firm.id)
+        }.not_to change { Firm.exists?(firm.id) }
+        .from(true)
+      end
+
+      it "logs a message" do
+        task.execute(mock: "false", firm_id: firm.id)
+
+        expect(Rails.logger).to have_received(:info).with("Firm (#{firm.name}), Office (#{office.code}) has 2 legal aid application associated with it. Skipping!")
+        expect(Rails.logger).to have_received(:info).with("Firm (#{firm.name}) has 1 office associated with it. Skipping!")
+      end
+    end
+
+    context "when Firm does not exist" do
+      it "does not delete the firm" do
+        expect {
+          task.execute(mock: "false", firm_id: nil)
+        }.not_to change { Firm.exists?(firm.id) }
+        .from(true)
+      end
+
+      it "logs an error message" do
+        task.execute(mock: "false", firm_id: nil)
+
+        expect(Rails.logger).to have_received(:info).with("FIRM does not exist")
+      end
+    end
+
+    context "when mock is true" do
+      it "does not delete the firm" do
+        expect {
+          task.execute(mock: "false", firm_id: nil)
+        }.not_to change { Firm.exists?(firm.id) }
+        .from(true)
+      end
+
+      it "logs a message" do
+        task.execute(mock: "true", firm_id: firm.id)
+
+        expect(Rails.logger).to have_received(:info).with("Firm (#{firm.name}), Office (#{office.code}) deleted successfully")
+        expect(Rails.logger).to have_received(:info).with("Firm (#{firm.name}) has 1 office associated with it. Skipping!")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5699)

The new PDA added Provider to incorrect firms and therefore office.
A few new firms where then created because of the above.

This is to transfer application to the correct office; providers to the correct firms; and to remove Firms where no providers have been onboarded.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
