### PR TITLE
AP-5796: Fix mismatched HTML tag

### DIFF
--- a/app/views/providers/check_capital_answers/show.html.erb
+++ b/app/views/providers/check_capital_answers/show.html.erb
@@ -10,7 +10,7 @@
 
   <%= render "shared/check_answers/assets", individual: %>
 
-  <h3 class="govuk-heading-m"><%= t(".what_happens_next.heading") %></h3>
+  <h2 class="govuk-heading-m"><%= t(".what_happens_next.heading") %></h2>
   <p class="govuk-body govuk-!-margin-bottom-7"><%= t(".what_happens_next.text") %></p>
 
   <%= next_action_buttons_with_form(

--- a/app/views/providers/check_passported_answers/show.html.erb
+++ b/app/views/providers/check_passported_answers/show.html.erb
@@ -11,7 +11,7 @@
 
   <%= render "shared/check_answers/assets", individual: %>
 
-  <h3 class="govuk-heading-m"><%= t(".what_happens_next") %></h2>
+  <h2 class="govuk-heading-m"><%= t(".what_happens_next") %></h2>
 
   <p class="govuk-body"><%= t(".what_happens_next_body") %></p>
 

--- a/app/views/providers/means/check_income_answers/show.html.erb
+++ b/app/views/providers/means/check_income_answers/show.html.erb
@@ -26,7 +26,7 @@
 
   <%= render "shared/check_answers/dependants" %>
 
-  <h3 class="govuk-heading-m"><%= t(".what_happens_next.heading") %></h3>
+  <h2 class="govuk-heading-m"><%= t(".what_happens_next.heading") %></h2>
   <p class="govuk-body govuk-!-margin-bottom-8"><%= t(".what_happens_next.text", individual:) %></p>
 
   <%= next_action_buttons_with_form(

--- a/features/providers/check_capital_answers.feature
+++ b/features/providers/check_capital_answers.feature
@@ -22,7 +22,7 @@ Feature: Check capital income answers
       | h3  | One-off payments your client received |
       | h3  | Disregarded payment 1 |
       | h3  | Payment to be reviewed 1 |
-      | h3  | What happens next |
+      | h2  | What happens next |
 
     Then the following sections should not exist:
       | tag | section |
@@ -68,7 +68,7 @@ Feature: Check capital income answers
       | h3  | One-off payments your client received |
       | h3  | Disregarded payment 1 |
       | h3  | Payment to be reviewed 1 |
-      | h3  | What happens next |
+      | h2  | What happens next |
 
     Then the following sections should not exist:
       | tag | section |
@@ -114,7 +114,7 @@ Feature: Check capital income answers
       | h3  | One-off payments your client received |
       | h3  | Disregarded payment 1 |
       | h3  | Payment to be reviewed 1 |
-      | h3  | What happens next |
+      | h2  | What happens next |
 
     Then the following sections should not exist:
       | tag | section |
@@ -162,7 +162,7 @@ Feature: Check capital income answers
       | h3  | Restrictions on your client or their partner's assets |
       | h3  | One-off payments your client or their partner received |
       | h3  | Payment to be reviewed 1 |
-      | h3  | What happens next |
+      | h2  | What happens next |
 
     Then the following sections should not exist:
       | tag | section |
@@ -208,7 +208,7 @@ Feature: Check capital income answers
       | h3  | One-off payments your client or their partner received |
       | h3  | Disregarded payment 1 |
       | h3  | Payment to be reviewed 1 |
-      | h3  | What happens next |
+      | h2  | What happens next |
 
     Then the following sections should not exist:
       | tag | section |
@@ -254,7 +254,7 @@ Feature: Check capital income answers
       | h3  | One-off payments your client or their partner received |
       | h3  | Disregarded payment 1 |
       | h3  | Payment to be reviewed 1 |
-      | h3  | What happens next |
+      | h2  | What happens next |
 
     Then the following sections should not exist:
       | tag | section |


### PR DESCRIPTION
## What
[Link to story](https://dsdmoj.atlassian.net/browse/AP-5796)

These pages had H3 What happens next links, but they (confirmed with Design) should have been H2's

One had a mismatched opening  and close tag  this reverts it back to an h2, and updates some others.  Ensuring the tests still pass

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
