### PR TITLE
Fix: spec date timebomb

### DIFF
--- a/spec/services/secure_application_finder_spec.rb
+++ b/spec/services/secure_application_finder_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SecureApplicationFinder do
     create(
       :citizen_access_token,
       legal_aid_application:,
-      expires_on: Date.new(2025, 2, 14),
+      expires_on: Time.zone.today + 2.years,
     )
   end
 


### PR DESCRIPTION

## What

This was created 2 years ago and hard coded... Happy Valentines Day all your test runs will fail! :D

This moves the creation date to always be perpetually two years away


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
