### PR TITLE
Chore: add link to standards to pull request template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -8,9 +8,9 @@ Describe what you did and why.
 
 Before you ask people to review this PR:
 
-- Tests and rubocop should be passing: `bundle exec rake`
+- Tests and rubocop should be passing: `bundle exec rake`.
 - Github should not be reporting conflicts; you should have recently run `git rebase main`.
-- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed
+- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
 - There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
 - The PR description should say what you changed and why, with a link to the JIRA story.
 - You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -10,7 +10,7 @@ Before you ask people to review this PR:
 
 - Tests and rubocop should be passing: `bundle exec rake`
 - Github should not be reporting conflicts; you should have recently run `git rebase main`.
-- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
+- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed
 - There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
 - The PR description should say what you changed and why, with a link to the JIRA story.
 - You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.


### PR DESCRIPTION
## What

add link to standards to pull request template

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
