### PR TITLE
AP-5563: CCMS payload for new evidence categories

### DIFF
--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -248,7 +248,7 @@ class LegalAidApplication < ApplicationRecord
 
   def evidence_is_required?
     RequiredDocumentCategoryAnalyser.call(self)
-    required_document_categories.any?
+    (required_document_categories + optional_document_categories).any?
   end
 
   def cfe_result
@@ -763,7 +763,7 @@ private
   end
 
   def validate_document_categories
-    required_document_categories.each do |category|
+    (required_document_categories + optional_document_categories).each do |category|
       errors.add(:required_document_categories, "must be valid document categories") unless DocumentCategory.displayable_document_category_names.include?(category)
     end
   end

--- a/app/services/required_document_category_analyser.rb
+++ b/app/services/required_document_category_analyser.rb
@@ -14,23 +14,28 @@ class RequiredDocumentCategoryAnalyser
     required_document_categories << "client_employment_evidence" if @application.employment_evidence_required?
     required_document_categories << "part_employ_evidence" if @application&.partner&.employment_evidence_required?
     required_document_categories << "court_application_or_order" if has_opponents_application? && !has_listed_final_hearing?
+
     if has_listed_final_hearing? && !has_opponents_application?
       required_document_categories << "court_order"
       required_document_categories << "expert_report"
     end
+
     if has_listed_final_hearing? && has_opponents_application?
       required_document_categories << "court_order"
       required_document_categories << "court_application"
       required_document_categories << "expert_report"
     end
+
     required_document_categories << "parental_responsibility" if has_parental_responsibility?
     required_document_categories << "local_authority_assessment" if local_authority_assessed?
     required_document_categories << "court_order" if @application.plf_court_order?
+
     if @application.public_law_family_proceedings?
       required_document_categories << "grounds_of_appeal"
       required_document_categories << "counsel_opinion"
       required_document_categories << "judgement"
     end
+
     @application.update!(required_document_categories:)
   end
 

--- a/app/services/required_document_category_analyser.rb
+++ b/app/services/required_document_category_analyser.rb
@@ -14,6 +14,8 @@ class RequiredDocumentCategoryAnalyser
     required_document_categories << "client_employment_evidence" if @application.employment_evidence_required?
     required_document_categories << "part_employ_evidence" if @application&.partner&.employment_evidence_required?
     required_document_categories << "court_application_or_order" if has_opponents_application? && !has_listed_final_hearing?
+    required_document_categories << "court_order" if @application.plf_court_order?
+    required_document_categories << "local_authority_assessment" if has_local_authority_assessment?
 
     if has_listed_final_hearing? && !has_opponents_application?
       required_document_categories << "court_order"
@@ -57,7 +59,7 @@ private
     @application.proceedings.any? { |proceeding| proceeding.relationship_to_child.in?(%w[court_order parental_responsibility_agreement]) }
   end
 
-  def local_authority_assessed?
+  def has_local_authority_assessment?
     @application.proceedings.any? { |proceeding| proceeding.child_care_assessment&.assessed? }
   end
 end

--- a/app/services/uploaded_evidence/base.rb
+++ b/app/services/uploaded_evidence/base.rb
@@ -28,7 +28,7 @@ module UploadedEvidence
     end
 
     def attachment_type_options
-      @attachment_type_options = required_documents.map { |rd| [rd, attachment_type_name(rd)] }
+      @attachment_type_options = required_and_optional_documents.map { |rd| [rd, attachment_type_name(rd)] }
       @attachment_type_options << %w[uncategorised Uncategorised]
       @attachment_type_options
     end
@@ -58,7 +58,15 @@ module UploadedEvidence
     end
 
     def required_documents
-      @required_documents = legal_aid_application.required_document_categories
+      @required_documents ||= legal_aid_application.required_document_categories
+    end
+
+    def optional_documents
+      @optional_documents ||= legal_aid_application.optional_document_categories
+    end
+
+    def required_and_optional_documents
+      @required_and_optional_documents ||= required_documents + optional_documents
     end
 
     def submission_form

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -980,7 +980,7 @@ en:
               court_application_missing: Upload the application to court for Section 8 proceedings
               court_order_missing: Upload the court order %{matter_type}
               parental_responsibility_missing: Upload the evidence of your client's parental responsibility
-              local_authority_assessment_missing: Upload the local authority assessment
+              local_authority_assessment_missing: Upload the evidence of the local authority's assessment
               file_empty: The selected file is empty
               file_too_big: The selected file must be smaller than %{size}MB
               file_virus: "%{file_name} contains a virus"

--- a/db/migrate/20250131101012_add_optional_document_categories_to_legal_aid_application.rb
+++ b/db/migrate/20250131101012_add_optional_document_categories_to_legal_aid_application.rb
@@ -1,0 +1,5 @@
+class AddOptionalDocumentCategoriesToLegalAidApplication < ActiveRecord::Migration[7.2]
+  def change
+    add_column :legal_aid_applications, :optional_document_categories, :string, array: true, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+<<<<<<< HEAD
 ActiveRecord::Schema[7.2].define(version: 2025_01_24_104720) do
+=======
+ActiveRecord::Schema[7.2].define(version: 2025_01_31_101012) do
+>>>>>>> bb0dea653 (AP-4415: Add optional document categories to legal_aid_applications)
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -668,6 +672,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_24_104720) do
     t.boolean "case_cloned"
     t.boolean "separate_representation_required"
     t.boolean "plf_court_order"
+    t.string "optional_document_categories", default: [], null: false, array: true
     t.index ["applicant_id"], name: "index_legal_aid_applications_on_applicant_id"
     t.index ["application_ref"], name: "index_legal_aid_applications_on_application_ref", unique: true
     t.index ["discarded_at"], name: "index_legal_aid_applications_on_discarded_at"

--- a/features/providers/public_law_family/merits_child_care_assessment_question_flow.feature
+++ b/features/providers/public_law_family/merits_child_care_assessment_question_flow.feature
@@ -118,7 +118,7 @@ Feature: Public law family merits appeal question flow
 
     # Test the error
     When I click 'Save and continue'
-    Then I should see govuk error summary "Upload the local authority assessment"
+    Then I should see govuk error summary "Upload the evidence of the local authority's assessment"
 
     When I upload an evidence file named 'hello_world.pdf'
     Then I should see 'hello_world.pdf'

--- a/spec/services/required_document_category_analyser_spec.rb
+++ b/spec/services/required_document_category_analyser_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe RequiredDocumentCategoryAnalyser do
           create(:proceeding, :pbm32, legal_aid_application: application)
         end
 
-        it "updates optional_document_categories to have several evidence types" do
+        it "updates required_document_categories to have several optional evidence types" do
           expect { call }.to change(application, :required_document_categories)
             .from([])
             .to(%w[grounds_of_appeal counsel_opinion judgement])


### PR DESCRIPTION
## What
Refactor and extend tests of payload changes for new evidence document categories.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5563)

The document id and upload xml generators already map any document
category based on there CCMS document type and description so we
only need to add some automated tests and UAT against CCMS on a 
non-production environment.


## Manual testing

The new document type for a local authority assessment  and a court order was successfully injected into CCMS

![image (3)](https://github.com/user-attachments/assets/51945f87-ae9f-4deb-83d0-d9f58cd9bc18)


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
