### PR TITLE
AP-5697: Remove SCA firm level permission

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -24,10 +24,6 @@ class Provider < ApplicationRecord
     ProviderDetailsCreator.call(self)
   end
 
-  def sca_permissions?
-    user_permissions.map(&:role).include?("special_children_act")
-  end
-
   def user_permissions
     permissions.empty? ? firm_permissions : permissions
   end

--- a/app/services/legal_framework/proceeding_types/all.rb
+++ b/app/services/legal_framework/proceeding_types/all.rb
@@ -38,9 +38,9 @@ module LegalFramework
 
       def call
         result = JSON.parse(request.body).map { |pt_hash| ProceedingTypeStruct.new(pt_hash) }
-        # TODO: remove the below when the SCA feature flag is removed
-        # filter out SCA applications
-        result.select!(&:not_sca?) unless Setting.special_childrens_act? && @legal_aid_application.provider.sca_permissions?
+        # TODO: remove below when the SCA feature flag is removed
+        # Filter out SCA applications
+        result.select!(&:not_sca?) unless Setting.special_childrens_act?
 
         # TODO: remove the below when the PLF feature flag is removed
         # Filter out PLF applications

--- a/app/views/providers/has_national_insurance_numbers/show.html.erb
+++ b/app/views/providers/has_national_insurance_numbers/show.html.erb
@@ -9,7 +9,7 @@
 
     <%= form.govuk_radio_buttons_fieldset(:has_national_insurance_number,
                                           legend: { text: page_title, size: "xl", tag: "h1" },
-                                          hint: { text: Setting.special_childrens_act? && @legal_aid_application.provider.sca_permissions? ? nil : t(".hint") }) do %>
+                                          hint: { text: Setting.special_childrens_act? ? nil : t(".hint") }) do %>
 
       <%= form.govuk_radio_button(
             :has_national_insurance_number,

--- a/db/seeds/permissions.rb
+++ b/db/seeds/permissions.rb
@@ -1,7 +1,6 @@
 class PermissionsPopulator
   ROLES = {
     # "example.permission.group" => "Description of example group",
-    "special_children_act" => "Allow the firm to access SCA proceedings",
   }.freeze
 
   def self.run

--- a/features/providers/special_children_act/secure_accomodation_order_cit.feature
+++ b/features/providers/special_children_act/secure_accomodation_order_cit.feature
@@ -3,7 +3,6 @@ Feature: Adding an SCA Secure Accommodation Order proceeding sets all client_inv
   Scenario: When a provider is adding proceedings and only adds a Secure Accommodation Order
     Given I start the journey as far as the applicant page
     And the feature flag for special_childrens_act is enabled
-    And the provider has SCA permissions
 
     When I enter name 'Test', 'User'
     Then I choose 'No'

--- a/features/step_definitions/debug_steps.rb
+++ b/features/step_definitions/debug_steps.rb
@@ -17,12 +17,6 @@ When(/^the feature flag for (.*?) is (enabled|disabled)$/) do |flag, enabled|
   Setting.setting.update!("#{flag}": value)
 end
 
-And(/^the provider has SCA permissions$/) do
-  # TODO: Remove when removing Setting.special_children_act
-  sca_permission = Permission.find_by(role: "special_children_act") || create(:permission, :special_children_act)
-  @registered_provider.firm.permissions << sca_permission
-end
-
 When(/^I sleep for (.*?) seconds$/) do |num_secs|
   sleep num_secs.to_i
 end

--- a/spec/factories/firms.rb
+++ b/spec/factories/firms.rb
@@ -4,15 +4,14 @@ FactoryBot.define do
     name { Faker::Company.name }
   end
 
-  trait :with_sca_permissions do
-    permissions do
-      sca = Permission.find_by(role: "special_children_act")
-      sca = create(:permission, :special_children_act) if sca.nil?
-      [sca]
-    end
-  end
-
   trait :with_no_permissions do
     permissions { [] }
+  end
+
+  trait :with_dummy_permission do
+    permissions do
+      dummy_permission = create(:permission, :dummy_permission)
+      [dummy_permission]
+    end
   end
 end

--- a/spec/factories/permissions.rb
+++ b/spec/factories/permissions.rb
@@ -3,9 +3,9 @@ FactoryBot.define do
     sequence(:role) { |n| "role_#{n}" }
     sequence(:description) { |n| "The description for role_#{n}" }
 
-    trait :special_children_act do
-      role { "special_children_act" }
-      description { "Allow the firm to access SCA proceedings" }
+    trait :dummy_permission do
+      role { "dummy_permission" }
+      description { "Allow the firm to have a dummy permission" }
     end
   end
 end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -18,6 +18,13 @@ FactoryBot.define do
       permissions { [] }
     end
 
+    trait :with_dummy_permission do
+      permissions do
+        dummy_permission = create(:permission, :dummy_permission)
+        [dummy_permission]
+      end
+    end
+
     trait :created_by_devise do
       firm { nil }
       name { nil }

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -36,37 +36,28 @@ RSpec.describe Provider do
       let(:firm) { create(:firm, :with_no_permissions) }
       let(:provider) { create(:provider, :with_no_permissions, firm:) }
 
-      it "returns false" do
+      it "returns empty array" do
         expect(provider.user_permissions).to be_empty
       end
     end
 
-    context "when the firm has SCA permissions" do
-      let(:firm) { create(:firm, :with_sca_permissions) }
-      let(:provider) { create(:provider, :with_no_permissions, firm:) }
-
-      it "returns a value" do
-        expect(provider.user_permissions).to be_a(ActiveRecord::Relation)
-      end
-    end
-  end
-
-  describe "sca_permissions?" do
-    context "with no permissions for provider and their firm" do
+    context "with permission for provider but not firm" do
       let(:firm) { create(:firm, :with_no_permissions) }
-      let(:provider) { create(:provider, :with_no_permissions, firm:) }
+      let(:provider) { create(:provider, :with_dummy_permission, firm:) }
 
-      it "returns false" do
-        expect(provider.sca_permissions?).to be false
+      it "returns the providers permission" do
+        expect(provider.user_permissions).to be_a(ActiveRecord::Relation)
+        expect(provider.user_permissions.first).to be(provider.permissions.first)
       end
     end
 
-    context "when the firm has SCA permissions" do
-      let(:firm) { create(:firm, :with_sca_permissions) }
+    context "with permission for firm but not provider" do
+      let(:firm) { create(:firm, :with_dummy_permission) }
       let(:provider) { create(:provider, :with_no_permissions, firm:) }
 
-      it "returns a value" do
-        expect(provider.sca_permissions?).to be true
+      it "returns the firms permission" do
+        expect(provider.user_permissions).to be_a(ActiveRecord::Relation)
+        expect(provider.user_permissions.first).to be(firm.permissions.first)
       end
     end
   end

--- a/spec/services/legal_framework/proceeding_types/all_spec.rb
+++ b/spec/services/legal_framework/proceeding_types/all_spec.rb
@@ -21,20 +21,8 @@ RSpec.describe LegalFramework::ProceedingTypes::All do
     context "when the special children act setting is on" do
       let(:sca_enabled) { true }
 
-      context "and the firm has SCA permissions enabled" do
-        let(:firm) { create(:firm, :with_sca_permissions) }
-        let(:provider) { create(:provider, :with_no_permissions, firm:) }
-        let(:legal_aid_application) { create :legal_aid_application, provider: }
-
-        it "returns the expected proceedings" do
-          expect(call.map(&:ccms_code)).to match_array %w[DA001 SE097 DA003 SE016E DA006 PB003]
-        end
-      end
-
-      context "and the firm does not have SCA permissions enabled" do
-        it "returns the expected proceedings" do
-          expect(call.map(&:ccms_code)).to match_array %w[DA001 SE097 DA003 SE016E DA006]
-        end
+      it "returns the expected proceedings" do
+        expect(call.map(&:ccms_code)).to match_array %w[DA001 SE097 DA003 SE016E DA006 PB003]
       end
     end
 
@@ -56,20 +44,8 @@ RSpec.describe LegalFramework::ProceedingTypes::All do
       let(:sca_enabled) { true }
       let(:plf_enabled) { true }
 
-      context "and the firm has SCA permissions enabled" do
-        let(:firm) { create(:firm, :with_sca_permissions) }
-        let(:provider) { create(:provider, :with_no_permissions, firm:) }
-        let(:legal_aid_application) { create :legal_aid_application, provider: }
-
-        it "returns the expected proceedings" do
-          expect(call.map(&:ccms_code)).to match_array %w[DA001 SE097 DA003 SE016E DA006 PB003 PBM01]
-        end
-      end
-
-      context "and the firm does not have SCA permissions enabled" do
-        it "returns the expected proceedings" do
-          expect(call.map(&:ccms_code)).to match_array %w[DA001 SE097 DA003 SE016E DA006 PBM01]
-        end
+      it "returns the expected proceedings" do
+        expect(call.map(&:ccms_code)).to match_array %w[DA001 SE097 DA003 SE016E DA006 PB003 PBM01]
       end
     end
   end


### PR DESCRIPTION

## What
Remove SCA firm [and provider] level permission

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Most firms that have been indentified as likely to
submit SCA applications have been onboarded now. This
removes the permission and requirement for a provider or
firm to have it so as to open it up to the remaining firms.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
