### PR TITLE
AP-5742: Add avoid breaks css to merits report

### DIFF
--- a/app/assets/stylesheets/print-styles.scss
+++ b/app/assets/stylesheets/print-styles.scss
@@ -75,7 +75,7 @@
   section.print-no-break,
   dl,
   h2 {
-    page-break-inside: avoid;
+    break-inside: avoid;
   }
 
   .print-header-wrapper {

--- a/app/views/providers/merits_reports/_applied_previously.html.erb
+++ b/app/views/providers/merits_reports/_applied_previously.html.erb
@@ -1,14 +1,18 @@
-<%= govuk_summary_card(title: t(".heading"),
-                       heading_level: 3,
-                       html_attributes: { id: "app-check-your-answers__applied_previously__card" }) do |card|
-      card.with_summary_list(actions: false, html_attributes: { id: "app-check-your-answers__applied_previously__summary" }) do |summary_list|
-        summary_list.with_row(html_attributes: { id: "app-check-your-answers__applied_previously" }) do |row|
-          row.with_key(text: t(".has_applied_before"), classes: "govuk-!-width-one-half")
-          row.with_value(text: yes_no(legal_aid_application.applicant.applied_previously))
+<section class="print-no-break">
+  <h2 class="govuk-heading-m"><%= t(".heading") %></h2>
+
+  <%= govuk_summary_card(title: t(".heading"),
+                         heading_level: 3,
+                         html_attributes: { id: "app-check-your-answers__applied_previously__card" }) do |card|
+        card.with_summary_list(actions: false, html_attributes: { id: "app-check-your-answers__applied_previously__summary" }) do |summary_list|
+          summary_list.with_row(html_attributes: { id: "app-check-your-answers__applied_previously" }) do |row|
+            row.with_key(text: t(".has_applied_before"), classes: "govuk-!-width-one-half")
+            row.with_value(text: yes_no(legal_aid_application.applicant.applied_previously))
+          end
+          summary_list.with_row(html_attributes: { id: "app-check-your-answers__previous_reference" }) do |row|
+            row.with_key(text: t(".previous_application_reference"), classes: "govuk-!-width-one-half")
+            row.with_value(text: legal_aid_application.applicant.previous_reference.presence || "-")
+          end
         end
-        summary_list.with_row(html_attributes: { id: "app-check-your-answers__previous_reference" }) do |row|
-          row.with_key(text: t(".previous_application_reference"), classes: "govuk-!-width-one-half")
-          row.with_value(text: legal_aid_application.applicant.previous_reference.presence || "-")
-        end
-      end
-    end %>
+      end %>
+</section>

--- a/app/views/providers/merits_reports/_delegated_functions.html.erb
+++ b/app/views/providers/merits_reports/_delegated_functions.html.erb
@@ -1,37 +1,53 @@
-<% proceedings.each do |proceeding| %>
-  <% if proceeding.used_delegated_functions? %>
 
-    <%= govuk_summary_card(title: proceeding.meaning,
-                           heading_level: 3,
-                           html_attributes: { id: "app-check-your-answers__delegated_functions__#{proceeding.name}" }) do |card|
-          card.with_summary_list(actions: false, html_attributes: { id: "app-check-your-answers__delegated_functions__#{proceeding.name}__summary" }) do |summary_list|
-            summary_list.with_row(html_attributes: { id: "app-check-your-answers__used_delegated_functions_reported_on__#{proceeding.name}" }) do |row|
-              row.with_key(text: t(".reported_on"), classes: "govuk-!-width-one-half")
-              row.with_value(text: proceeding.used_delegated_functions_reported_on)
+
+<% proceedings.each_with_index do |proceeding, idx| %>
+  <section class="print-no-break">
+
+    <%#
+      Print the heading WITHIN the print-no-break section BUT only for first proceedng.
+      This is so that the overall heading is kept on the same page as the first
+      proceeding card, at least, but that we do not force subsequent cards to be on the
+      same page.
+    %>
+    <% if idx == 0 %>
+      <h2 class="govuk-heading-m"><%= t ".heading" %></h2>
+    <% end %>
+
+    <% if proceeding.used_delegated_functions? %>
+
+      <%= govuk_summary_card(title: proceeding.meaning,
+                             heading_level: 3,
+                             html_attributes: { id: "app-check-your-answers__delegated_functions__#{proceeding.name}" }) do |card|
+            card.with_summary_list(actions: false, html_attributes: { id: "app-check-your-answers__delegated_functions__#{proceeding.name}__summary" }) do |summary_list|
+              summary_list.with_row(html_attributes: { id: "app-check-your-answers__used_delegated_functions_reported_on__#{proceeding.name}" }) do |row|
+                row.with_key(text: t(".reported_on"), classes: "govuk-!-width-one-half")
+                row.with_value(text: proceeding.used_delegated_functions_reported_on)
+              end
+
+              summary_list.with_row(html_attributes: { id: "app-check-your-answers__used_delegated_functions_on__#{proceeding.name}" }) do |row|
+                row.with_key(text: t(".used_on"), classes: "govuk-!-width-one-half")
+                row.with_value(text: proceeding.used_delegated_functions_on)
+              end
+
+              summary_list.with_row(html_attributes: { id: "app-check-your-answers__delegated_functions_days_to_report__#{proceeding.name}" }) do |row|
+                row.with_key(text: t(".days_to_report"), classes: "govuk-!-width-one-half")
+                row.with_value(text: distance_of_time_in_words(proceeding.used_delegated_functions_reported_on, proceeding.used_delegated_functions_on))
+              end
             end
+          end %>
 
-            summary_list.with_row(html_attributes: { id: "app-check-your-answers__used_delegated_functions_on__#{proceeding.name}" }) do |row|
-              row.with_key(text: t(".used_on"), classes: "govuk-!-width-one-half")
-              row.with_value(text: proceeding.used_delegated_functions_on)
+    <% else %>
+
+      <%= govuk_summary_card(title: proceeding.meaning,
+                             heading_level: 3,
+                             html_attributes: { id: "app-check-your-answers__delegated_functions__#{proceeding.name}" }) do |card|
+            card.with_summary_list(actions: false, html_attributes: { id: "app-check-your-answers__delegated_functions" }) do |summary_list|
+              summary_list.with_row(html_attributes: { id: "app-check-your-answers__used_delegated_functions_on__#{proceeding.name}" }) do |row|
+                row.with_value(text: t(".not_used"), classes: "govuk-!-width-full")
+              end
             end
+          end %>
 
-            summary_list.with_row(html_attributes: { id: "app-check-your-answers__delegated_functions_days_to_report__#{proceeding.name}" }) do |row|
-              row.with_key(text: t(".days_to_report"), classes: "govuk-!-width-one-half")
-              row.with_value(text: distance_of_time_in_words(proceeding.used_delegated_functions_reported_on, proceeding.used_delegated_functions_on))
-            end
-          end
-        end %>
-
-  <% else %>
-
-    <%= govuk_summary_card(title: proceeding.meaning,
-                           heading_level: 3,
-                           html_attributes: { id: "app-check-your-answers__delegated_functions__#{proceeding.name}" }) do |card|
-          card.with_summary_list(actions: false, html_attributes: { id: "app-check-your-answers__delegated_functions" }) do |summary_list|
-            summary_list.with_row(html_attributes: { id: "app-check-your-answers__used_delegated_functions_on__#{proceeding.name}" }) do |row|
-              row.with_value(text: t(".not_used"), classes: "govuk-!-width-full")
-            end
-          end
-        end %>
-  <% end %>
+    <% end %>
+  </section>
 <% end %>

--- a/app/views/providers/merits_reports/_proceeding_details.html.erb
+++ b/app/views/providers/merits_reports/_proceeding_details.html.erb
@@ -1,12 +1,17 @@
-<%= govuk_summary_card(title: t(".heading"),
-                       heading_level: 3,
-                       html_attributes: { id: "app-check-your-answers__proceeding_details__card" }) do |card|
-      card.with_summary_list(actions: false, html_attributes: { id: "app-check-your-answers__proceeding_details__summary" }) do |summary_list|
-        legal_aid_application.proceedings_by_name.each_with_index do |proceeding, i|
-          summary_list.with_row(classes: "app-check-your-answers__#{proceeding.name}__row") do |row|
-            row.with_key(text: "#{t('.proceeding')} #{i + 1}", classes: "govuk-!-width-one-half")
-            row.with_value { proceeding.meaning }
+
+<section class="print-no-break">
+  <h2 class="govuk-heading-m"><%= t(".heading") %></h2>
+
+  <%= govuk_summary_card(title: t(".card_title"),
+                         heading_level: 3,
+                         html_attributes: { id: "app-check-your-answers__proceeding_details__card" }) do |card|
+        card.with_summary_list(actions: false, html_attributes: { id: "app-check-your-answers__proceeding_details__summary" }) do |summary_list|
+          legal_aid_application.proceedings_by_name.each_with_index do |proceeding, i|
+            summary_list.with_row(classes: "app-check-your-answers__#{proceeding.name}__row") do |row|
+              row.with_key(text: "#{t('.proceeding')} #{i + 1}", classes: "govuk-!-width-one-half")
+              row.with_value { proceeding.meaning }
+            end
           end
         end
-      end
-    end %>
+      end %>
+</section>

--- a/app/views/providers/merits_reports/show.html.erb
+++ b/app/views/providers/merits_reports/show.html.erb
@@ -3,50 +3,55 @@
 
   <%= render "shared/application_ref", legal_aid_application: @legal_aid_application %>
 
-  <h2 class="govuk-heading-m"><%= t(".client_details_heading") %></h2>
-  <%= render(
-        "shared/check_answers/client_details",
-        attributes: %i[first_name last_name last_name_at_birth changed_last_name date_of_birth age means_test national_insurance_number has_partner],
-        applicant: @legal_aid_application.applicant,
-        read_only: true,
-      ) %>
-
-  <% if @legal_aid_application.applicant_has_partner? %>
-    <h2 class="govuk-heading-m"><%= t(".partner_details_heading") %></h2>
+  <section class="print-no-break">
+    <h2 class="govuk-heading-m"><%= t(".client_details_heading") %></h2>
     <%= render(
-          "shared/check_answers/partner_details",
-          attributes: %i[first_name last_name date_of_birth national_insurance_number],
-          partner: @legal_aid_application.partner,
+          "shared/check_answers/client_details",
+          attributes: %i[first_name last_name last_name_at_birth changed_last_name date_of_birth age means_test national_insurance_number has_partner],
+          applicant: @legal_aid_application.applicant,
           read_only: true,
         ) %>
+  </section>
+
+  <% if @legal_aid_application.applicant_has_partner? %>
+    <section class="print-no-break">
+      <h2 class="govuk-heading-m"><%= t(".partner_details_heading") %></h2>
+      <%= render(
+            "shared/check_answers/partner_details",
+            attributes: %i[first_name last_name date_of_birth national_insurance_number],
+            partner: @legal_aid_application.partner,
+            read_only: true,
+          ) %>
+    </section>
   <% end %>
 
-  <h2 class="govuk-heading-m"><%= t(".previous_legal_aid_heading") %></h2>
   <%= render("applied_previously", legal_aid_application: @legal_aid_application) %>
 
-  <h2 class="govuk-heading-m"><%= t(".applying_for") %></h2>
   <%= render("proceeding_details", legal_aid_application: @legal_aid_application) %>
 
-  <h2 class="govuk-heading-m"><%= t ".delegated_functions_heading" %></h2>
   <%= render("delegated_functions", proceedings: @legal_aid_application.proceedings.in_order_of_addition) %>
 
   <% if @legal_aid_application.non_sca_used_delegated_functions? %>
-    <h2 class="govuk-heading-m"><%= t ".emergency_cost_limit" %></h2>
-    <%= render(
-          "shared/check_answers/emergency_costs",
-          legal_aid_application: @legal_aid_application,
-          read_only: true,
-        ) %>
+    <section class="print-no-break">
+      <h2 class="govuk-heading-m"><%= t ".emergency_cost_limit" %></h2>
+      <%= render(
+            "shared/check_answers/emergency_costs",
+            legal_aid_application: @legal_aid_application,
+            read_only: true,
+          ) %>
+    </section>
   <% end %>
 
   <% if @legal_aid_application.substantive_cost_overridable? %>
-    <h2 class="govuk-heading-m"><%= t ".substantive_cost_limit" %></h2>
-    <%= render(
-          "shared/check_answers/substantive_costs",
-          legal_aid_application: @legal_aid_application,
-          heading: t(".substantive_cost_limit"),
-          read_only: true,
-        ) %>
+    <section class="print-no-break">
+      <h2 class="govuk-heading-m"><%= t ".substantive_cost_limit" %></h2>
+      <%= render(
+            "shared/check_answers/substantive_costs",
+            legal_aid_application: @legal_aid_application,
+            heading: t(".substantive_cost_limit"),
+            read_only: true,
+          ) %>
+    </section>
   <% end %>
 
   <%= render(

--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -38,8 +38,10 @@
 <% end %>
 
 <% if @legal_aid_application.uploaded_evidence_collection %>
-  <h2 class="govuk-heading-l"><%= t(".evidence_upload_heading") %></h2>
-  <%= render("shared/check_answers/merits/supporting_evidence", read_only:) %>
+  <section class="print-no-break">
+    <h2 class="govuk-heading-l"><%= t(".evidence_upload_heading") %></h2>
+    <%= render("shared/check_answers/merits/supporting_evidence", read_only:) %>
+  </section>
 <% end %>
 
 <!--This is to prevent the separate representation section from showing up anywhere other than the merits report -->

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1491,9 +1491,6 @@ en:
         heading: Merits report
         client_details_heading: Client details
         partner_details_heading: Partner details
-        previous_legal_aid_heading: Previous Legal Aid
-        applying_for: What you're applying for
-        delegated_functions_heading: Delegated functions
         emergency_cost_limit: Emergency cost limit
         substantive_cost_limit: Substantive cost limit
       applied_previously:
@@ -1501,9 +1498,11 @@ en:
         has_applied_before: Has your client applied for civil legal aid before?
         previous_application_reference: Previous CCMS reference number
       proceeding_details:
-        heading: Proceedings
+        heading: What you're applying for
+        card_title: Proceedings
         proceeding: Proceeding
       delegated_functions:
+        heading: Delegated functions
         reported_on: Date reported
         used_on: Date delegated functions were used
         days_to_report: Days to report


### PR DESCRIPTION
## What
Avoid page breaks between headings and their summary card on the merits report

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5742)

For sections with a single card the heading can otherwise
become separated from the summary card's page. Which is
not ideal for a printed document being reviewed by caseworkers.

**Also**, this replaces a deprecated css attribute `page-break-inside` for `break-inside` - 
see [deprecation notice](https://developer.mozilla.org/en-US/docs/Web/CSS/page-break-inside)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
