### PR TITLE
AP-5639: Add routing to ECCT for PLF Second Appeal cases

### DIFF
--- a/app/models/application_digest.rb
+++ b/app/models/application_digest.rb
@@ -20,6 +20,7 @@ class ApplicationDigest < ApplicationRecord
     child_subject
     parental_responsibility_evidence
     autogranted
+    ecct_routed
   ].freeze
 
   class << self
@@ -76,6 +77,7 @@ class ApplicationDigest < ApplicationRecord
         child_subject: laa.child_subject_relationship?,
         parental_responsibility_evidence: laa.parental_responsibility_evidence?,
         autogranted: laa.auto_grant_special_children_act?,
+        ecct_routed: laa.ecct_routing?,
       }
     end
 

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -246,6 +246,10 @@ class LegalAidApplication < ApplicationRecord
     ].none?
   end
 
+  def ecct_routing?
+    appeal.present? && appeal.second_appeal?
+  end
+
   def evidence_is_required?
     DocumentCategoryAnalyser.call(self)
     allowed_document_categories.any?

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -495,5 +495,9 @@ module CCMS
     def chances_of_success
       legal_aid_application.lead_proceeding.chances_of_success
     end
+
+    def second_appeal?(_options)
+      legal_aid_application&.appeal&.second_appeal? || false
+    end
   end
 end

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -499,5 +499,21 @@ module CCMS
     def second_appeal?(_options)
       legal_aid_application&.appeal&.second_appeal? || false
     end
+
+    def case_owner_std_family_merits(_options)
+      legal_aid_application&.appeal&.second_appeal? ? false : true
+    end
+
+    def means_routing(_options)
+      legal_aid_application.passported? ? "CAM" : "MANB"
+    end
+
+    def merits_routing(_options)
+      legal_aid_application&.appeal&.second_appeal? ? "ECF" : "SFM"
+    end
+
+    def merits_routing_name(_options)
+      legal_aid_application&.appeal&.second_appeal? ? "ECF Team" : "Standard Family Merits"
+    end
   end
 end

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -492,6 +492,10 @@ module CCMS
       ManualReviewDeterminer.new(legal_aid_application).manual_review_required?
     end
 
+    def output_chances_of_success?(_options)
+      chances_of_success.present?
+    end
+
     def chances_of_success
       legal_aid_application.lead_proceeding.chances_of_success
     end

--- a/app/services/ccms/requestors/case_add_requestor.rb
+++ b/app/services/ccms/requestors/case_add_requestor.rb
@@ -107,7 +107,7 @@ module CCMS
         xml.__send__(:"casebio:MeansAssesments") { generate_means_assessment(xml) }
         xml.__send__(:"casebio:MeritsAssesments") { generate_merits_assessment(xml) }
         xml.__send__(:"casebio:DevolvedPowersDate", @legal_aid_application.used_delegated_functions_on.to_fs(:ccms_date)) if @legal_aid_application.non_sca_used_delegated_functions?
-        xml.__send__(:"casebio:ApplicationAmendmentType", @legal_aid_application.non_sca_used_delegated_functions? ? "SUBDP" : "SUB")
+        xml.__send__(:"casebio:ApplicationAmendmentType", generate_application_amendment_type)
         xml.__send__(:"casebio:LARDetails") { generate_lar_details(xml) }
       end
 
@@ -151,6 +151,18 @@ module CCMS
 
       def generate_lar_details(xml)
         xml.__send__(:"casebio:LARScopeFlag", true)
+      end
+
+      def generate_application_amendment_type
+        if @legal_aid_application.non_sca_used_delegated_functions?
+          "SUBDP"
+        elsif @legal_aid_application.ecct_routing?
+          # the team is currently named ECCT (Exceptional and Complex Cases Team), but were
+          # previously named ECF (Exceptional Case Funding) and that is what CCMS expects
+          "ECF"
+        else
+          "SUB"
+        end
       end
 
       def generate_client(xml)

--- a/app/services/reports/mis/application_detail_csv_line.rb
+++ b/app/services/reports/mis/application_detail_csv_line.rb
@@ -39,6 +39,7 @@ module Reports
                :used_delegated_functions_reported_on,
                :lowest_prospect_of_success,
                :hmrc_responses,
+               :ecct_routing?,
                :vehicles, to: :laa
 
       delegate :case_ccms_reference, to: :ccms_submission
@@ -177,6 +178,7 @@ module Reports
           "Child subject relationship?",
           "Parental responsibility evidence?",
           "Autogranted?",
+          "ECCT routed?",
         ]
       end
 
@@ -216,6 +218,7 @@ module Reports
         child_subject_client_involvement_type
         sca
         autogranted
+        ecct_routed
         sanitise
       end
 
@@ -479,6 +482,10 @@ module Reports
           @line << nil
           @line << nil
         end
+      end
+
+      def ecct_routed
+        @line << yesno(laa.ecct_routing?)
       end
 
       def autogranted

--- a/config/ccms/attribute_block_configs/base.yml
+++ b/config/ccms/attribute_block_configs/base.yml
@@ -3559,7 +3559,7 @@ global_merits:
     response_type: boolean
     user_defined: false
   ECF_FLAG:
-    value: false
+    value: '#second_appeal?'
     br100_meaning: ECF Flag
     response_type: boolean
     user_defined: true

--- a/config/ccms/attribute_block_configs/base.yml
+++ b/config/ccms/attribute_block_configs/base.yml
@@ -1669,8 +1669,8 @@ global_means:
     response_type: boolean
     user_defined: true
   MEANS_ROUTING:
-    generate_block?: false
-    value: MANB
+    generate_block?: '#application_ecct_routing?'
+    value: '#means_routing'
     br100_meaning: means routing
     response_type: text
     user_defined: false
@@ -3014,7 +3014,7 @@ global_merits:
     response_type: boolean
     user_defined: false
   MERITS_ROUTING:
-    value: SFM
+    value: "#merits_routing"
     br100_meaning: merits routing owner
     response_type: text
     user_defined: false
@@ -3266,8 +3266,8 @@ global_merits:
     response_type: number
     user_defined: false
   MERITS_ROUTING_NAME:
-    generate_block?: false
-    value: Standard Family Merits
+    generate_block?: '#application_ecct_routing?'
+    value: "#merits_routing_name"
     br100_meaning: merits routing name
     response_type: text
     user_defined: false
@@ -3678,7 +3678,7 @@ global_merits:
     response_type: boolean
     user_defined: false
   CASE_OWNER_STD_FAMILY_MERITS:
-    value: true
+    value: "#case_owner_std_family_merits"
     br100_meaning: The Case Owner Is The Standard Family Merits Team
     response_type: boolean
     user_defined: false

--- a/config/ccms/attribute_block_configs/base.yml
+++ b/config/ccms/attribute_block_configs/base.yml
@@ -4868,6 +4868,7 @@ proceeding_merits:
     response_type: text
     user_defined: false
   FAMILY_PROSPECTS_OF_SUCCESS:
+    generate_block?: "#output_chances_of_success?"
     value: "#ccms_equivalent_prospects_of_success"
     br100_meaning: 'Fam: The Family Prospects Of Success For The Proceeding'
     response_type: text

--- a/config/ccms/attribute_block_configs/non_passported.yml
+++ b/config/ccms/attribute_block_configs/non_passported.yml
@@ -843,7 +843,7 @@ global_means:
     user_defined: false
     br100_meaning: "The proceeding's prospect of success"
     response_type: text
-    generate_block?: true
+    generate_block?: "#output_chances_of_success?"
     value: '#ccms_code_prospects_of_success'
   OUT_GB_INFER_C_29WP3_18A:
     generate_block?: false
@@ -1897,19 +1897,19 @@ proceeding_merits:
     response_type: currency
     generate_block?: true
   FAM_PROSP_50_OR_BETTER:
-    generate_block?: true
+    generate_block?: "#output_chances_of_success?"
     value: '#chances_of_success_success_prospect_likely?'
   FAM_PROSP_BORDER_UNCERT_POOR:
-    generate_block?: true
+    generate_block?: "#output_chances_of_success?"
     value: '#chances_of_success_success_prospect_borderline?'
   FAM_PROSP_MARGINAL:
-    generate_block?: true
+    generate_block?: "#output_chances_of_success?"
     value: '#chances_of_success_success_prospect_marginal?'
   FAM_PROSP_POOR:
-    generate_block?: true
+    generate_block?: "#output_chances_of_success?"
     value: '#chances_of_success_success_prospect_poor?'
   FAM_PROSP_UNCERTAIN:
-    generate_block?: true
+    generate_block?: "#output_chances_of_success?"
     value: '#chances_of_success_success_prospect_not_known?'
   FAM_PROSP_BORDERLINE_UNCERT:
     generate_block?: true

--- a/config/ccms/attribute_block_configs/non_passported.yml
+++ b/config/ccms/attribute_block_configs/non_passported.yml
@@ -540,7 +540,7 @@ global_means:
     response_type: text
     generate_block?: true
   MEANS_ROUTING:
-    value: BCM
+    value: '#means_routing'
     br100_meaning: means routing
     user_defined: false
     response_type: text

--- a/db/migrate/20250217105318_add_ecct_routed_to_application_digest.rb
+++ b/db/migrate/20250217105318_add_ecct_routed_to_application_digest.rb
@@ -1,0 +1,5 @@
+class AddEcctRoutedToApplicationDigest < ActiveRecord::Migration[7.2]
+  def change
+    add_column :application_digests, :ecct_routed, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_17_105318) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -199,6 +199,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.boolean "child_subject"
     t.boolean "parental_responsibility_evidence"
     t.boolean "autogranted"
+    t.boolean "ecct_routed"
     t.index ["legal_aid_application_id"], name: "index_application_digests_on_legal_aid_application_id", unique: true
   end
 

--- a/spec/factories/proceedings.rb
+++ b/spec/factories/proceedings.rb
@@ -418,6 +418,10 @@ FactoryBot.define do
     ccms_matter_code { "KPBLB" }
     client_involvement_type_ccms_code { "A" }
     client_involvement_type_description { "Applicant/Claimant/Petitioner" }
+    after(:create) do |proceeding, evaluator|
+      create(:scope_limitation, :emergency, proceeding:) unless evaluator.no_scope_limitations
+      create(:scope_limitation, :substantive, proceeding:) unless evaluator.no_scope_limitations
+    end
   end
 
   trait :pbm32 do

--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -2344,6 +2344,36 @@ RSpec.describe LegalAidApplication do
     end
   end
 
+  describe "ecct_routing?" do
+    subject { legal_aid_application.ecct_routing? }
+
+    context "when there is no appeal" do
+      it { is_expected.to be false }
+    end
+
+    context "when there is an appeal" do
+      let(:legal_aid_application) do
+        create(:legal_aid_application,
+               :with_second_appeal,
+               second_appeal:,
+               original_judge_level: nil,
+               court_type:)
+      end
+      let(:second_appeal) { false }
+      let(:court_type) { "court_of_appeal" }
+
+      context "and second_appeal is false" do
+        it { is_expected.to be false }
+      end
+
+      context "and second_appeal is true" do
+        let(:second_appeal) { true }
+
+        it { is_expected.to be true }
+      end
+    end
+  end
+
 private
 
   def find_attachment(evidence_collection, filename)

--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -420,6 +420,51 @@ module CCMS
             expect(block).to be_present
           end
         end
+
+        describe "when the application has a PLF Appeal proceeding" do
+          let(:legal_aid_application) do
+            create(:legal_aid_application,
+                   :with_everything,
+                   :with_positive_benefit_check_result,
+                   :with_second_appeal,
+                   :with_proceedings,
+                   explicit_proceedings: %i[pbm01a],
+                   set_lead_proceeding: :pbm01a,
+                   applicant:,
+                   vehicles:,
+                   other_assets_declaration:,
+                   savings_amount:,
+                   provider:,
+                   opponents:,
+                   domestic_abuse_summary:,
+                   office:,
+                   second_appeal:,
+                   original_judge_level: nil,
+                   court_type:)
+          end
+
+          let(:proceeding) { legal_aid_application.proceedings.detect { |p| p.ccms_code == "PBM01A" } }
+
+          context "and the provider answered no to the Second Appeal merits question" do
+            let(:second_appeal) { false }
+            let(:court_type) { "court_of_appeal" }
+
+            it "sets the ECF_FLAG value to false" do
+              block = XmlExtractor.call(request_xml, :global_merits, "ECF_FLAG")
+              expect(block).to have_boolean_response false
+            end
+          end
+
+          context "and the provider answered yes to the Second Appeal merits question" do
+            let(:second_appeal) { true }
+            let(:court_type) { "court_of_appeal" }
+
+            it "sets the ECF_FLAG value to true" do
+              block = XmlExtractor.call(request_xml, :global_merits, "ECF_FLAG")
+              expect(block).to have_boolean_response true
+            end
+          end
+        end
       end
     end
   end

--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -453,6 +453,31 @@ module CCMS
               block = XmlExtractor.call(request_xml, :global_merits, "ECF_FLAG")
               expect(block).to have_boolean_response false
             end
+
+            it "sets MERITS_ROUTING" do
+              block = XmlExtractor.call(request_xml, :global_merits, "MERITS_ROUTING")
+              expect(block).to have_text_response "SFM"
+            end
+
+            it "excludes the MERITS_ROUTING_NAME block" do
+              block = XmlExtractor.call(request_xml, :global_merits, "MERITS_ROUTING_NAME")
+              expect(block).not_to be_present
+            end
+
+            it "sets CASE_OWNER_STD_FAMILY_MERITS to true" do
+              block = XmlExtractor.call(request_xml, :global_merits, "CASE_OWNER_STD_FAMILY_MERITS")
+              expect(block).to have_boolean_response true
+            end
+
+            it "sets ApplicationAmendmentType to SUB" do
+              block = XmlExtractor.call(request_xml, :application_amendment_type)
+              expect(block.children.text).to eq "SUB"
+            end
+
+            it "excludes the MEANS_ROUTING block" do
+              block = XmlExtractor.call(request_xml, :global_means, "MEANS_ROUTING")
+              expect(block).not_to be_present
+            end
           end
 
           context "and the provider answered yes to the Second Appeal merits question" do
@@ -462,6 +487,33 @@ module CCMS
             it "sets the ECF_FLAG value to true" do
               block = XmlExtractor.call(request_xml, :global_merits, "ECF_FLAG")
               expect(block).to have_boolean_response true
+            end
+
+            it "sets MERITS_ROUTING" do
+              block = XmlExtractor.call(request_xml, :global_merits, "MERITS_ROUTING")
+              expect(block).to have_text_response "ECF"
+            end
+
+            it "sets MERITS_ROUTING_NAME" do
+              block = XmlExtractor.call(request_xml, :global_merits, "MERITS_ROUTING_NAME")
+              expect(block).to have_text_response "ECF Team"
+            end
+
+            it "sets CASE_OWNER_STD_FAMILY_MERITS to false" do
+              block = XmlExtractor.call(request_xml, :global_merits, "CASE_OWNER_STD_FAMILY_MERITS")
+              expect(block).to have_boolean_response false
+            end
+
+            it "sets ApplicationAmendmentType to ECF" do
+              block = XmlExtractor.call(request_xml, :application_amendment_type)
+              expect(block.children.text).to eq "ECF"
+            end
+
+            context "when the application is passported" do
+              it "sets MEANS_ROUTING to CAM" do
+                block = XmlExtractor.call(request_xml, :global_means, "MEANS_ROUTING")
+                expect(block).to have_text_response "CAM"
+              end
             end
           end
         end

--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -516,6 +516,29 @@ module CCMS
               end
             end
           end
+
+          context "and the client is a respondent" do
+            let(:second_appeal) { false }
+            let(:court_type) { "court_of_appeal" }
+
+            before do
+              proceeding.chances_of_success.destroy!
+              proceeding.update!(client_involvement_type_ccms_code: "D",
+                                 client_involvement_type_description: "Defendant or respondent")
+            end
+
+            it "excludes the FAMILY_PROSPECTS_OF_SUCCESS block" do
+              # this merits question is not asked in PLF proceedings where the client is not an Applicant or Joined Party
+              block = XmlExtractor.call(request_xml, :proceeding_merits, "FAMILY_PROSPECTS_OF_SUCCESS")
+              expect(block).not_to be_present
+            end
+
+            it "excludes the PROSPECTS_OF_SUCCESS block" do
+              # this merits question is not asked in PLF proceedings where the client is not an Applicant or Joined Party
+              block = XmlExtractor.call(request_xml, :proceeding_merits, "PROSPECTS_OF_SUCCESS")
+              expect(block).not_to be_present
+            end
+          end
         end
       end
     end

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_additional_property_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_additional_property_attributes_spec.rb
@@ -85,7 +85,7 @@ module CCMS
             ["global_means", "GB_INPUT_B_13WP3_49A", "text", true, "None of the above"],
             ["global_means", "MARITIAL_STATUS", "text", true, "U"],
             ["global_means", "MEANS_OPA_RELEASE", "text", false, "12.2"],
-            ["global_means", "MEANS_ROUTING", "text", false, "BCM"],
+            ["global_means", "MEANS_ROUTING", "text", false, "MANB"],
             ["global_means", "POA_OR_BILL_FLAG", "text", true, "N/A"],
             ["global_means", "RB_VERSION_DATE_MEANS", "date", false, "29-11-2019"],
             ["global_means", "RB_VERSION_NUMBER_MEANS", "text", false, "v2.31.6"],

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_attributes_spec.rb
@@ -577,6 +577,13 @@ module CCMS
           end
         end
 
+        describe "MEANS_ROUTING" do
+          it "is set to MANB" do
+            block = XmlExtractor.call(xml, :global_means, "MEANS_ROUTING")
+            expect(block).to have_text_response "MANB"
+          end
+        end
+
         def will_attributes
           %w[
             WILL_INPUT_B_2WP2_10A


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5639)

This PR updates the CCMS payload to set routing details for passported and non-passported PLF applications that have the second_appeal present and set to true

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
