### PR TITLE
AP-5725: Update state change for linked cases

### DIFF
--- a/app/controllers/providers/address_selections_base_controller.rb
+++ b/app/controllers/providers/address_selections_base_controller.rb
@@ -5,8 +5,6 @@ module Providers
     def show
       return redirect_to back_path unless address.postcode
 
-      legal_aid_application.enter_applicant_details! unless no_state_change_required?
-
       @addresses = address_lookup.result
       titleize_addresses
       filter_addresses(building_number_name) if building_number_name
@@ -27,10 +25,6 @@ module Providers
     end
 
   private
-
-    def no_state_change_required?
-      legal_aid_application.entering_applicant_details? || legal_aid_application.checking_applicant_details?
-    end
 
     def address_lookup
       @address_lookup ||= AddressLookupService.call(address.postcode)

--- a/app/controllers/providers/correspondence_address/choices_controller.rb
+++ b/app/controllers/providers/correspondence_address/choices_controller.rb
@@ -5,6 +5,7 @@ module Providers
 
       def show
         @form = Addresses::ChoiceForm.new(model: applicant)
+        legal_aid_application.enter_applicant_details! unless no_state_change_required?
       end
 
       def update
@@ -14,6 +15,10 @@ module Providers
       end
 
     private
+
+      def no_state_change_required?
+        legal_aid_application.entering_applicant_details? || legal_aid_application.checking_applicant_details?
+      end
 
       def applicant
         legal_aid_application.applicant

--- a/spec/requests/providers/correspondence_address/choices_controller_spec.rb
+++ b/spec/requests/providers/correspondence_address/choices_controller_spec.rb
@@ -25,6 +25,24 @@ RSpec.describe Providers::CorrespondenceAddress::ChoicesController do
         expect(unescaped_response_body).to include("Where should we send your client's correspondence?")
       end
     end
+
+    context "when the state is initiated" do
+      let(:legal_aid_application) { create(:legal_aid_application, :with_applicant, :initiated) }
+
+      it "fires the enter_applicant_details event and changes the state to entering_applicant_details" do
+        login_as provider
+        expect { get_request }.to change { legal_aid_application.reload.state }.from("initiated").to("entering_applicant_details")
+      end
+    end
+
+    context "when the state is entering_applicant_details" do
+      let(:legal_aid_application) { create(:legal_aid_application, :with_applicant, :entering_applicant_details) }
+
+      it "skips the enter_applicant_details event" do
+        login_as provider
+        expect { get_request }.not_to change { legal_aid_application.reload.state }
+      end
+    end
   end
 
   describe "PATCH/providers/applications/:legal_aid_application_id/where_to_send_correspondence" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5725)

The method of changing the state from initiated to entering_applicant_details was only being called on certain address and the limitation controllers.  When a provider chose a business address and linked a case, it bypassed all of the state change mechanisms.

This PR moves the address state change to the first address page which should not be bypassed in any of our current flows

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
