### PR TITLE
AP-5753: Add print-no-break sections on means reports print page

### DIFF
--- a/app/assets/stylesheets/print-styles.scss
+++ b/app/assets/stylesheets/print-styles.scss
@@ -66,6 +66,10 @@
     break-inside: avoid;
   }
 
+  .print-no-break-after {
+    break-after: avoid;
+  }
+
   .print-header-wrapper {
     position: relative;
   }

--- a/app/views/providers/means_reports/_benefits_breakdown.html.erb
+++ b/app/views/providers/means_reports/_benefits_breakdown.html.erb
@@ -6,8 +6,7 @@
      data_source = @legal_aid_application.applicant
    end %>
 
-<section class="print-no-break">
-  <h2 class="govuk-heading-m"><%= t(".#{individual}.heading") %></h2>
+  <h2 class="govuk-heading-m print-no-break-after"><%= t(".#{individual}.heading") %></h2>
 
   <%= govuk_summary_card(title: t(".#{individual}.heading"),
                          heading_level: 3,
@@ -21,4 +20,3 @@
           end
         end
       end %>
-</section>

--- a/app/views/providers/means_reports/_capital_result.html.erb
+++ b/app/views/providers/means_reports/_capital_result.html.erb
@@ -1,6 +1,5 @@
 
-<section class="print-no-break">
-  <h2 class="govuk-heading-m"><%= t(".heading") %></h2>
+<h2 class="govuk-heading-m print-no-break-after"><%= t(".heading") %></h2>
 
   <%= govuk_summary_card(title: t(".heading"),
                          heading_level: 3,
@@ -27,4 +26,3 @@
           end
         end
       end %>
-</section>

--- a/app/views/providers/means_reports/_caseworker_review.html.erb
+++ b/app/views/providers/means_reports/_caseworker_review.html.erb
@@ -1,5 +1,4 @@
-<section class="print-no-break">
-  <h2 class="govuk-heading-m"><%= t("providers.means_reports.caseworker_review_section_heading") %></h2>
+<h2 class="govuk-heading-m print-no-break-after"><%= t("providers.means_reports.caseworker_review_section_heading") %></h2>
 
   <%= govuk_summary_card(title: t("providers.means_reports.caseworker_review_section_heading"),
                          heading_level: 3,
@@ -29,4 +28,3 @@
           end
         end
       end %>
-</section>

--- a/app/views/providers/means_reports/_income_details.html.erb
+++ b/app/views/providers/means_reports/_income_details.html.erb
@@ -1,5 +1,4 @@
-<section class="print-no-break">
-  <h2 class="govuk-heading-m"><%= t(".heading") %></h2>
+  <h2 class="govuk-heading-m print-no-break-after"><%= t(".heading") %></h2>
 
   <%= govuk_summary_card(title: t(".heading"),
                          heading_level: 3,
@@ -29,4 +28,3 @@
           end
         end
       end %>
-</section>

--- a/app/views/providers/means_reports/_income_result.html.erb
+++ b/app/views/providers/means_reports/_income_result.html.erb
@@ -1,5 +1,4 @@
-<section class="print-no-break">
-  <h2 class="govuk-heading-m"><%= t(".heading") %></h2>
+<h2 class="govuk-heading-m print-no-break-after"><%= t(".heading") %></h2>
 
   <%= govuk_summary_card(title: t(".heading"),
                          heading_level: 3,
@@ -36,4 +35,3 @@
           end
         end
       end %>
-</section>

--- a/app/views/providers/means_reports/_outgoings_and_deductions_details.html.erb
+++ b/app/views/providers/means_reports/_outgoings_and_deductions_details.html.erb
@@ -1,50 +1,48 @@
-<section class="print-no-break">
-  <h2 class="govuk-heading-m"><%= t(".heading") %></h2>
+<h2 class="govuk-heading-m print-no-break-after"><%= t(".heading") %></h2>
 
-  <%= govuk_summary_card(title: t(".heading"),
-                         heading_level: 3,
-                         html_attributes: { id: "app-check-your-answers__outgoings_and_deductions_details__card" }) do |card|
-        card.with_summary_list(actions: false, html_attributes: { id: "app-check-your-answers__outgoings_and_deductions_details__summary" }) do |summary_list|
-          outgoings_detail_items.each do |item|
-            summary_list.with_row do |row|
-              row.with_key(text: t(".client.#{item.name}"), classes: "govuk-!-width-one-half")
-              row.with_value { gds_number_to_currency(@cfe_result.__send__(item.value_method)) }
-            end
-          end
-
-          outgoings_detail_items.each do |item|
-            next unless @legal_aid_application.applicant.has_partner_with_no_contrary_interest? && partner_exclude_items.exclude?(item.value_method)
-
-            summary_list.with_row do |row|
-              row.with_key(text: t(".partner.#{item.name}"), classes: "govuk-!-width-one-half")
-              row.with_value { gds_number_to_currency(@cfe_result.__send__(item.value_method, partner: true)) }
-            end
-          end
-
-          deductions_detail_items(@legal_aid_application).each do |item|
-            summary_list.with_row do |row|
-              row.with_key(text: t(".client.#{item.name}"), classes: "govuk-!-width-one-half")
-              row.with_value { gds_number_to_currency(@cfe_result.__send__(item.value_method)) }
-            end
-
-            next unless @legal_aid_application.applicant.has_partner_with_no_contrary_interest? && partner_exclude_items.exclude?(item.value_method)
-
-            summary_list.with_row do |row|
-              row.with_key(text: t(".partner.#{item.name}"), classes: "govuk-!-width-one-half")
-              row.with_value { gds_number_to_currency(@cfe_result.__send__(item.value_method, partner: true)) }
-            end
-          end
-
-          result = if @legal_aid_application.applicant.has_partner_with_no_contrary_interest?
-                     @cfe_result.__send__(:total_monthly_outgoings) + @cfe_result.__send__(:total_monthly_outgoings, partner: true) + @cfe_result.__send__(:total_deductions)
-                   else
-                     @cfe_result.__send__(:total_monthly_outgoings) + @cfe_result.__send__(:total_deductions)
-                   end
-
-          summary_list.with_row(classes: "bold-border-top") do |row|
-            row.with_key { t(".total_outgoings_and_deductions") }
-            row.with_value(text: gds_number_to_currency(gds_number_to_currency(result)), html_attributes: { class: "govuk-!-font-weight-bold" })
+<%= govuk_summary_card(title: t(".heading"),
+                       heading_level: 3,
+                       html_attributes: { id: "app-check-your-answers__outgoings_and_deductions_details__card" }) do |card|
+      card.with_summary_list(actions: false, html_attributes: { id: "app-check-your-answers__outgoings_and_deductions_details__summary" }) do |summary_list|
+        outgoings_detail_items.each do |item|
+          summary_list.with_row do |row|
+            row.with_key(text: t(".client.#{item.name}"), classes: "govuk-!-width-one-half")
+            row.with_value { gds_number_to_currency(@cfe_result.__send__(item.value_method)) }
           end
         end
-      end %>
-</section>
+
+        outgoings_detail_items.each do |item|
+          next unless @legal_aid_application.applicant.has_partner_with_no_contrary_interest? && partner_exclude_items.exclude?(item.value_method)
+
+          summary_list.with_row do |row|
+            row.with_key(text: t(".partner.#{item.name}"), classes: "govuk-!-width-one-half")
+            row.with_value { gds_number_to_currency(@cfe_result.__send__(item.value_method, partner: true)) }
+          end
+        end
+
+        deductions_detail_items(@legal_aid_application).each do |item|
+          summary_list.with_row do |row|
+            row.with_key(text: t(".client.#{item.name}"), classes: "govuk-!-width-one-half")
+            row.with_value { gds_number_to_currency(@cfe_result.__send__(item.value_method)) }
+          end
+
+          next unless @legal_aid_application.applicant.has_partner_with_no_contrary_interest? && partner_exclude_items.exclude?(item.value_method)
+
+          summary_list.with_row do |row|
+            row.with_key(text: t(".partner.#{item.name}"), classes: "govuk-!-width-one-half")
+            row.with_value { gds_number_to_currency(@cfe_result.__send__(item.value_method, partner: true)) }
+          end
+        end
+
+        result = if @legal_aid_application.applicant.has_partner_with_no_contrary_interest?
+                   @cfe_result.__send__(:total_monthly_outgoings) + @cfe_result.__send__(:total_monthly_outgoings, partner: true) + @cfe_result.__send__(:total_deductions)
+                 else
+                   @cfe_result.__send__(:total_monthly_outgoings) + @cfe_result.__send__(:total_deductions)
+                 end
+
+        summary_list.with_row(classes: "bold-border-top") do |row|
+          row.with_key { t(".total_outgoings_and_deductions") }
+          row.with_value(text: gds_number_to_currency(gds_number_to_currency(result)), html_attributes: { class: "govuk-!-font-weight-bold" })
+        end
+      end
+    end %>

--- a/app/views/providers/means_reports/_proceeding_eligibility.html.erb
+++ b/app/views/providers/means_reports/_proceeding_eligibility.html.erb
@@ -1,10 +1,12 @@
-<h2 class="govuk-heading-m"><%= t("providers.means_reports.proceeding_eligibility") %></h2>
+<section class="print-no-break">
+  <h2 class="govuk-heading-m"><%= t("providers.means_reports.proceeding_eligibility") %></h2>
 
-<%= govuk_summary_list(card: { title: t("providers.means_reports.proceeding_eligibility") }, actions: false, html_attributes: { id: "proceeding-eligibility-questions" }) do |summary_list| %>
-  <% results.each do |proceeding_type, result| %>
-    <%= summary_list.with_row do |row| %>
-      <%= row.with_key(text: proceeding_type, classes: "govuk-!-width-one-half") %>
-      <%= row.with_value(text: result) %>
+  <%= govuk_summary_list(card: { title: t("providers.means_reports.proceeding_eligibility") }, actions: false, html_attributes: { id: "proceeding-eligibility-questions" }) do |summary_list| %>
+    <% results.each do |proceeding_type, result| %>
+      <%= summary_list.with_row do |row| %>
+        <%= row.with_key(text: proceeding_type, classes: "govuk-!-width-one-half") %>
+        <%= row.with_value(text: result) %>
+      <% end %>
     <% end %>
   <% end %>
-<% end %>
+</section>

--- a/app/views/providers/means_reports/_proceeding_eligibility.html.erb
+++ b/app/views/providers/means_reports/_proceeding_eligibility.html.erb
@@ -1,12 +1,10 @@
-<section class="print-no-break">
-  <h2 class="govuk-heading-m"><%= t("providers.means_reports.proceeding_eligibility") %></h2>
+<h2 class="govuk-heading-m print-no-break-after"><%= t("providers.means_reports.proceeding_eligibility") %></h2>
 
-  <%= govuk_summary_list(card: { title: t("providers.means_reports.proceeding_eligibility") }, actions: false, html_attributes: { id: "proceeding-eligibility-questions" }) do |summary_list| %>
-    <% results.each do |proceeding_type, result| %>
-      <%= summary_list.with_row do |row| %>
-        <%= row.with_key(text: proceeding_type, classes: "govuk-!-width-one-half") %>
-        <%= row.with_value(text: result) %>
-      <% end %>
+<%= govuk_summary_list(card: { title: t("providers.means_reports.proceeding_eligibility") }, actions: false, html_attributes: { id: "proceeding-eligibility-questions" }) do |summary_list| %>
+  <% results.each do |proceeding_type, result| %>
+    <%= summary_list.with_row do |row| %>
+      <%= row.with_key(text: proceeding_type, classes: "govuk-!-width-one-half") %>
+      <%= row.with_value(text: result) %>
     <% end %>
   <% end %>
-</section>
+<% end %>

--- a/app/views/providers/means_reports/_receives_benefits.html.erb
+++ b/app/views/providers/means_reports/_receives_benefits.html.erb
@@ -1,14 +1,12 @@
-<section class="print-no-break">
-  <h2 class="govuk-heading-m"><%= t("providers.means_reports.benefit_check_heading") %></h2>
+<h2 class="govuk-heading-m print-no-break-after"><%= t("providers.means_reports.benefit_check_heading") %></h2>
 
-  <%= govuk_summary_card(title: t("providers.means_reports.benefit_check_heading"),
-                         heading_level: 3,
-                         html_attributes: { id: "app-check-your-answers__receieves_benefits__card" }) do |card|
-        card.with_summary_list(actions: false, html_attributes: { id: "app-check-your-answers__receieves_benefits__summary" }) do |summary_list|
-          summary_list.with_row(html_attributes: { id: "app-check-your-answers__receives_benefit" }) do |row|
-            row.with_key(text: t("providers.means_reports.benefit_check_question"), classes: "govuk-!-width-one-half")
-            row.with_value(text: yes_no(@legal_aid_application.applicant_receives_benefit?))
-          end
+<%= govuk_summary_card(title: t("providers.means_reports.benefit_check_heading"),
+                       heading_level: 3,
+                       html_attributes: { id: "app-check-your-answers__receieves_benefits__card" }) do |card|
+      card.with_summary_list(actions: false, html_attributes: { id: "app-check-your-answers__receieves_benefits__summary" }) do |summary_list|
+        summary_list.with_row(html_attributes: { id: "app-check-your-answers__receives_benefit" }) do |row|
+          row.with_key(text: t("providers.means_reports.benefit_check_question"), classes: "govuk-!-width-one-half")
+          row.with_value(text: yes_no(@legal_aid_application.applicant_receives_benefit?))
         end
-      end %>
-</section>
+      end
+    end %>

--- a/app/views/providers/means_reports/_uploaded_bank_statements.html.erb
+++ b/app/views/providers/means_reports/_uploaded_bank_statements.html.erb
@@ -1,38 +1,36 @@
-<section class="print-no-break">
-  <h2 class="govuk-heading-m"><%= t(".bank_statement_heading") %></h2>
+<h2 class="govuk-heading-m print-no-break-after"><%= t(".bank_statement_heading") %></h2>
 
-  <% has_partner = @legal_aid_application.applicant.has_partner_with_no_contrary_interest? %>
+<% has_partner = @legal_aid_application.applicant.has_partner_with_no_contrary_interest? %>
 
-  <%= govuk_summary_card(title: t(".bank_statement_heading"),
-                         heading_level: 3,
-                         html_attributes: { id: "app-check-your-answers__bank_statements_client__card" }) do |card| %>
+<%= govuk_summary_card(title: t(".bank_statement_heading"),
+                       heading_level: 3,
+                       html_attributes: { id: "app-check-your-answers__bank_statements_client__card" }) do |card| %>
 
-    <% card.with_summary_list(actions: false, html_attributes: { id: "app-check-your-answers__bank_statements_client__summary" }) do |summary_list| %>
-      <% if @legal_aid_application.client_uploading_bank_statements? %>
-        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__bank_statements_client_summary" }) do |row| %>
-          <%= row.with_key(text: has_partner ? t(".bank_statement_question_with_partner") : t(".bank_statement_question"), classes: "govuk-!-width-one-half") %>
-          <%= row.with_value do %>
-            <ul class="govuk-list">
-              <% attachments_with_size(@legal_aid_application.attachments.bank_statement_evidence).each do |answer| %>
-                <li><%= answer %></li>
-              <% end %>
-            </ul>
-          <% end %>
+  <% card.with_summary_list(actions: false, html_attributes: { id: "app-check-your-answers__bank_statements_client__summary" }) do |summary_list| %>
+    <% if @legal_aid_application.client_uploading_bank_statements? %>
+      <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__bank_statements_client_summary" }) do |row| %>
+        <%= row.with_key(text: has_partner ? t(".bank_statement_question_with_partner") : t(".bank_statement_question"), classes: "govuk-!-width-one-half") %>
+        <%= row.with_value do %>
+          <ul class="govuk-list">
+            <% attachments_with_size(@legal_aid_application.attachments.bank_statement_evidence).each do |answer| %>
+              <li><%= answer %></li>
+            <% end %>
+          </ul>
         <% end %>
       <% end %>
+    <% end %>
 
-      <% if has_partner && @legal_aid_application.partner_uploading_bank_statements? %>
-        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__bank_statements_partner_summary" }) do |row| %>
-          <%= row.with_key(text: t(".partner_bank_statement_question"), classes: "govuk-!-width-one-half") %>
-          <%= row.with_value do %>
-            <ul class="govuk-list">
-              <% attachments_with_size(@legal_aid_application.attachments.part_bank_state_evidence).each do |answer| %>
-                <li><%= answer %></li>
-              <% end %>
-            </ul>
-          <% end %>
+    <% if has_partner && @legal_aid_application.partner_uploading_bank_statements? %>
+      <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__bank_statements_partner_summary" }) do |row| %>
+        <%= row.with_key(text: t(".partner_bank_statement_question"), classes: "govuk-!-width-one-half") %>
+        <%= row.with_value do %>
+          <ul class="govuk-list">
+            <% attachments_with_size(@legal_aid_application.attachments.part_bank_state_evidence).each do |answer| %>
+              <li><%= answer %></li>
+            <% end %>
+          </ul>
         <% end %>
       <% end %>
     <% end %>
   <% end %>
-</section>
+<% end %>

--- a/app/views/providers/means_reports/_with_cfe_result_details.html.erb
+++ b/app/views/providers/means_reports/_with_cfe_result_details.html.erb
@@ -58,15 +58,17 @@
 
 <%= render "capital_result" %>
 
-<h2 class="govuk-heading-m"><%= t(".assets_heading") %></h2>
-<% individual = "_with_partner" if @legal_aid_application.applicant.has_partner_with_no_contrary_interest? %>
-<%= render "shared/check_answers/assets", means_report: true, read_only: true, individual: %>
+<section class="print-no-break">
+  <h2 class="govuk-heading-m"><%= t(".assets_heading") %></h2>
+  <% individual = "_with_partner" if @legal_aid_application.applicant.has_partner_with_no_contrary_interest? %>
+  <%= render "shared/check_answers/assets", means_report: true, read_only: true, individual: %>
 
-<% if @legal_aid_application.passported? && @manual_review_determiner.manual_review_required? %>
-    <div class="govuk-!-padding-bottom-8"></div>
-    <%= render "caseworker_review" %>
-<% end %>
+  <% if @legal_aid_application.passported? && @manual_review_determiner.manual_review_required? %>
+      <div class="govuk-!-padding-bottom-8"></div>
+      <%= render "caseworker_review" %>
+  <% end %>
 
-<% if @legal_aid_application.uploading_bank_statements? %>
-  <%= render "uploaded_bank_statements" %>
-<% end %>
+  <% if @legal_aid_application.uploading_bank_statements? %>
+    <%= render "uploaded_bank_statements" %>
+  <% end %>
+<section class="print-no-break">

--- a/app/views/providers/means_reports/_with_cfe_result_details.html.erb
+++ b/app/views/providers/means_reports/_with_cfe_result_details.html.erb
@@ -48,18 +48,15 @@
                        else
                          "your client"
                        end %>
-  <section class="print-no-break">
-    <h2 class="govuk-heading-m"><%= t("providers.means.check_income_answers.dependants.heading-h2") %></h2>
-    <%= render "shared/check_answers/dependants", individual: individual_text, read_only: true, means_report: true %>
-  </section>
+  <h2 class="govuk-heading-m print-no-break-after"><%= t("providers.means.check_income_answers.dependants.heading-h2") %></h2>
+  <%= render "shared/check_answers/dependants", individual: individual_text, read_only: true, means_report: true %>
 
   <%= render "caseworker_review" %>
 <% end %>
 
 <%= render "capital_result" %>
 
-<section class="print-no-break">
-  <h2 class="govuk-heading-m"><%= t(".assets_heading") %></h2>
+  <h2 class="govuk-heading-m print-no-break-after"><%= t(".assets_heading") %></h2>
   <% individual = "_with_partner" if @legal_aid_application.applicant.has_partner_with_no_contrary_interest? %>
   <%= render "shared/check_answers/assets", means_report: true, read_only: true, individual: %>
 
@@ -71,4 +68,3 @@
   <% if @legal_aid_application.uploading_bank_statements? %>
     <%= render "uploaded_bank_statements" %>
   <% end %>
-<section class="print-no-break">

--- a/app/views/providers/means_reports/show.html.erb
+++ b/app/views/providers/means_reports/show.html.erb
@@ -5,7 +5,7 @@
 
   <%= render "shared/application_ref", legal_aid_application: @legal_aid_application %>
 
-  <h2 class="govuk-heading-m"><%= t(".client_details_heading") %></h2>
+  <h2 class="govuk-heading-m print-no-break-after"><%= t(".client_details_heading") %></h2>
   <%= render(
         "shared/check_answers/client_details",
         attributes: %i[first_name last_name last_name_at_birth changed_last_name date_of_birth age means_test national_insurance_number care_of home_address],
@@ -14,7 +14,7 @@
       ) %>
 
   <% if @legal_aid_application.applicant_has_partner? %>
-    <h2 class="govuk-heading-m"><%= t(".partner_details_heading") %></h2>
+    <h2 class="govuk-heading-m print-no-break-after"><%= t(".partner_details_heading") %></h2>
     <%= render(
           "shared/check_answers/partner_details",
           attributes: %i[first_name last_name date_of_birth national_insurance_number],

--- a/app/views/shared/_savings_and_investments.html.erb
+++ b/app/views/shared/_savings_and_investments.html.erb
@@ -1,45 +1,47 @@
-<% if @cfe_result.liquid_capital_items.any? %>
-  <h2 class="govuk-heading-m"><%= t(".savings_and_investments") %></h2>
+<section class="print-no-break">
+  <% if @cfe_result.liquid_capital_items.any? %>
+    <h2 class="govuk-heading-m"><%= t(".savings_and_investments") %></h2>
 
-  <%= govuk_table do |table|
-        table.with_caption(html_attributes: { class: "govuk-visually-hidden" }, text: t(".table_caption"))
+    <%= govuk_table do |table|
+          table.with_caption(html_attributes: { class: "govuk-visually-hidden" }, text: t(".table_caption"))
 
-        table.with_head do |head|
-          head.with_row do |row|
-            row.with_cell(html_attributes: { class: "govuk-visually-hidden" }, text: t(".savings_and_investments_type"))
-            row.with_cell(html_attributes: { class: "govuk-visually-hidden" }, numeric: true, text: t(".amount"))
-          end
-        end
-
-        if @cfe_result.version_6?
-          table.with_body do |body|
-            body.with_row do |row|
-              row.with_cell(header: true, text: t(".current_accounts"))
-              row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.current_accounts))
-            end
-            body.with_row do |row|
-              row.with_cell(header: true, text: t(".savings_accounts"))
-              row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.savings_accounts))
+          table.with_head do |head|
+            head.with_row do |row|
+              row.with_cell(html_attributes: { class: "govuk-visually-hidden" }, text: t(".savings_and_investments_type"))
+              row.with_cell(html_attributes: { class: "govuk-visually-hidden" }, numeric: true, text: t(".amount"))
             end
           end
-        else
-          table.with_body do |body|
-            @cfe_result.liquid_capital_items.each do |item|
-              next unless capital_items_to_display?(@legal_aid_application, item)
 
+          if @cfe_result.version_6?
+            table.with_body do |body|
               body.with_row do |row|
-                row.with_cell(header: true, text: item_description(@legal_aid_application, item))
-                row.with_cell(numeric: true, text: gds_number_to_currency(item[:value]))
+                row.with_cell(header: true, text: t(".current_accounts"))
+                row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.current_accounts))
+              end
+              body.with_row do |row|
+                row.with_cell(header: true, text: t(".savings_accounts"))
+                row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.savings_accounts))
+              end
+            end
+          else
+            table.with_body do |body|
+              @cfe_result.liquid_capital_items.each do |item|
+                next unless capital_items_to_display?(@legal_aid_application, item)
+
+                body.with_row do |row|
+                  row.with_cell(header: true, text: item_description(@legal_aid_application, item))
+                  row.with_cell(numeric: true, text: gds_number_to_currency(item[:value]))
+                end
+              end
+            end
+
+            table.with_foot do |foot|
+              foot.with_row do |row|
+                row.with_cell(header: true, text: t(".assessed_amount"))
+                row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_savings))
               end
             end
           end
-
-          table.with_foot do |foot|
-            foot.with_row do |row|
-              row.with_cell(header: true, text: t(".assessed_amount"))
-              row.with_cell(numeric: true, text: gds_number_to_currency(@cfe_result.total_savings))
-            end
-          end
-        end
-      end %>
-<% end %>
+        end %>
+  <% end %>
+</section>

--- a/app/views/shared/check_answers/_assets.html.erb
+++ b/app/views/shared/check_answers/_assets.html.erb
@@ -34,7 +34,7 @@
       <% end %>
     <% end %>
 
-    <h3 class="govuk-heading-m print-no-break-after"><%= t(".assets.total_in_bank_accounts") %></h3>
+    <h2 class="govuk-heading-l print-no-break-after"><%= t(".assets.total_in_bank_accounts") %></h2>
     <%= govuk_summary_card(title: t(".assets.money_in_bank_accounts"),
                            heading_level: 3,
                            html_attributes: { "data-test": "applicant-bank-accounts" }) do |card| %>

--- a/app/views/shared/check_answers/_assets.html.erb
+++ b/app/views/shared/check_answers/_assets.html.erb
@@ -9,8 +9,8 @@
 
 <h2 class="govuk-heading-l print-no-break-after"><%= t(".assets.bank_accounts_heading") %></h2>
 
-  <% if @legal_aid_application.non_passported? && !@legal_aid_application.client_uploading_bank_statements? %>
-    <!-- non-passported truelayer only -->
+<% if @legal_aid_application.non_passported? && !@legal_aid_application.client_uploading_bank_statements? %>
+<!-- non-passported truelayer only -->
 
   <% if read_only %>
     <%= govuk_summary_card(title: t(".assets.clients_bank_accounts"),
@@ -51,98 +51,100 @@
     <% end %>
   <% end %>
 
-  <% else %>
-    <!-- passported or non-passported bank statement uploaded -->
-    <%= govuk_summary_card(title: t(".assets.client_bank_accounts"),
+<% else %>
+<!-- passported or non-passported bank statement uploaded -->
+  <%= govuk_summary_card(title: t(".assets.client_bank_accounts"),
+                         heading_level: 3,
+                         html_attributes: { id: "app-check-your-answers__bank_accounts_items", "data-test": "applicant-bank-accounts" }) do |card| %>
+    <% unless read_only %>
+      <% card.with_action do %>
+        <%= govuk_link_to(
+              t("generic.change"),
+              check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
+              "aria-label": "#{t('generic.change')} #{t('.assets.client_bank_accounts')} values",
+            ) %>
+      <% end %>
+    <% end %>
+
+    <%= card.with_summary_list(actions: false) do |summary_list| %>
+      <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__offline_current_accounts" }) do |row| %>
+        <%= row.with_key(text: @legal_aid_application&.applicant&.has_partner? ? t(".assets.client_current_account") : t(".assets.current_accounts"), classes: "govuk-!-width-one-half") %>
+        <%= row.with_value { @legal_aid_application&.savings_amount&.offline_current_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.offline_current_accounts) : t("generic.none") } %>
+      <% end %>
+      <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__offline_savings_accounts" }) do |row| %>
+        <%= row.with_key(text: @legal_aid_application&.applicant&.has_partner? ? t(".assets.client_savings_account") : t(".assets.savings_accounts"), classes: "govuk-!-width-one-half") %>
+        <%= row.with_value { @legal_aid_application&.savings_amount&.offline_savings_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.offline_savings_accounts) : t("generic.none") } %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<% if @legal_aid_application&.partner %>
+<%#  offline savings accounts for partner %>
+
+  <% change_url = if @legal_aid_application.non_passported? && !@legal_aid_application.uploading_bank_statements?
+                    :partner_bank_accounts
+                  else
+                    :offline_accounts
+                  end %>
+
+  <%= govuk_summary_card(title: t(".assets.partner_bank_accounts"),
+                         heading_level: 3,
+                         html_attributes: { "data-test": "partner-bank-accounts" }) do |card| %>
+    <% unless read_only %>
+      <% card.with_action do %>
+        <%= govuk_link_to(
+              t("generic.change"),
+              check_answer_url_for(journey_type, change_url, @legal_aid_application),
+              "aria-label": "#{t('generic.change')} #{t('.assets.partner_bank_accounts')} values",
+            ) %>
+      <% end %>
+    <% end %>
+    <%= card.with_summary_list(actions: false) do |summary_list| %>
+      <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__partner_offline_current_accounts" }) do |row| %>
+        <%= row.with_key(text: t(".assets.partner_current_account"), classes: "govuk-!-width-one-half") %>
+        <%= row.with_value { @legal_aid_application.savings_amount.partner_offline_current_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.partner_offline_current_accounts) : t("generic.none") } %>
+      <% end %>
+      <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__partner_offline_savings_accounts" }) do |row| %>
+        <%= row.with_key(text: t(".assets.partner_savings_account"), classes: "govuk-!-width-one-half") %>
+        <%= row.with_value { @legal_aid_application.savings_amount.partner_offline_savings_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.partner_offline_savings_accounts) : t("generic.none") } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% if @legal_aid_application.uploading_bank_statements? || !@legal_aid_application.non_passported? %>
+  <%#  offline savings accounts for bank statement uploads or passported %>
+
+    <%= govuk_summary_card(title: t(".assets.joint_bank_accounts"),
                            heading_level: 3,
-                           html_attributes: { id: "app-check-your-answers__bank_accounts_items", "data-test": "applicant-bank-accounts" }) do |card| %>
+                           html_attributes: { "data-test": "joint-bank-accounts" }) do |card| %>
       <% unless read_only %>
         <% card.with_action do %>
-          <%= govuk_link_to(
-                t("generic.change"),
-                check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
-                "aria-label": "#{t('generic.change')} #{t('.assets.client_bank_accounts')} values",
-              ) %>
-      <% end %>
-    <% end %>
-
-      <%= card.with_summary_list(actions: false) do |summary_list| %>
-        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__offline_current_accounts" }) do |row| %>
-          <%= row.with_key(text: @legal_aid_application&.applicant&.has_partner? ? t(".assets.client_current_account") : t(".assets.current_accounts"), classes: "govuk-!-width-one-half") %>
-          <%= row.with_value { @legal_aid_application&.savings_amount&.offline_current_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.offline_current_accounts) : t("generic.none") } %>
-        <% end %>
-        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__offline_savings_accounts" }) do |row| %>
-          <%= row.with_key(text: @legal_aid_application&.applicant&.has_partner? ? t(".assets.client_savings_account") : t(".assets.savings_accounts"), classes: "govuk-!-width-one-half") %>
-          <%= row.with_value { @legal_aid_application&.savings_amount&.offline_savings_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.offline_savings_accounts) : t("generic.none") } %>
-        <% end %>
-      <% end %>
-    <% end %>
-  <% end %>
-
-  <% if @legal_aid_application&.partner %>
-    <% change_url = if @legal_aid_application.non_passported? && !@legal_aid_application.uploading_bank_statements?
-                      :partner_bank_accounts
-                    else
-                      :offline_accounts
-                    end %>
-
-    <%#  offline savings accounts for partner %>
-    <%= govuk_summary_card(title: t(".assets.partner_bank_accounts"),
-                           heading_level: 3,
-                           html_attributes: { "data-test": "partner-bank-accounts" }) do |card| %>
-      <% unless read_only %>
-        <% card.with_action do %>
-          <%= govuk_link_to(
-                t("generic.change"),
-                check_answer_url_for(journey_type, change_url, @legal_aid_application),
-                "aria-label": "#{t('generic.change')} #{t('.assets.partner_bank_accounts')} values",
-              ) %>
+          <%= govuk_link_to(t("generic.change"),
+                            check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
+                            "aria-label": "#{t('generic.change')} #{t('.assets.joint_bank_accounts')} values") %>
         <% end %>
       <% end %>
       <%= card.with_summary_list(actions: false) do |summary_list| %>
-        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__partner_offline_current_accounts" }) do |row| %>
-          <%= row.with_key(text: t(".assets.partner_current_account"), classes: "govuk-!-width-one-half") %>
-          <%= row.with_value { @legal_aid_application.savings_amount.partner_offline_current_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.partner_offline_current_accounts) : t("generic.none") } %>
+        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__joint_offline_current_accounts" }) do |row| %>
+          <%= row.with_key(text: t(".assets.joint_current_account"), classes: "govuk-!-width-one-half") %>
+          <%= row.with_value { @legal_aid_application.savings_amount.joint_offline_current_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.joint_offline_current_accounts) : t("generic.none") } %>
         <% end %>
-        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__partner_offline_savings_accounts" }) do |row| %>
-          <%= row.with_key(text: t(".assets.partner_savings_account"), classes: "govuk-!-width-one-half") %>
-          <%= row.with_value { @legal_aid_application.savings_amount.partner_offline_savings_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.partner_offline_savings_accounts) : t("generic.none") } %>
-        <% end %>
-      <% end %>
-    <% end %>
-
-    <%#  offline savings accounts for bank statement uploads or passported %>
-    <% if @legal_aid_application.uploading_bank_statements? || !@legal_aid_application.non_passported? %>
-      <%= govuk_summary_card(title: t(".assets.joint_bank_accounts"),
-                             heading_level: 3,
-                             html_attributes: { "data-test": "joint-bank-accounts" }) do |card| %>
-        <% unless read_only %>
-          <% card.with_action do %>
-            <%= govuk_link_to(t("generic.change"),
-                              check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
-                              "aria-label": "#{t('generic.change')} #{t('.assets.joint_bank_accounts')} values") %>
-          <% end %>
-        <% end %>
-        <%= card.with_summary_list(actions: false) do |summary_list| %>
-          <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__joint_offline_current_accounts" }) do |row| %>
-            <%= row.with_key(text: t(".assets.joint_current_account"), classes: "govuk-!-width-one-half") %>
-            <%= row.with_value { @legal_aid_application.savings_amount.joint_offline_current_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.joint_offline_current_accounts) : t("generic.none") } %>
-          <% end %>
-          <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__joint_offline_savings_accounts" }) do |row| %>
-            <%= row.with_key(text: t(".assets.joint_savings_account"), classes: "govuk-!-width-one-half") %>
-            <%= row.with_value { @legal_aid_application.savings_amount.joint_offline_savings_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.joint_offline_savings_accounts) : t("generic.none") } %>
-          <% end %>
+        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__joint_offline_savings_accounts" }) do |row| %>
+          <%= row.with_key(text: t(".assets.joint_savings_account"), classes: "govuk-!-width-one-half") %>
+          <%= row.with_value { @legal_aid_application.savings_amount.joint_offline_savings_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.joint_offline_savings_accounts) : t("generic.none") } %>
         <% end %>
       <% end %>
     <% end %>
   <% end %>
+<% end %>
 
-  <%#  offline savings accounts for non-passported truelayer %>
-  <% if @legal_aid_application.non_passported? && !@legal_aid_application.uploading_bank_statements? %>
-    <div class="govuk-!-padding-bottom-9">
-      <%= render "shared/check_answers/offline_savings_accounts", read_only: %>
-    </div>
-  <% end %>
+<%#  offline savings accounts for non-passported truelayer %>
+<% if @legal_aid_application.non_passported? && !@legal_aid_application.uploading_bank_statements? %>
+  <div class="govuk-!-padding-bottom-9">
+    <%= render "shared/check_answers/offline_savings_accounts", read_only: %>
+  </div>
+<% end %>
 
 <h2 class="govuk-heading-l print-no-break-after"><%= t(".assets.savings_and_assets_heading") %></h2>
 

--- a/app/views/shared/check_answers/_assets.html.erb
+++ b/app/views/shared/check_answers/_assets.html.erb
@@ -3,75 +3,68 @@
 <% online_savings_accounts = @legal_aid_application.online_savings_accounts_balance %>
 <% online_current_accounts = @legal_aid_application.online_current_accounts_balance %>
 
-<section class="print-no-break">
-  <%= render "shared/check_answers/property", read_only:, individual: %>
-</section>
+<%= render "shared/check_answers/property", read_only:, individual: %>
 
-<section class="print-no-break">
-  <%= render "shared/check_answers/vehicles", read_only:, individual: %>
-</section>
+<%= render "shared/check_answers/vehicles", read_only:, individual: %>
 
-  <h2 class="govuk-heading-l"><%= t(".assets.bank_accounts_heading") %></h2>
+<h2 class="govuk-heading-l print-no-break-after"><%= t(".assets.bank_accounts_heading") %></h2>
 
-<section class="print-no-break">
   <% if @legal_aid_application.non_passported? && !@legal_aid_application.client_uploading_bank_statements? %>
     <!-- non-passported truelayer only -->
 
     <% if read_only %>
-      <%= govuk_summary_card(title: t(".assets.clients_bank_accounts"),
-                             heading_level: 3,
-                             html_attributes: { id: "applicant-bank-accounts-details" }) do |card| %>
-        <% unless read_only %>
-          <% card.with_action do %>
-            <%= govuk_link_to(t("generic.change"),
-                              check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
-                              "aria-label": "#{t('generic.change')} #{t('.assets.client_bank_accounts')} values") %>
+        <%= govuk_summary_card(title: t(".assets.clients_bank_accounts"),
+                               heading_level: 3,
+                               html_attributes: { id: "applicant-bank-accounts-details" }) do |card| %>
+          <% unless read_only %>
+            <% card.with_action do %>
+              <%= govuk_link_to(t("generic.change"),
+                                check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
+                                "aria-label": "#{t('generic.change')} #{t('.assets.client_bank_accounts')} values") %>
+            <% end %>
           <% end %>
-        <% end %>
 
-        <%= card.with_summary_list(actions: false) do |summary_list| %>
-          <% @legal_aid_application&.applicant&.bank_accounts&.each do |account| %>
-            <%= summary_list.with_row do |row| %>
-              <%= row.with_key(text: "#{account.name}, #{account.account_number}, #{account.sort_code}", classes: "govuk-!-width-one-half") %>
-              <%= row.with_value { gds_number_to_currency(account.balance).to_s } %>
+          <%= card.with_summary_list(actions: false) do |summary_list| %>
+            <% @legal_aid_application&.applicant&.bank_accounts&.each do |account| %>
+              <%= summary_list.with_row do |row| %>
+                <%= row.with_key(text: "#{account.name}, #{account.account_number}, #{account.sort_code}", classes: "govuk-!-width-one-half") %>
+                <%= row.with_value { gds_number_to_currency(account.balance).to_s } %>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>
-      <% end %>
 
-      <h3 class="govuk-heading-m"><%= t(".assets.total_in_bank_accounts") %></h3>
-
+    <h3 class="govuk-heading-m"><%= t(".assets.total_in_bank_accounts") %></h3>
       <%= govuk_summary_card(title: t(".assets.money_in_bank_accounts"),
                              heading_level: 3,
                              html_attributes: { "data-test": "applicant-bank-accounts" }) do |card| %>
-          <%= card.with_summary_list(actions: false) do |summary_list| %>
-            <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__online_current_accounts" }) do |row| %>
-              <%= row.with_key(text: @legal_aid_application&.applicant&.has_partner? ? t(".assets.client_current_account") : t(".assets.current_accounts"), classes: "govuk-!-width-one-half") %>
-              <%= row.with_value { online_current_accounts.present? ? gds_number_to_currency(online_current_accounts) : t("generic.none") } %>
-            <% end %>
-            <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__online_savings_accounts" }) do |row| %>
-              <%= row.with_key(text: @legal_aid_application&.applicant&.has_partner? ? t(".assets.client_savings_account") : t(".assets.savings_accounts"), classes: "govuk-!-width-one-half") %>
-              <%= row.with_value { online_savings_accounts.present? ? gds_number_to_currency(online_savings_accounts) : t("generic.none") } %>
-            <% end %>
+        <%= card.with_summary_list(actions: false) do |summary_list| %>
+          <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__online_current_accounts" }) do |row| %>
+            <%= row.with_key(text: @legal_aid_application&.applicant&.has_partner? ? t(".assets.client_current_account") : t(".assets.current_accounts"), classes: "govuk-!-width-one-half") %>
+            <%= row.with_value { online_current_accounts.present? ? gds_number_to_currency(online_current_accounts) : t("generic.none") } %>
           <% end %>
+          <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__online_savings_accounts" }) do |row| %>
+            <%= row.with_key(text: @legal_aid_application&.applicant&.has_partner? ? t(".assets.client_savings_account") : t(".assets.savings_accounts"), classes: "govuk-!-width-one-half") %>
+            <%= row.with_value { online_savings_accounts.present? ? gds_number_to_currency(online_savings_accounts) : t("generic.none") } %>
+          <% end %>
+        <% end %>
       <% end %>
-    <% end %>
+<% end %>
 
   <% else %>
     <!-- passported or non-passported bank statement uploaded -->
-
-    <%= govuk_summary_card(title: t(".assets.client_bank_accounts"),
-                           heading_level: 3,
-                           html_attributes: { id: "app-check-your-answers__bank_accounts_items", "data-test": "applicant-bank-accounts" }) do |card| %>
-      <% unless read_only %>
-        <% card.with_action do %>
-          <%= govuk_link_to(
-                t("generic.change"),
-                check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
-                "aria-label": "#{t('generic.change')} #{t('.assets.client_bank_accounts')} values",
-              ) %>
+      <%= govuk_summary_card(title: t(".assets.client_bank_accounts"),
+                             heading_level: 3,
+                             html_attributes: { id: "app-check-your-answers__bank_accounts_items", "data-test": "applicant-bank-accounts" }) do |card| %>
+        <% unless read_only %>
+          <% card.with_action do %>
+            <%= govuk_link_to(
+                  t("generic.change"),
+                  check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
+                  "aria-label": "#{t('generic.change')} #{t('.assets.client_bank_accounts')} values",
+                ) %>
+        <% end %>
       <% end %>
-    <% end %>
 
       <%= card.with_summary_list(actions: false) do |summary_list| %>
         <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__offline_current_accounts" }) do |row| %>
@@ -94,53 +87,53 @@
                     end %>
 
     <%#  offline savings accounts for partner %>
-    <%= govuk_summary_card(title: t(".assets.partner_bank_accounts"),
-                           heading_level: 3,
-                           html_attributes: { "data-test": "partner-bank-accounts" }) do |card| %>
-      <% unless read_only %>
-        <% card.with_action do %>
-          <%= govuk_link_to(
-                t("generic.change"),
-                check_answer_url_for(journey_type, change_url, @legal_aid_application),
-                "aria-label": "#{t('generic.change')} #{t('.assets.partner_bank_accounts')} values",
-              ) %>
+      <%= govuk_summary_card(title: t(".assets.partner_bank_accounts"),
+                             heading_level: 3,
+                             html_attributes: { "data-test": "partner-bank-accounts" }) do |card| %>
+        <% unless read_only %>
+          <% card.with_action do %>
+            <%= govuk_link_to(
+                  t("generic.change"),
+                  check_answer_url_for(journey_type, change_url, @legal_aid_application),
+                  "aria-label": "#{t('generic.change')} #{t('.assets.partner_bank_accounts')} values",
+                ) %>
+          <% end %>
         <% end %>
-      <% end %>
-      <%= card.with_summary_list(actions: false) do |summary_list| %>
-        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__partner_offline_current_accounts" }) do |row| %>
-          <%= row.with_key(text: t(".assets.partner_current_account"), classes: "govuk-!-width-one-half") %>
-          <%= row.with_value { @legal_aid_application.savings_amount.partner_offline_current_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.partner_offline_current_accounts) : t("generic.none") } %>
+        <%= card.with_summary_list(actions: false) do |summary_list| %>
+          <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__partner_offline_current_accounts" }) do |row| %>
+            <%= row.with_key(text: t(".assets.partner_current_account"), classes: "govuk-!-width-one-half") %>
+            <%= row.with_value { @legal_aid_application.savings_amount.partner_offline_current_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.partner_offline_current_accounts) : t("generic.none") } %>
+          <% end %>
+          <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__partner_offline_savings_accounts" }) do |row| %>
+            <%= row.with_key(text: t(".assets.partner_savings_account"), classes: "govuk-!-width-one-half") %>
+            <%= row.with_value { @legal_aid_application.savings_amount.partner_offline_savings_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.partner_offline_savings_accounts) : t("generic.none") } %>
+          <% end %>
         <% end %>
-        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__partner_offline_savings_accounts" }) do |row| %>
-          <%= row.with_key(text: t(".assets.partner_savings_account"), classes: "govuk-!-width-one-half") %>
-          <%= row.with_value { @legal_aid_application.savings_amount.partner_offline_savings_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.partner_offline_savings_accounts) : t("generic.none") } %>
-        <% end %>
-      <% end %>
     <% end %>
 
     <%#  offline savings accounts for bank statement uploads or passported %>
     <% if @legal_aid_application.uploading_bank_statements? || !@legal_aid_application.non_passported? %>
-      <%= govuk_summary_card(title: t(".assets.joint_bank_accounts"),
-                             heading_level: 3,
-                             html_attributes: { "data-test": "joint-bank-accounts" }) do |card| %>
-        <% unless read_only %>
-          <% card.with_action do %>
-            <%= govuk_link_to(t("generic.change"),
-                              check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
-                              "aria-label": "#{t('generic.change')} #{t('.assets.joint_bank_accounts')} values") %>
+        <%= govuk_summary_card(title: t(".assets.joint_bank_accounts"),
+                               heading_level: 3,
+                               html_attributes: { "data-test": "joint-bank-accounts" }) do |card| %>
+          <% unless read_only %>
+            <% card.with_action do %>
+              <%= govuk_link_to(t("generic.change"),
+                                check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
+                                "aria-label": "#{t('generic.change')} #{t('.assets.joint_bank_accounts')} values") %>
+            <% end %>
+          <% end %>
+          <%= card.with_summary_list(actions: false) do |summary_list| %>
+            <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__joint_offline_current_accounts" }) do |row| %>
+              <%= row.with_key(text: t(".assets.joint_current_account"), classes: "govuk-!-width-one-half") %>
+              <%= row.with_value { @legal_aid_application.savings_amount.joint_offline_current_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.joint_offline_current_accounts) : t("generic.none") } %>
+            <% end %>
+            <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__joint_offline_savings_accounts" }) do |row| %>
+              <%= row.with_key(text: t(".assets.joint_savings_account"), classes: "govuk-!-width-one-half") %>
+              <%= row.with_value { @legal_aid_application.savings_amount.joint_offline_savings_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.joint_offline_savings_accounts) : t("generic.none") } %>
+            <% end %>
           <% end %>
         <% end %>
-        <%= card.with_summary_list(actions: false) do |summary_list| %>
-          <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__joint_offline_current_accounts" }) do |row| %>
-            <%= row.with_key(text: t(".assets.joint_current_account"), classes: "govuk-!-width-one-half") %>
-            <%= row.with_value { @legal_aid_application.savings_amount.joint_offline_current_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.joint_offline_current_accounts) : t("generic.none") } %>
-          <% end %>
-          <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__joint_offline_savings_accounts" }) do |row| %>
-            <%= row.with_key(text: t(".assets.joint_savings_account"), classes: "govuk-!-width-one-half") %>
-            <%= row.with_value { @legal_aid_application.savings_amount.joint_offline_savings_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.joint_offline_savings_accounts) : t("generic.none") } %>
-          <% end %>
-        <% end %>
-      <% end %>
     <% end %>
   <% end %>
 
@@ -151,70 +144,66 @@
     </div>
   <% end %>
 
-  <h2 class="govuk-heading-l"><%= t(".assets.savings_and_assets_heading") %></h2>
+<h2 class="govuk-heading-l print-no-break-after"><%= t(".assets.savings_and_assets_heading") %></h2>
 
-<section class="print-no-break">
-  <%#  savings and investments %>
-  <%= govuk_summary_card(title: t(".assets.savings_and_investments#{individual}"),
-                         heading_level: 3,
-                         html_attributes: { id: "app-check-your-answers__savings_and_investments_items" }) do |card| %>
-    <% unless read_only %>
-      <% card.with_action do %>
-        <%= govuk_link_to(t("generic.change"),
-                          check_answer_url_for(journey_type, :savings_and_investments, @legal_aid_application),
-                          visually_hidden_suffix: t(".assets.savings_and_investments#{individual}")) %>
-      <% end %>
+<%#  savings and investments %>
+<%= govuk_summary_card(title: t(".assets.savings_and_investments#{individual}"),
+                       heading_level: 3,
+                       html_attributes: { id: "app-check-your-answers__savings_and_investments_items" }) do |card| %>
+  <% unless read_only %>
+    <% card.with_action do %>
+      <%= govuk_link_to(t("generic.change"),
+                        check_answer_url_for(journey_type, :savings_and_investments, @legal_aid_application),
+                        visually_hidden_suffix: t(".assets.savings_and_investments#{individual}")) %>
     <% end %>
-    <% card.with_summary_list do |summary_list| %>
-      <% if capital_amounts_list(@legal_aid_application).nil? %>
-        <% summary_list.with_row do |row| %>
-          <%= row.with_key(text: t("shared.forms.revealing_checkbox.attribute.providers.savings_and_investments.none_label"), classes: "govuk-!-width-one-half") %>
-          <%= row.with_value { t("generic.none") } %>
-        <% end %>
-      <% else %>
-        <% capital_amounts_list(@legal_aid_application).each do |item| %>
-          <%= summary_list.with_row do |row| %>
-            <%= row.with_key(text: t("shared.forms.revealing_checkbox.attribute.providers.savings_and_investments.check_box_#{item.first}"), classes: "govuk-!-width-one-half") %>
-            <%= row.with_value { gds_number_to_currency(item.second) } %>
-          <% end %>
+  <% end %>
+  <% card.with_summary_list do |summary_list| %>
+    <% if capital_amounts_list(@legal_aid_application).nil? %>
+      <% summary_list.with_row do |row| %>
+        <%= row.with_key(text: t("shared.forms.revealing_checkbox.attribute.providers.savings_and_investments.none_label"), classes: "govuk-!-width-one-half") %>
+        <%= row.with_value { t("generic.none") } %>
+      <% end %>
+    <% else %>
+      <% capital_amounts_list(@legal_aid_application).each do |item| %>
+        <%= summary_list.with_row do |row| %>
+          <%= row.with_key(text: t("shared.forms.revealing_checkbox.attribute.providers.savings_and_investments.check_box_#{item.first}"), classes: "govuk-!-width-one-half") %>
+          <%= row.with_value { gds_number_to_currency(item.second) } %>
         <% end %>
       <% end %>
     <% end %>
   <% end %>
+<% end %>
 
-<section class="print-no-break">
-  <%#  other assets %>
-  <%= govuk_summary_card(title: t(".assets.other_assets#{individual}"),
-                         heading_level: 3,
-                         html_attributes: { id: "app-check-your-answers__other_assets_items" }) do |card| %>
-    <% unless read_only %>
-      <% card.with_action do %>
-        <%= govuk_link_to(t("generic.change"),
-                          check_answer_url_for(journey_type, :other_assets, @legal_aid_application),
-                          visually_hidden_suffix: t(".assets.other_assets#{individual}")) %>
-      <% end %>
+<%#  other assets %>
+<%= govuk_summary_card(title: t(".assets.other_assets#{individual}"),
+                       heading_level: 3,
+                       html_attributes: { id: "app-check-your-answers__other_assets_items" }) do |card| %>
+  <% unless read_only %>
+    <% card.with_action do %>
+      <%= govuk_link_to(t("generic.change"),
+                        check_answer_url_for(journey_type, :other_assets, @legal_aid_application),
+                        visually_hidden_suffix: t(".assets.other_assets#{individual}")) %>
     <% end %>
-    <% card.with_summary_list do |summary_list| %>
-      <% if capital_assets_list(@legal_aid_application).nil? %>
-        <% summary_list.with_row do |row| %>
-          <%= row.with_key(text: t("shared.forms.revealing_checkbox.attribute.providers.other_assets.none_label"), classes: "govuk-!-width-one-half") %>
-          <%= row.with_value { t("generic.none") } %>
-        <% end %>
-      <% else %>
-        <% capital_assets_list(@legal_aid_application).each do |item| %>
-          <%= summary_list.with_row do |row| %>
-            <%= row.with_key(text: t("shared.forms.revealing_checkbox.attribute.providers.other_assets.check_box_#{item.first}"), classes: "govuk-!-width-one-half") %>
-            <%= row.with_value { item.first.eql?("second_home_percentage") ? capital_amount_text(item.second, :percentage) : gds_number_to_currency(item.second) } %>
-          <% end %>
+  <% end %>
+  <% card.with_summary_list do |summary_list| %>
+    <% if capital_assets_list(@legal_aid_application).nil? %>
+      <% summary_list.with_row do |row| %>
+        <%= row.with_key(text: t("shared.forms.revealing_checkbox.attribute.providers.other_assets.none_label"), classes: "govuk-!-width-one-half") %>
+        <%= row.with_value { t("generic.none") } %>
+      <% end %>
+    <% else %>
+      <% capital_assets_list(@legal_aid_application).each do |item| %>
+        <%= summary_list.with_row do |row| %>
+          <%= row.with_key(text: t("shared.forms.revealing_checkbox.attribute.providers.other_assets.check_box_#{item.first}"), classes: "govuk-!-width-one-half") %>
+          <%= row.with_value { item.first.eql?("second_home_percentage") ? capital_amount_text(item.second, :percentage) : gds_number_to_currency(item.second) } %>
         <% end %>
       <% end %>
     <% end %>
   <% end %>
+<% end %>
 
-<section class="print-no-break">
-  <%#  asset restrictions %>
-  <%= render("shared/check_answers/restrictions", read_only:, individual:) if @legal_aid_application.own_capital? %>
-</section>
+<%#  asset restrictions %>
+<%= render("shared/check_answers/restrictions", read_only:, individual:) if @legal_aid_application.own_capital? %>
 
   <%#  policy disregards - to be removed as part of AP-5510 when there are no applications with policy disregards %>
   <% if @legal_aid_application.policy_disregards.present? %>
@@ -234,4 +223,3 @@
   <% else %>
     <%= render("shared/check_answers/capital_disregards", read_only:, individual:) %>
   <% end %>
-</section>

--- a/app/views/shared/check_answers/_assets.html.erb
+++ b/app/views/shared/check_answers/_assets.html.erb
@@ -12,59 +12,59 @@
   <% if @legal_aid_application.non_passported? && !@legal_aid_application.client_uploading_bank_statements? %>
     <!-- non-passported truelayer only -->
 
-    <% if read_only %>
-        <%= govuk_summary_card(title: t(".assets.clients_bank_accounts"),
-                               heading_level: 3,
-                               html_attributes: { id: "applicant-bank-accounts-details" }) do |card| %>
-          <% unless read_only %>
-            <% card.with_action do %>
-              <%= govuk_link_to(t("generic.change"),
-                                check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
-                                "aria-label": "#{t('generic.change')} #{t('.assets.client_bank_accounts')} values") %>
-            <% end %>
-          <% end %>
-
-          <%= card.with_summary_list(actions: false) do |summary_list| %>
-            <% @legal_aid_application&.applicant&.bank_accounts&.each do |account| %>
-              <%= summary_list.with_row do |row| %>
-                <%= row.with_key(text: "#{account.name}, #{account.account_number}, #{account.sort_code}", classes: "govuk-!-width-one-half") %>
-                <%= row.with_value { gds_number_to_currency(account.balance).to_s } %>
-              <% end %>
-            <% end %>
-          <% end %>
+  <% if read_only %>
+    <%= govuk_summary_card(title: t(".assets.clients_bank_accounts"),
+                           heading_level: 3,
+                           html_attributes: { id: "applicant-bank-accounts-details" }) do |card| %>
+      <% unless read_only %>
+        <% card.with_action do %>
+          <%= govuk_link_to(t("generic.change"),
+                            check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
+                            "aria-label": "#{t('generic.change')} #{t('.assets.client_bank_accounts')} values") %>
         <% end %>
+      <% end %>
 
-    <h3 class="govuk-heading-m"><%= t(".assets.total_in_bank_accounts") %></h3>
-      <%= govuk_summary_card(title: t(".assets.money_in_bank_accounts"),
-                             heading_level: 3,
-                             html_attributes: { "data-test": "applicant-bank-accounts" }) do |card| %>
-        <%= card.with_summary_list(actions: false) do |summary_list| %>
-          <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__online_current_accounts" }) do |row| %>
-            <%= row.with_key(text: @legal_aid_application&.applicant&.has_partner? ? t(".assets.client_current_account") : t(".assets.current_accounts"), classes: "govuk-!-width-one-half") %>
-            <%= row.with_value { online_current_accounts.present? ? gds_number_to_currency(online_current_accounts) : t("generic.none") } %>
-          <% end %>
-          <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__online_savings_accounts" }) do |row| %>
-            <%= row.with_key(text: @legal_aid_application&.applicant&.has_partner? ? t(".assets.client_savings_account") : t(".assets.savings_accounts"), classes: "govuk-!-width-one-half") %>
-            <%= row.with_value { online_savings_accounts.present? ? gds_number_to_currency(online_savings_accounts) : t("generic.none") } %>
+      <%= card.with_summary_list(actions: false) do |summary_list| %>
+        <% @legal_aid_application&.applicant&.bank_accounts&.each do |account| %>
+          <%= summary_list.with_row do |row| %>
+            <%= row.with_key(text: "#{account.name}, #{account.account_number}, #{account.sort_code}", classes: "govuk-!-width-one-half") %>
+            <%= row.with_value { gds_number_to_currency(account.balance).to_s } %>
           <% end %>
         <% end %>
       <% end %>
-<% end %>
+    <% end %>
+
+    <h3 class="govuk-heading-m print-no-break-after"><%= t(".assets.total_in_bank_accounts") %></h3>
+    <%= govuk_summary_card(title: t(".assets.money_in_bank_accounts"),
+                           heading_level: 3,
+                           html_attributes: { "data-test": "applicant-bank-accounts" }) do |card| %>
+      <%= card.with_summary_list(actions: false) do |summary_list| %>
+        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__online_current_accounts" }) do |row| %>
+          <%= row.with_key(text: @legal_aid_application&.applicant&.has_partner? ? t(".assets.client_current_account") : t(".assets.current_accounts"), classes: "govuk-!-width-one-half") %>
+          <%= row.with_value { online_current_accounts.present? ? gds_number_to_currency(online_current_accounts) : t("generic.none") } %>
+        <% end %>
+        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__online_savings_accounts" }) do |row| %>
+          <%= row.with_key(text: @legal_aid_application&.applicant&.has_partner? ? t(".assets.client_savings_account") : t(".assets.savings_accounts"), classes: "govuk-!-width-one-half") %>
+          <%= row.with_value { online_savings_accounts.present? ? gds_number_to_currency(online_savings_accounts) : t("generic.none") } %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
 
   <% else %>
     <!-- passported or non-passported bank statement uploaded -->
-      <%= govuk_summary_card(title: t(".assets.client_bank_accounts"),
-                             heading_level: 3,
-                             html_attributes: { id: "app-check-your-answers__bank_accounts_items", "data-test": "applicant-bank-accounts" }) do |card| %>
-        <% unless read_only %>
-          <% card.with_action do %>
-            <%= govuk_link_to(
-                  t("generic.change"),
-                  check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
-                  "aria-label": "#{t('generic.change')} #{t('.assets.client_bank_accounts')} values",
-                ) %>
-        <% end %>
+    <%= govuk_summary_card(title: t(".assets.client_bank_accounts"),
+                           heading_level: 3,
+                           html_attributes: { id: "app-check-your-answers__bank_accounts_items", "data-test": "applicant-bank-accounts" }) do |card| %>
+      <% unless read_only %>
+        <% card.with_action do %>
+          <%= govuk_link_to(
+                t("generic.change"),
+                check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
+                "aria-label": "#{t('generic.change')} #{t('.assets.client_bank_accounts')} values",
+              ) %>
       <% end %>
+    <% end %>
 
       <%= card.with_summary_list(actions: false) do |summary_list| %>
         <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__offline_current_accounts" }) do |row| %>
@@ -87,53 +87,53 @@
                     end %>
 
     <%#  offline savings accounts for partner %>
-      <%= govuk_summary_card(title: t(".assets.partner_bank_accounts"),
-                             heading_level: 3,
-                             html_attributes: { "data-test": "partner-bank-accounts" }) do |card| %>
-        <% unless read_only %>
-          <% card.with_action do %>
-            <%= govuk_link_to(
-                  t("generic.change"),
-                  check_answer_url_for(journey_type, change_url, @legal_aid_application),
-                  "aria-label": "#{t('generic.change')} #{t('.assets.partner_bank_accounts')} values",
-                ) %>
-          <% end %>
+    <%= govuk_summary_card(title: t(".assets.partner_bank_accounts"),
+                           heading_level: 3,
+                           html_attributes: { "data-test": "partner-bank-accounts" }) do |card| %>
+      <% unless read_only %>
+        <% card.with_action do %>
+          <%= govuk_link_to(
+                t("generic.change"),
+                check_answer_url_for(journey_type, change_url, @legal_aid_application),
+                "aria-label": "#{t('generic.change')} #{t('.assets.partner_bank_accounts')} values",
+              ) %>
         <% end %>
-        <%= card.with_summary_list(actions: false) do |summary_list| %>
-          <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__partner_offline_current_accounts" }) do |row| %>
-            <%= row.with_key(text: t(".assets.partner_current_account"), classes: "govuk-!-width-one-half") %>
-            <%= row.with_value { @legal_aid_application.savings_amount.partner_offline_current_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.partner_offline_current_accounts) : t("generic.none") } %>
-          <% end %>
-          <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__partner_offline_savings_accounts" }) do |row| %>
-            <%= row.with_key(text: t(".assets.partner_savings_account"), classes: "govuk-!-width-one-half") %>
-            <%= row.with_value { @legal_aid_application.savings_amount.partner_offline_savings_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.partner_offline_savings_accounts) : t("generic.none") } %>
-          <% end %>
+      <% end %>
+      <%= card.with_summary_list(actions: false) do |summary_list| %>
+        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__partner_offline_current_accounts" }) do |row| %>
+          <%= row.with_key(text: t(".assets.partner_current_account"), classes: "govuk-!-width-one-half") %>
+          <%= row.with_value { @legal_aid_application.savings_amount.partner_offline_current_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.partner_offline_current_accounts) : t("generic.none") } %>
         <% end %>
+        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__partner_offline_savings_accounts" }) do |row| %>
+          <%= row.with_key(text: t(".assets.partner_savings_account"), classes: "govuk-!-width-one-half") %>
+          <%= row.with_value { @legal_aid_application.savings_amount.partner_offline_savings_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.partner_offline_savings_accounts) : t("generic.none") } %>
+        <% end %>
+      <% end %>
     <% end %>
 
     <%#  offline savings accounts for bank statement uploads or passported %>
     <% if @legal_aid_application.uploading_bank_statements? || !@legal_aid_application.non_passported? %>
-        <%= govuk_summary_card(title: t(".assets.joint_bank_accounts"),
-                               heading_level: 3,
-                               html_attributes: { "data-test": "joint-bank-accounts" }) do |card| %>
-          <% unless read_only %>
-            <% card.with_action do %>
-              <%= govuk_link_to(t("generic.change"),
-                                check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
-                                "aria-label": "#{t('generic.change')} #{t('.assets.joint_bank_accounts')} values") %>
-            <% end %>
-          <% end %>
-          <%= card.with_summary_list(actions: false) do |summary_list| %>
-            <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__joint_offline_current_accounts" }) do |row| %>
-              <%= row.with_key(text: t(".assets.joint_current_account"), classes: "govuk-!-width-one-half") %>
-              <%= row.with_value { @legal_aid_application.savings_amount.joint_offline_current_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.joint_offline_current_accounts) : t("generic.none") } %>
-            <% end %>
-            <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__joint_offline_savings_accounts" }) do |row| %>
-              <%= row.with_key(text: t(".assets.joint_savings_account"), classes: "govuk-!-width-one-half") %>
-              <%= row.with_value { @legal_aid_application.savings_amount.joint_offline_savings_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.joint_offline_savings_accounts) : t("generic.none") } %>
-            <% end %>
+      <%= govuk_summary_card(title: t(".assets.joint_bank_accounts"),
+                             heading_level: 3,
+                             html_attributes: { "data-test": "joint-bank-accounts" }) do |card| %>
+        <% unless read_only %>
+          <% card.with_action do %>
+            <%= govuk_link_to(t("generic.change"),
+                              check_answer_url_for(journey_type, :offline_accounts, @legal_aid_application),
+                              "aria-label": "#{t('generic.change')} #{t('.assets.joint_bank_accounts')} values") %>
           <% end %>
         <% end %>
+        <%= card.with_summary_list(actions: false) do |summary_list| %>
+          <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__joint_offline_current_accounts" }) do |row| %>
+            <%= row.with_key(text: t(".assets.joint_current_account"), classes: "govuk-!-width-one-half") %>
+            <%= row.with_value { @legal_aid_application.savings_amount.joint_offline_current_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.joint_offline_current_accounts) : t("generic.none") } %>
+          <% end %>
+          <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__joint_offline_savings_accounts" }) do |row| %>
+            <%= row.with_key(text: t(".assets.joint_savings_account"), classes: "govuk-!-width-one-half") %>
+            <%= row.with_value { @legal_aid_application.savings_amount.joint_offline_savings_accounts.present? ? gds_number_to_currency(@legal_aid_application.savings_amount.joint_offline_savings_accounts) : t("generic.none") } %>
+          <% end %>
+        <% end %>
+      <% end %>
     <% end %>
   <% end %>
 
@@ -205,21 +205,21 @@
 <%#  asset restrictions %>
 <%= render("shared/check_answers/restrictions", read_only:, individual:) if @legal_aid_application.own_capital? %>
 
-  <%#  policy disregards - to be removed as part of AP-5510 when there are no applications with policy disregards %>
-  <% if @legal_aid_application.policy_disregards.present? %>
-    <%= render(
-          "shared/check_answers/one_link_section",
-          name: :policy_disregards,
-          url: check_answer_url_for(journey_type, :policy_disregards, @legal_aid_application),
-          question: t(".assets.policy_disregards#{individual}"),
-          answer_hash: policy_disregards_list(@legal_aid_application.policy_disregards),
-          read_only:,
-        ) %>
-  <% end %>
+<%#  policy disregards - to be removed as part of AP-5510 when there are no applications with policy disregards %>
+<% if @legal_aid_application.policy_disregards.present? %>
+  <%= render(
+        "shared/check_answers/one_link_section",
+        name: :policy_disregards,
+        url: check_answer_url_for(journey_type, :policy_disregards, @legal_aid_application),
+        question: t(".assets.policy_disregards#{individual}"),
+        answer_hash: policy_disregards_list(@legal_aid_application.policy_disregards),
+        read_only:,
+      ) %>
+<% end %>
 
-  <%#  capital disregards %>
-  <% if means_report %>
-    <%= render("providers/means_reports/capital_disregards", read_only:, individual:) %>
-  <% else %>
-    <%= render("shared/check_answers/capital_disregards", read_only:, individual:) %>
-  <% end %>
+<%#  capital disregards %>
+<% if means_report %>
+  <%= render("providers/means_reports/capital_disregards", read_only:, individual:) %>
+<% else %>
+  <%= render("shared/check_answers/capital_disregards", read_only:, individual:) %>
+<% end %>

--- a/app/views/shared/check_answers/_assets.html.erb
+++ b/app/views/shared/check_answers/_assets.html.erb
@@ -9,9 +9,11 @@
 
 <section class="print-no-break">
   <%= render "shared/check_answers/vehicles", read_only:, individual: %>
+</section>
 
   <h2 class="govuk-heading-l"><%= t(".assets.bank_accounts_heading") %></h2>
 
+<section class="print-no-break">
   <% if @legal_aid_application.non_passported? && !@legal_aid_application.client_uploading_bank_statements? %>
     <!-- non-passported truelayer only -->
 
@@ -151,6 +153,7 @@
 
   <h2 class="govuk-heading-l"><%= t(".assets.savings_and_assets_heading") %></h2>
 
+<section class="print-no-break">
   <%#  savings and investments %>
   <%= govuk_summary_card(title: t(".assets.savings_and_investments#{individual}"),
                          heading_level: 3,
@@ -179,6 +182,7 @@
     <% end %>
   <% end %>
 
+<section class="print-no-break">
   <%#  other assets %>
   <%= govuk_summary_card(title: t(".assets.other_assets#{individual}"),
                          heading_level: 3,
@@ -207,8 +211,10 @@
     <% end %>
   <% end %>
 
+<section class="print-no-break">
   <%#  asset restrictions %>
   <%= render("shared/check_answers/restrictions", read_only:, individual:) if @legal_aid_application.own_capital? %>
+</section>
 
   <%#  policy disregards - to be removed as part of AP-5510 when there are no applications with policy disregards %>
   <% if @legal_aid_application.policy_disregards.present? %>

--- a/app/views/shared/check_answers/_one_link_section.html.erb
+++ b/app/views/shared/check_answers/_one_link_section.html.erb
@@ -13,28 +13,29 @@
   <% end %>
 </div>
 
-<%= govuk_summary_list(
-      card: { title: question },
-      actions: !read_only,
-      html_attributes: { id: "app-check-your-answers__#{name}_items" },
-    ) do |summary_list| %>
-  <% if answer_hash.present? %>
-    <% answer_hash&.fetch(:items, [])&.each_with_index do |item, index| %>
-      <% name = item.name || "#{name}_#{index}" %>
+  <%= govuk_summary_list(
+        card: { title: question },
+        actions: !read_only,
+        html_attributes: { id: "app-check-your-answers__#{name}_items" },
+      ) do |summary_list| %>
+    <% if answer_hash.present? %>
+      <% answer_hash&.fetch(:items, [])&.each_with_index do |item, index| %>
+        <% name = item.name || "#{name}_#{index}" %>
+        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{name}" }) do |row| %>
+          <%= row.with_key(text: item.label, classes: "govuk-!-width-one-half") %>
+          <%= row.with_value { safe_yes_or_no(item.amount_text) } %>
+        <% end %>
+      <% end %>
+    <% else %>
       <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{name}" }) do |row| %>
-        <%= row.with_key(text: item.label, classes: "govuk-!-width-one-half") %>
-        <%= row.with_value { safe_yes_or_no(item.amount_text) } %>
+        <%= row.with_key(text: question, classes: "govuk-!-width-one-half") %>
+        <%= row.with_value { t("generic.none_declared") } %>
+        <%= row.with_action(
+              text: t("generic.change"),
+              href: url,
+              visually_hidden_text: question,
+            ) %>
       <% end %>
     <% end %>
-  <% else %>
-    <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{name}" }) do |row| %>
-      <%= row.with_key(text: question, classes: "govuk-!-width-one-half") %>
-      <%= row.with_value { t("generic.none_declared") } %>
-      <%= row.with_action(
-            text: t("generic.change"),
-            href: url,
-            visually_hidden_text: question,
-          ) %>
-    <% end %>
   <% end %>
-<% end %>
+</section>

--- a/app/views/shared/check_answers/_one_link_section.html.erb
+++ b/app/views/shared/check_answers/_one_link_section.html.erb
@@ -13,29 +13,28 @@
   <% end %>
 </div>
 
-  <%= govuk_summary_list(
-        card: { title: question },
-        actions: !read_only,
-        html_attributes: { id: "app-check-your-answers__#{name}_items" },
-      ) do |summary_list| %>
-    <% if answer_hash.present? %>
-      <% answer_hash&.fetch(:items, [])&.each_with_index do |item, index| %>
-        <% name = item.name || "#{name}_#{index}" %>
-        <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{name}" }) do |row| %>
-          <%= row.with_key(text: item.label, classes: "govuk-!-width-one-half") %>
-          <%= row.with_value { safe_yes_or_no(item.amount_text) } %>
-        <% end %>
-      <% end %>
-    <% else %>
+<%= govuk_summary_list(
+      card: { title: question },
+      actions: !read_only,
+      html_attributes: { id: "app-check-your-answers__#{name}_items" },
+    ) do |summary_list| %>
+  <% if answer_hash.present? %>
+    <% answer_hash&.fetch(:items, [])&.each_with_index do |item, index| %>
+      <% name = item.name || "#{name}_#{index}" %>
       <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{name}" }) do |row| %>
-        <%= row.with_key(text: question, classes: "govuk-!-width-one-half") %>
-        <%= row.with_value { t("generic.none_declared") } %>
-        <%= row.with_action(
-              text: t("generic.change"),
-              href: url,
-              visually_hidden_text: question,
-            ) %>
+        <%= row.with_key(text: item.label, classes: "govuk-!-width-one-half") %>
+        <%= row.with_value { safe_yes_or_no(item.amount_text) } %>
       <% end %>
     <% end %>
+  <% else %>
+    <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{name}" }) do |row| %>
+      <%= row.with_key(text: question, classes: "govuk-!-width-one-half") %>
+      <%= row.with_value { t("generic.none_declared") } %>
+      <%= row.with_action(
+            text: t("generic.change"),
+            href: url,
+            visually_hidden_text: question,
+          ) %>
+    <% end %>
   <% end %>
-</section>
+<% end %>

--- a/app/views/shared/check_answers/_property.html.erb
+++ b/app/views/shared/check_answers/_property.html.erb
@@ -20,7 +20,8 @@
 <% end %>
 
 <% if @legal_aid_application.own_home? %>
-  <%= govuk_summary_card(title: t("shared.check_answers.assets.property.heading_property_details#{individual}"), heading_level: 3,
+  <%= govuk_summary_card(title: t("shared.check_answers.assets.property.heading_property_details#{individual}"),
+                         heading_level: 3,
                          html_attributes: { id: "app-check-your-answers__property_details_questions" }) do |card| %>
     <% unless read_only %>
       <% card.with_action do %>

--- a/app/views/shared/check_answers/_vehicles.html.erb
+++ b/app/views/shared/check_answers/_vehicles.html.erb
@@ -1,6 +1,6 @@
 <% read_only = false unless local_assigns[:read_only] %>
 
-<h2 class="govuk-heading-l"><%= t(".#{journey_type}.heading") %></h2>
+<h2 class="govuk-heading-l print-no-break-after"><%= t(".#{journey_type}.heading") %></h2>
 <%= govuk_summary_card(title: t(".#{journey_type}.card_heading"), heading_level: 3, html_attributes: { id: "app-check-your-answers__vehicles" }) do |card| %>
   <% card.with_action do %>
     <% if !read_only %>


### PR DESCRIPTION
## What

[Means reports - Headings appearing on separate pages to content.](https://dsdmoj.atlassian.net/browse/AP-5753)

Connect headings with sections on Means report so that sections are printed on the same page.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
