### PR TITLE
AP-5754: Add sort to ensure evidence order is consistent

### DIFF
--- a/spec/models/legal_aid_application_spec.rb
+++ b/spec/models/legal_aid_application_spec.rb
@@ -1793,16 +1793,15 @@ RSpec.describe LegalAidApplication do
 
     context "when evidence has been uploaded" do
       it "returns a hash of evidence attachments grouped by category" do
-        expect(laa.uploaded_evidence_by_category).to eq({
-          "gateway_evidence" => [
-            find_attachment(collection.original_attachments, "Fake Gateway Evidence 1"),
-            find_attachment(collection.original_attachments, "Fake Gateway Evidence 2"),
-          ],
-          "benefit_evidence" => [
-            find_attachment(collection.original_attachments, "Fake Benefit Evidence 1"),
-            find_attachment(collection.original_attachments, "Fake Benefit Evidence 2"),
-          ],
-        })
+        # Added sort to ensure the order is consistent. Without it we got flickering tests with attachments out of order
+        expect(laa.uploaded_evidence_by_category["gateway_evidence"].sort).to eq [
+          find_attachment(collection.original_attachments, "Fake Gateway Evidence 1"),
+          find_attachment(collection.original_attachments, "Fake Gateway Evidence 2"),
+        ].sort
+        expect(laa.uploaded_evidence_by_category["benefit_evidence"].sort).to eq [
+          find_attachment(collection.original_attachments, "Fake Benefit Evidence 1"),
+          find_attachment(collection.original_attachments, "Fake Benefit Evidence 2"),
+        ].sort
       end
     end
   end


### PR DESCRIPTION


## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5754)

Previously this test was flickering. Add sort to ensure the order is consistent, so that it is hopefully more stable.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
