### PR TITLE
AP-5621: Remove fixed width of means report print style

### DIFF
--- a/app/assets/stylesheets/print-styles.scss
+++ b/app/assets/stylesheets/print-styles.scss
@@ -61,7 +61,6 @@
     .govuk-summary-list__key,
     .govuk-summary-list__value {
       display: table-cell;
-      width: 100mm !important;
       padding-top: 2.65mm;
       padding-bottom: 2.65mm;
       text-align: left;


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5621)

The fixed width caused the lines and data to overflow when generating Means and Merits reports.  This is a minimal fix

There was conversation about reviewing the entire print CSS handling, but this ticket is just to address the overruns


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
