### PR TITLE
AP-5525: Add delegated function hint

### DIFF
--- a/app/views/providers/proceeding_loop/delegated_functions/show.html.erb
+++ b/app/views/providers/proceeding_loop/delegated_functions/show.html.erb
@@ -8,7 +8,8 @@
     <span class="govuk-caption-xl"><%= position_in_array(@proceeding) %></span>
     <h1 class="govuk-heading-xl"><%= page_title %></h1>
     <%= form.govuk_radio_buttons_fieldset(:used_delegated_functions,
-                                          legend: { size: "m", tag: "h2", text: t(".question") }) do %>
+                                          legend: { size: "m", tag: "h2", text: t(".question") },
+                                          hint: { text: @proceeding.special_childrens_act? ? t(".sca_hint") : "" }) do %>
       <%= form.govuk_radio_button :used_delegated_functions, true, label: { text: t("generic.yes") } do %>
          <%= form.govuk_date_field :used_delegated_functions_on,
                                    legend: { text: t("shared.forms.date_input_fields.used_delegated_functions_on_label"), class: "govuk-label govuk-date-input__label" },

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1996,6 +1996,7 @@ en:
       delegated_functions:
         show:
           question: Have you used delegated functions for this proceeding?
+          sca_hint: Answer this, even for special children act
       final_hearings:
         show:
           question: Has the proceeding been listed for a final contested hearing?

--- a/spec/requests/providers/proceeding_loop/delegated_functions_controller_spec.rb
+++ b/spec/requests/providers/proceeding_loop/delegated_functions_controller_spec.rb
@@ -27,10 +27,27 @@ RSpec.describe "DelegatedFunctionsController" do
         expect(response).to have_http_status(:ok)
       end
 
-      it "displays the proceeding header" do
-        expect(response.body).to include("Proceeding 1")
-        expect(response.body).to include("Inherent jurisdiction high court injunction")
-        expect(response.body).to include("Have you used delegated functions for this proceeding?")
+      context "with a non-Special children act (non-SCA) proceeding" do
+        it "displays expected header, question and [not] hint" do
+          expect(response.body)
+            .to include("Proceeding 1")
+            .and include("Inherent jurisdiction high court injunction")
+            .and include("Have you used delegated functions for this proceeding?")
+
+          expect(response.body).not_to include("Answer this, even for special children act")
+        end
+      end
+
+      context "with an Special children act (SCA) proceeding" do
+        let(:application) { create(:legal_aid_application, :with_proceedings, explicit_proceedings: %i[pb003], set_lead_proceeding: :pb003) }
+
+        it "displays expected header, question and SCA hint" do
+          expect(response.body)
+            .to include("Proceeding 1")
+            .and include("Child assessment order")
+            .and include("Have you used delegated functions for this proceeding?")
+            .and include("Answer this, even for special children act")
+        end
       end
     end
   end


### PR DESCRIPTION
## What
Add hint text to delegated functions question

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5525)

Inline with designs and business logic (see ticket) the hint should be shown only on SCA proceeding delegated function pages.

## After
![Screenshot 2025-01-31 at 14 28 13](https://github.com/user-attachments/assets/dedacb24-78ff-4ea5-b1d5-f322eaf436db)


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
