### PR TITLE
AP-5380: Add  PLF merits question, Is matter opposed? 

### DIFF
--- a/app/controllers/providers/application_merits_task/is_matter_opposed_controller.rb
+++ b/app/controllers/providers/application_merits_task/is_matter_opposed_controller.rb
@@ -1,0 +1,26 @@
+module Providers
+  module ApplicationMeritsTask
+    class IsMatterOpposedController < ProviderBaseController
+      def show
+        @form = ApplicationMeritsTask::MatterOpposedForm.new(model: matter_opposed)
+      end
+
+      def update
+        @form = ApplicationMeritsTask::MatterOpposedForm.new(form_params)
+        render :show unless update_task_save_continue_or_draft(:application, :matter_opposed)
+      end
+
+    private
+
+      def matter_opposed
+        legal_aid_application.matter_opposed || legal_aid_application.build_matter_opposed
+      end
+
+      def form_params
+        merge_with_model(matter_opposed) do
+          params.require(:application_merits_task_matter_opposed).permit(:matter_opposed)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/providers/application_merits_task/is_matter_opposed_controller.rb
+++ b/app/controllers/providers/application_merits_task/is_matter_opposed_controller.rb
@@ -2,7 +2,7 @@ module Providers
   module ApplicationMeritsTask
     class IsMatterOpposedController < ProviderBaseController
       def show
-        @form = ApplicationMeritsTask::MatterOpposedForm.new(model: matter_opposed)
+        @form = ApplicationMeritsTask::MatterOpposedForm.new(model: matter_opposition)
       end
 
       def update
@@ -12,13 +12,13 @@ module Providers
 
     private
 
-      def matter_opposed
-        legal_aid_application.matter_opposed || legal_aid_application.build_matter_opposed
+      def matter_opposition
+        legal_aid_application.matter_opposition || legal_aid_application.build_matter_opposition
       end
 
       def form_params
-        merge_with_model(matter_opposed) do
-          params.require(:application_merits_task_matter_opposed).permit(:matter_opposed)
+        merge_with_model(matter_opposition) do
+          params.require(:application_merits_task_matter_opposition).permit(:matter_opposed)
         end
       end
     end

--- a/app/forms/providers/application_merits_task/matter_opposed_form.rb
+++ b/app/forms/providers/application_merits_task/matter_opposed_form.rb
@@ -1,11 +1,11 @@
 module Providers
   module ApplicationMeritsTask
     class MatterOpposedForm < BaseForm
-      form_for ::ApplicationMeritsTask::MatterOpposed
+      form_for ::ApplicationMeritsTask::MatterOpposition
 
       attr_accessor :matter_opposed
 
-      validates :matter_opposed, presence: true, unless: :draft?
+      validates :matter_opposed, inclusion: %w[true false], unless: :draft?
     end
   end
 end

--- a/app/forms/providers/application_merits_task/matter_opposed_form.rb
+++ b/app/forms/providers/application_merits_task/matter_opposed_form.rb
@@ -1,0 +1,11 @@
+module Providers
+  module ApplicationMeritsTask
+    class MatterOpposedForm < BaseForm
+      form_for ::ApplicationMeritsTask::MatterOpposed
+
+      attr_accessor :matter_opposed
+
+      validates :matter_opposed, presence: true, unless: :draft?
+    end
+  end
+end

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -21,6 +21,7 @@ module Flow
         client_denial_of_allegations: Steps::ProviderMerits::ClientDenialOfAllegationsStep,
         client_offered_undertakings: Steps::ProviderMerits::ClientOfferedUndertakingsStep,
         in_scope_of_laspos: Steps::ProviderMerits::InScopeOfLasposStep,
+        is_matter_opposed: Steps::ProviderMerits::IsMatterOpposedStep,
         nature_of_urgencies: Steps::ProviderMerits::NatureOfUrgenciesStep,
         matter_opposed_reasons: Steps::ProviderMerits::MatterOpposedReasonsStep,
         second_appeals: Steps::ProviderMerits::SecondAppealsStep,

--- a/app/services/flow/merits_loop.rb
+++ b/app/services/flow/merits_loop.rb
@@ -49,6 +49,7 @@ module Flow
         client_relationship_to_proceeding: :is_client_biological_parent,
         client_child_care_assessment: :child_care_assessments,
         court_order_copy: :court_order_copies,
+        matter_opposed: :is_matter_opposed,
       }[task]
     end
 

--- a/app/services/flow/steps/provider_merits/is_matter_opposed_step.rb
+++ b/app/services/flow/steps/provider_merits/is_matter_opposed_step.rb
@@ -1,0 +1,11 @@
+module Flow
+  module Steps
+    module ProviderMerits
+      IsMatterOpposedStep = Step.new(
+        path: ->(application) { Steps.urls.providers_legal_aid_application_is_matter_opposed_path(application) },
+        forward: ->(application) { Flow::MeritsLoop.forward_flow(application, :application) },
+        check_answers: :check_merits_answers,
+      )
+    end
+  end
+end

--- a/app/views/providers/application_merits_task/is_matter_opposed/show.html.erb
+++ b/app/views/providers/application_merits_task/is_matter_opposed/show.html.erb
@@ -4,7 +4,7 @@
       method: :patch,
     ) do |f| %>
   <%= page_template page_title: t(".page_heading"), template: :basic, form: f do %>
-    <%= f.govuk_collection_radio_buttons :is_matter_opposed,
+    <%= f.govuk_collection_radio_buttons :matter_opposed,
                                          yes_no_options,
                                          :value,
                                          :label,

--- a/app/views/providers/application_merits_task/is_matter_opposed/show.html.erb
+++ b/app/views/providers/application_merits_task/is_matter_opposed/show.html.erb
@@ -1,0 +1,15 @@
+<%= form_with(
+      model: @form,
+      url: providers_legal_aid_application_is_matter_opposed_path(@legal_aid_application),
+      method: :patch,
+    ) do |f| %>
+  <%= page_template page_title: t(".page_heading"), template: :basic, form: f do %>
+    <%= f.govuk_collection_radio_buttons :is_matter_opposed,
+                                         yes_no_options,
+                                         :value,
+                                         :label,
+                                         legend: { text: t(".page_heading"), size: "xl", tag: "h1" } %>
+
+    <%= next_action_buttons(show_draft: true, form: f) %>
+  <% end %>
+<% end %>

--- a/app/views/providers/check_merits_answers/show.html.erb
+++ b/app/views/providers/check_merits_answers/show.html.erb
@@ -34,6 +34,7 @@
           allegation: @legal_aid_application&.allegation,
           undertaking: @legal_aid_application&.undertaking,
           urgency: @legal_aid_application&.urgency,
+          matter_opposition: @legal_aid_application&.matter_opposition,
           read_only: false,
         ) %>
 

--- a/app/views/providers/merits_reports/show.html.erb
+++ b/app/views/providers/merits_reports/show.html.erb
@@ -83,6 +83,7 @@
         allegation: @legal_aid_application&.allegation,
         undertaking: @legal_aid_application&.undertaking,
         urgency: @legal_aid_application&.urgency,
+        matter_opposition: @legal_aid_application&.matter_opposition,
         read_only: true,
       ) %>
 <% end %>

--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -10,8 +10,6 @@
 
 <%= render("shared/check_answers/merits/children_involved", read_only:) if @legal_aid_application.involved_children.any? %>
 
-<%= render("shared/check_answers/merits/matter_opposition", read_only:) if @legal_aid_application.matter_opposition %>
-
 <%= render("shared/check_answers/merits/urgency", read_only:, urgency:) if @legal_aid_application.urgency %>
 
 <% if @legal_aid_application.legal_framework_merits_task_list.includes_task?(:application, :second_appeal) %>
@@ -19,6 +17,10 @@
 <% end %>
 
 <%= render("shared/check_answers/plf_court_order", read_only:) if [true, false].include?(@legal_aid_application.plf_court_order) %>
+
+<%= render("shared/check_answers/merits/matter_opposition", read_only:) if matter_opposition && matter_opposition.reason.present? %>
+
+<%= render("shared/check_answers/merits/is_matter_opposed", read_only:) if matter_opposition && [true, false].include?(matter_opposition.matter_opposed) %>
 
 <%= render("shared/check_answers/merits/allegation", allegation:, read_only:) if @legal_aid_application.allegation %>
 

--- a/app/views/shared/check_answers/merits/_is_matter_opposed.html.erb
+++ b/app/views/shared/check_answers/merits/_is_matter_opposed.html.erb
@@ -1,0 +1,14 @@
+<%= govuk_summary_card(title: t(".heading"), html_attributes: { id: "app-check-your-answers__is_matter_opposed" }, heading_level: 3) do |card|
+      unless read_only
+        card.with_action do
+          govuk_link_to(t("generic.change"),
+                        providers_legal_aid_application_is_matter_opposed_path(@legal_aid_application), visually_hidden_text: t(".heading"))
+        end
+      end
+      card.with_summary_list(actions: false) do |summary_list|
+        summary_list.with_row(html_attributes: { id: "app-check-your-answers__matter_is_opposed" }) do |row|
+          row.with_key(text: t(".description"), classes: "govuk-!-width-one-third")
+          row.with_value(text: yes_no(@legal_aid_application.matter_opposition.matter_opposed?))
+        end
+      end
+    end %>

--- a/app/views/shared/review_application/_questions_and_answers.html.erb
+++ b/app/views/shared/review_application/_questions_and_answers.html.erb
@@ -104,6 +104,7 @@
           allegation: @legal_aid_application&.allegation,
           undertaking: @legal_aid_application&.undertaking,
           urgency: @legal_aid_application&.urgency,
+          matter_opposition: @legal_aid_application&.matter_opposition,
           read_only: true,
         ) %>
   </section>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -236,6 +236,8 @@ en:
           attributes:
             reason:
               blank: Enter why the Section 8 matter is opposed
+            matter_opposed:
+              inclusion: Select yes if the matter is opposed by your client
         application_merits_task/undertaking:
           attributes:
             offered:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1487,6 +1487,7 @@ en:
           second_appeal: second_appeal
           client_child_care_assessment: child_care_assessment
           court_order_copy: court_order_copy
+          matter_opposed: is_matter_opposed
     merits_reports:
       show:
         heading: Merits report

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -575,6 +575,9 @@ en:
       in_scope_of_laspos:
         show:
           page_title: Are the Section 8 proceedings you're applying for in scope of the Legal Aid, Sentencing and Punishment of Offenders Act 2012 (LASPO)?
+      is_matter_opposed:
+        show:
+          page_heading: Is the matter opposed by your client?
       matter_opposed_reasons:
         show:
           page_heading: Why is the Section 8 matter opposed by your client or the other party?
@@ -1442,6 +1445,7 @@ en:
         laspo: Section 8 and LASPO
         second_appeal: The second appeal
         court_order_copy: The court order
+        matter_opposed: If the matter is opposed
         # Proceeding level tasks
         chances_of_success_html: <span class="govuk-visually-hidden">%{proceeding} </span>Chances of success
         children_proceeding_html: <span class="govuk-visually-hidden">%{proceeding} </span>Children involved in this proceeding

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -503,6 +503,9 @@ en:
         matter_opposition:
           matter_opposed_reason: Reasons why the matter is opposed
           matter_opposed_reason_heading: Why the matter is opposed
+        is_matter_opposed:
+          heading: If the matter is opposed
+          description: Matter is opposed?
         allegation:
           heading: Allegation
           denies_all: Client wholly or substantially denies any allegations?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -373,6 +373,7 @@ Rails.application.routes.draw do
         resource :first_appeal_court_type, only: %i[show update], path: "appeal_court_type"
         resource :second_appeal_court_type, only: %i[show update]
         resource :court_order_copy, only: %i[show update], path: "court_order"
+        resource :is_matter_opposed, only: %i[show update]
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -373,7 +373,7 @@ Rails.application.routes.draw do
         resource :first_appeal_court_type, only: %i[show update], path: "appeal_court_type"
         resource :second_appeal_court_type, only: %i[show update]
         resource :court_order_copy, only: %i[show update], path: "court_order"
-        resource :is_matter_opposed, only: %i[show update]
+        resource :is_matter_opposed, only: %i[show update], controller: "is_matter_opposed"
       end
     end
 

--- a/db/migrate/20250124104720_add_matter_opposed_to_matter_oppositions.rb
+++ b/db/migrate/20250124104720_add_matter_opposed_to_matter_oppositions.rb
@@ -1,0 +1,5 @@
+class AddMatterOpposedToMatterOppositions < ActiveRecord::Migration[7.2]
+  def change
+    add_column :matter_oppositions, :matter_opposed, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_21_090656) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_24_104720) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -737,6 +737,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_21_090656) do
     t.text "reason", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "matter_opposed"
     t.index ["legal_aid_application_id"], name: "index_matter_oppositions_on_legal_aid_application_id"
   end
 

--- a/spec/factories/legal_framework_merits_task_list.rb
+++ b/spec/factories/legal_framework_merits_task_list.rb
@@ -67,6 +67,10 @@ FactoryBot.define do
       serialized_data { build(:legal_framework_serializable_merits_task_list, :pbm16_defendant).to_yaml }
     end
 
+    trait :pbm40_as_applicant do
+      serialized_data { build(:legal_framework_serializable_merits_task_list, :pbm40_as_applicant).to_yaml }
+    end
+
     trait :broken_opponent do
       serialized_data { build(:legal_framework_serializable_merits_task_list, :broken_opponent).to_yaml }
     end

--- a/spec/factories/legal_framework_serialized_merits_task_list.rb
+++ b/spec/factories/legal_framework_serialized_merits_task_list.rb
@@ -519,6 +519,31 @@ FactoryBot.define do
       end
     end
 
+    trait :pbm40_as_applicant do
+      lfa_response do
+        {
+          request_id: SecureRandom.uuid,
+          application: {
+            tasks: {
+              opponent_name: [],
+              statement_of_case: [],
+              children_application: [],
+              matter_opposed: [],
+            },
+          },
+          proceedings: [
+            {
+              ccms_code: "PBM40",
+              tasks: {
+                children_proceeding: [:children_application],
+                chances_of_success: [],
+              },
+            },
+          ],
+        }
+      end
+    end
+
     trait :pbm16_defendant do
       lfa_response do
         {

--- a/spec/forms/providers/application_merits_task/matter_opposed_form_spec.rb
+++ b/spec/forms/providers/application_merits_task/matter_opposed_form_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe Providers::ApplicationMeritsTask::MatterOpposedForm do
+  let(:legal_aid_application) { create(:legal_aid_application) }
+  let(:params) { { model: build(:matter_opposition, legal_aid_application:), matter_opposed: } }
+
+  describe "#validate" do
+    subject(:form) { described_class.new(params) }
+
+    context "when matter_opposed is blank" do
+      let(:matter_opposed) { nil }
+
+      it "is invalid" do
+        expect(form).not_to be_valid
+        expect(form.errors).to be_added(:matter_opposed, :inclusion, value: nil)
+      end
+    end
+
+    context "when matter_opposed is not blank" do
+      let(:matter_opposed) { "true" }
+
+      it "is valid" do
+        expect(form).to be_valid
+      end
+    end
+  end
+
+  describe "#save" do
+    subject(:save_form) { described_class.new(params).save }
+
+    let(:matter_opposition) { legal_aid_application.matter_opposition }
+
+    before { save_form }
+
+    context "when the form is invalid" do
+      let(:matter_opposed) { nil }
+
+      it "does not create a matter opposition record" do
+        expect(matter_opposition).to be_nil
+      end
+    end
+
+    context "when the form is valid" do
+      let(:matter_opposed) { "true" }
+
+      it "creates a matter opposition record" do
+        expect(matter_opposition).to have_attributes(
+          legal_aid_application_id: legal_aid_application.id,
+          matter_opposed: true,
+        )
+      end
+    end
+  end
+end

--- a/spec/forms/providers/application_merits_task/matter_opposed_form_spec.rb
+++ b/spec/forms/providers/application_merits_task/matter_opposed_form_spec.rb
@@ -16,8 +16,16 @@ RSpec.describe Providers::ApplicationMeritsTask::MatterOpposedForm do
       end
     end
 
-    context "when matter_opposed is not blank" do
+    context "when matter_opposed is true" do
       let(:matter_opposed) { "true" }
+
+      it "is valid" do
+        expect(form).to be_valid
+      end
+    end
+
+    context "when matter_opposed is false" do
+      let(:matter_opposed) { "false" }
 
       it "is valid" do
         expect(form).to be_valid
@@ -40,13 +48,24 @@ RSpec.describe Providers::ApplicationMeritsTask::MatterOpposedForm do
       end
     end
 
-    context "when the form is valid" do
+    context "when the form is passed true" do
       let(:matter_opposed) { "true" }
 
       it "creates a matter opposition record" do
         expect(matter_opposition).to have_attributes(
           legal_aid_application_id: legal_aid_application.id,
           matter_opposed: true,
+        )
+      end
+    end
+
+    context "when the form is passed false" do
+      let(:matter_opposed) { "false" }
+
+      it "creates a matter opposition record" do
+        expect(matter_opposition).to have_attributes(
+          legal_aid_application_id: legal_aid_application.id,
+          matter_opposed: false,
         )
       end
     end

--- a/spec/requests/providers/application_merits_task/is_matter_opposed_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/is_matter_opposed_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Providers::ApplicationMeritsTask::IsMatterOpposedController do
 
     context "when the application has a matter opposition" do
       it "displays the reason" do
-        _matter_opposition = create(
+        create(
           :matter_opposition,
           legal_aid_application:,
           matter_opposed: true,

--- a/spec/requests/providers/application_merits_task/is_matter_opposed_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/is_matter_opposed_controller_spec.rb
@@ -1,0 +1,168 @@
+require "rails_helper"
+
+RSpec.describe Providers::ApplicationMeritsTask::IsMatterOpposedController do
+  let(:legal_aid_application) do
+    create(
+      :legal_aid_application,
+      :with_proceedings,
+      explicit_proceedings: %i[pbm40],
+    )
+  end
+
+  let(:provider) { legal_aid_application.provider }
+
+  describe "GET /providers/applications/:legal_aid_application_id/is_matter_opposed" do
+    subject(:request) do
+      get providers_legal_aid_application_is_matter_opposed_path(legal_aid_application)
+    end
+
+    it "returns ok" do
+      login_as provider
+
+      request
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    context "when the application has a matter opposition" do
+      it "displays the reason" do
+        _matter_opposition = create(
+          :matter_opposition,
+          legal_aid_application:,
+          matter_opposed: true,
+        )
+        login_as provider
+
+        request
+
+        expect(page).to have_field(
+          "application_merits_task_matter_opposition[matter_opposed]",
+          with: "true",
+        )
+      end
+    end
+
+    context "when the provider is not authenticated" do
+      before { request }
+
+      it_behaves_like "a provider not authenticated"
+    end
+
+    context "when the provider is not authorised" do
+      before do
+        login_as create(:provider)
+        request
+      end
+
+      it_behaves_like "an authenticated provider from a different firm"
+    end
+  end
+
+  describe "PATCH /providers/applications/:legal_aid_application_id/is_matter_opposed" do
+    subject(:request) do
+      patch providers_legal_aid_application_is_matter_opposed_path(legal_aid_application),
+            params: params.merge(button_clicked)
+    end
+
+    let(:merits_task_list) do
+      create(
+        :legal_framework_merits_task_list,
+        :pbm40_as_applicant,
+        legal_aid_application:,
+      )
+    end
+
+    let(:params) { { application_merits_task_matter_opposition: { matter_opposed: } } }
+    let(:matter_opposed) { true }
+    let(:button_clicked) { {} }
+    let(:draft_button) { { draft_button: "Save as draft" } }
+    let(:continue_button) { { continue_button: "Save and continue" } }
+
+    before do
+      allow(LegalFramework::MeritsTasksService)
+        .to receive(:call)
+        .with(legal_aid_application)
+        .and_return(merits_task_list)
+    end
+
+    context "when the provider continues" do
+      let(:button_clicked) { continue_button }
+
+      it "updates the matter_opposed, completes the task, and redirects to the next page" do
+        login_as provider
+
+        request
+
+        expect(legal_aid_application.matter_opposition.matter_opposed).to eq(matter_opposed)
+        expect(matter_opposed_task.state).to eq(:complete)
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    context "when the provider saves as draft" do
+      let(:button_clicked) { draft_button }
+
+      it "updates the matter_opposed, does not complete the task, and redirects to the applications page" do
+        login_as provider
+
+        request
+
+        expect(legal_aid_application.matter_opposition.matter_opposed).to eq(matter_opposed)
+        expect(matter_opposed_task.state).to eq(:not_started)
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
+    context "when the application has a matter_opposed" do
+      let(:matter_opposed) { false }
+
+      it "updates the reason" do
+        matter_opposition = create(
+          :matter_opposition,
+          legal_aid_application:,
+          reason: true,
+        )
+        login_as provider
+
+        request
+
+        expect(ApplicationMeritsTask::MatterOpposition.count).to eq(1)
+        expect(matter_opposition.reload.matter_opposed).to eq(matter_opposed)
+      end
+    end
+
+    context "when the form is invalid" do
+      let(:matter_opposed) { nil }
+
+      it "displays an error and does not update the reason or complete the task" do
+        login_as provider
+
+        request
+
+        expect(page).to have_error_message("Select yes if the matter is opposed by your client")
+        expect(legal_aid_application.matter_opposition).to be_nil
+        expect(matter_opposed_task.state).to eq(:not_started)
+      end
+    end
+
+    context "when the provider is not authenticated" do
+      before { request }
+
+      it_behaves_like "a provider not authenticated"
+    end
+
+    context "when the provider is not authorised" do
+      before do
+        login_as create(:provider)
+        request
+      end
+
+      it_behaves_like "an authenticated provider from a different firm"
+    end
+  end
+
+  def matter_opposed_task
+    application_tasks = merits_task_list.reload.task_list.tasks[:application]
+    application_tasks.detect { |task| task.name == :matter_opposed }
+  end
+end

--- a/spec/requests/providers/check_merits_answers_controller_spec.rb
+++ b/spec/requests/providers/check_merits_answers_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "sidekiq/testing"
 
-RSpec.describe "check merits answers requests" do
+RSpec.describe Providers::CheckMeritsAnswersController do
   include ActionView::Helpers::NumberHelper
 
   describe "GET /providers/applications/:id/check_merits_answers" do

--- a/spec/services/flow/steps/provider_merits/is_matter_opposed_step_spec.rb
+++ b/spec/services/flow/steps/provider_merits/is_matter_opposed_step_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::ProviderMerits::IsMatterOpposedStep, type: :request do
+  let(:legal_aid_application) { create(:legal_aid_application) }
+
+  describe "#path" do
+    subject { described_class.path.call(legal_aid_application) }
+
+    it { is_expected.to eq providers_legal_aid_application_is_matter_opposed_path(legal_aid_application) }
+  end
+
+  describe "#forward" do
+    subject { described_class.forward.call(legal_aid_application) }
+
+    before do
+      allow(Flow::MeritsLoop).to receive(:forward_flow).and_return(:merits_task_lists)
+    end
+
+    it { is_expected.to eq :merits_task_lists }
+  end
+
+  describe "#check_answers" do
+    subject { described_class.check_answers }
+
+    it { is_expected.to eq :check_merits_answers }
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5380)

Add the new, PLF, Is matter opposed? question

This chooses to extend the `MatterOpposition` object to store the optional values.  It now stores a text value for `request` and a boolean value for `matter_opposed`.  This required changes to the CYA (and associated)pages to check for the object _and_ value presence before rendering as the questions are exclusive to PLF and optional for other matter types.  

Happy to discuss if a different structure is preferred! 🙂 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
