### PR TITLE
AP-5580: Move SCA parental responsibility merits question to application

### DIFF
--- a/db/migrate/20250213135157_add_relationship_to_children_to_applicant.rb
+++ b/db/migrate/20250213135157_add_relationship_to_children_to_applicant.rb
@@ -1,0 +1,5 @@
+class AddRelationshipToChildrenToApplicant < ActiveRecord::Migration[7.2]
+  def change
+    add_column :applicants, :relationship_to_children, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -152,6 +152,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.boolean "shared_benefit_with_partner"
     t.boolean "applied_previously"
     t.string "previous_reference"
+    t.string "relationship_to_children"
     t.index ["confirmation_token"], name: "index_applicants_on_confirmation_token", unique: true
     t.index ["email"], name: "index_applicants_on_email"
     t.index ["unlock_token"], name: "index_applicants_on_unlock_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
 
-  create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "active_storage_attachments", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.uuid "record_id", null: false
     t.string "record_type", null: false
@@ -24,7 +24,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "active_storage_blobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -42,7 +42,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "actor_permissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "actor_permissions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "permittable_type"
     t.uuid "permittable_id"
     t.uuid "permission_id"
@@ -52,7 +52,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["permittable_type", "permittable_id"], name: "index_actor_permissions_on_permittable_type_and_permittable_id"
   end
 
-  create_table "addresses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "addresses", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "address_line_one"
     t.string "address_line_two"
     t.string "city"
@@ -76,12 +76,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["applicant_id"], name: "index_addresses_on_applicant_id"
   end
 
-  create_table "admin_reports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "admin_reports", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "admin_users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "admin_users", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "username", default: "", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -96,7 +96,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "allegations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "allegations", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.boolean "denies_all"
     t.string "additional_information"
@@ -115,7 +115,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["legal_aid_application_id"], name: "index_appeals_on_legal_aid_application_id"
   end
 
-  create_table "applicants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "applicants", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "first_name"
     t.date "date_of_birth"
     t.datetime "created_at", precision: nil, null: false
@@ -158,7 +158,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["unlock_token"], name: "index_applicants_on_unlock_token", unique: true
   end
 
-  create_table "application_digests", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "application_digests", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.string "firm_name", null: false
     t.string "provider_username", null: false
@@ -203,7 +203,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["legal_aid_application_id"], name: "index_application_digests_on_legal_aid_application_id", unique: true
   end
 
-  create_table "attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "attachments", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.string "attachment_type"
     t.uuid "pdf_attachment_id"
@@ -213,7 +213,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.text "original_filename"
   end
 
-  create_table "attempts_to_settles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "attempts_to_settles", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.text "attempts_made"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -221,7 +221,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["proceeding_id"], name: "index_attempts_to_settles_on_proceeding_id"
   end
 
-  create_table "bank_account_holders", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "bank_account_holders", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "bank_provider_id", null: false
     t.json "true_layer_response"
     t.string "full_name"
@@ -232,7 +232,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["bank_provider_id"], name: "index_bank_account_holders_on_bank_provider_id"
   end
 
-  create_table "bank_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "bank_accounts", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "bank_provider_id", null: false
     t.json "true_layer_response"
     t.json "true_layer_balance_response"
@@ -248,7 +248,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["bank_provider_id"], name: "index_bank_accounts_on_bank_provider_id"
   end
 
-  create_table "bank_errors", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "bank_errors", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "applicant_id", null: false
     t.string "bank_name"
     t.text "error"
@@ -257,13 +257,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["applicant_id"], name: "index_bank_errors_on_applicant_id"
   end
 
-  create_table "bank_holidays", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "bank_holidays", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.text "dates"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "bank_providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "bank_providers", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "applicant_id", null: false
     t.json "true_layer_response"
     t.string "credentials_id"
@@ -275,7 +275,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["true_layer_provider_id", "applicant_id"], name: "index_bank_providers_on_true_layer_provider_id_and_applicant_id", unique: true
   end
 
-  create_table "bank_transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "bank_transactions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "bank_account_id", null: false
     t.json "true_layer_response"
     t.string "true_layer_id"
@@ -295,7 +295,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["transaction_type_id"], name: "index_bank_transactions_on_transaction_type_id"
   end
 
-  create_table "benefit_check_results", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "benefit_check_results", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.string "result"
     t.string "dwp_ref"
@@ -318,7 +318,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["legal_aid_application_id"], name: "index_capital_disregards_on_legal_aid_application_id"
   end
 
-  create_table "cash_transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "cash_transactions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "legal_aid_application_id"
     t.decimal "amount"
     t.date "transaction_date"
@@ -332,13 +332,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["owner_type", "owner_id"], name: "index_cash_transactions_on_owner"
   end
 
-  create_table "ccms_opponent_ids", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "ccms_opponent_ids", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.integer "serial_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "ccms_submission_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "ccms_submission_documents", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "submission_id"
     t.string "status"
     t.string "document_type"
@@ -348,7 +348,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.uuid "attachment_id"
   end
 
-  create_table "ccms_submission_histories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "ccms_submission_histories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "submission_id", null: false
     t.string "from_state"
     t.string "to_state"
@@ -361,7 +361,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["submission_id"], name: "index_ccms_submission_histories_on_submission_id"
   end
 
-  create_table "ccms_submissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "ccms_submissions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.string "applicant_ccms_reference"
     t.string "case_ccms_reference"
@@ -375,7 +375,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["legal_aid_application_id"], name: "index_ccms_submissions_on_legal_aid_application_id"
   end
 
-  create_table "cfe_results", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "cfe_results", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.uuid "submission_id"
     t.text "result"
@@ -384,7 +384,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.string "type", default: "CFE::V1::Result"
   end
 
-  create_table "cfe_submission_histories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "cfe_submission_histories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "submission_id"
     t.string "url"
     t.string "http_method"
@@ -397,7 +397,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "cfe_submissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "cfe_submissions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.uuid "assessment_id"
     t.string "aasm_state"
@@ -408,7 +408,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["legal_aid_application_id"], name: "index_cfe_submissions_on_legal_aid_application_id"
   end
 
-  create_table "chances_of_successes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "chances_of_successes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.text "application_purpose"
@@ -429,7 +429,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["proceeding_id"], name: "index_child_care_assessments_on_proceeding_id"
   end
 
-  create_table "citizen_access_tokens", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "citizen_access_tokens", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.string "token", default: "", null: false
     t.date "expires_on", null: false
@@ -438,7 +438,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["legal_aid_application_id"], name: "index_citizen_access_tokens_on_legal_aid_application_id"
   end
 
-  create_table "debugs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "debugs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "debug_type"
     t.string "legal_aid_application_id"
     t.string "session_id"
@@ -452,7 +452,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.string "browser_details"
   end
 
-  create_table "dependants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "dependants", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.integer "number"
     t.string "name"
@@ -468,7 +468,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["legal_aid_application_id"], name: "index_dependants_on_legal_aid_application_id"
   end
 
-  create_table "document_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "document_categories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.boolean "submit_to_ccms", default: false, null: false
     t.string "ccms_document_type"
@@ -480,7 +480,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.string "description"
   end
 
-  create_table "domestic_abuse_summaries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "domestic_abuse_summaries", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.boolean "warning_letter_sent"
     t.text "warning_letter_sent_details"
@@ -493,7 +493,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["legal_aid_application_id"], name: "index_domestic_abuse_summaries_on_legal_aid_application_id"
   end
 
-  create_table "dwp_overrides", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "dwp_overrides", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.text "passporting_benefit"
     t.boolean "has_evidence_of_benefit"
@@ -502,7 +502,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["legal_aid_application_id"], name: "index_dwp_overrides_on_legal_aid_application_id", unique: true
   end
 
-  create_table "employment_payments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "employment_payments", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "employment_id"
     t.date "date", null: false
     t.decimal "gross", default: "0.0", null: false
@@ -515,7 +515,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["employment_id"], name: "index_employment_payments_on_employment_id"
   end
 
-  create_table "employments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "employments", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -526,7 +526,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["owner_type", "owner_id"], name: "index_employments_on_owner"
   end
 
-  create_table "feedbacks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "feedbacks", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.boolean "done_all_needed"
     t.integer "satisfaction"
     t.text "improvement_suggestion"
@@ -542,7 +542,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.uuid "legal_aid_application_id"
   end
 
-  create_table "final_hearings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "final_hearings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "proceeding_id", null: false
     t.integer "work_type"
     t.boolean "listed", null: false
@@ -554,14 +554,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["proceeding_id"], name: "index_final_hearings_on_proceeding_id"
   end
 
-  create_table "firms", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "firms", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "ccms_id"
     t.string "name"
   end
 
-  create_table "hmrc_responses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "hmrc_responses", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "submission_id"
     t.string "use_case"
     t.json "response"
@@ -575,7 +575,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["owner_type", "owner_id"], name: "index_hmrc_responses_on_owner"
   end
 
-  create_table "incidents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "incidents", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.date "occurred_on"
     t.text "details"
     t.uuid "legal_aid_application_id"
@@ -585,14 +585,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["legal_aid_application_id"], name: "index_incidents_on_legal_aid_application_id"
   end
 
-  create_table "individuals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "individuals", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "involved_children", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "involved_children", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.string "full_name"
     t.date "date_of_birth"
@@ -602,7 +602,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["legal_aid_application_id"], name: "index_involved_children_on_legal_aid_application_id"
   end
 
-  create_table "legal_aid_application_transaction_types", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "legal_aid_application_transaction_types", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.uuid "transaction_type_id"
     t.datetime "created_at", precision: nil, null: false
@@ -614,7 +614,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["transaction_type_id"], name: "laa_trans_type_on_transaction_type_id"
   end
 
-  create_table "legal_aid_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "legal_aid_applications", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "application_ref"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
@@ -676,7 +676,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["provider_id"], name: "index_legal_aid_applications_on_provider_id"
   end
 
-  create_table "legal_framework_merits_task_lists", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "legal_framework_merits_task_lists", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.text "serialized_data"
     t.datetime "created_at", null: false
@@ -684,7 +684,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["legal_aid_application_id"], name: "idx_lfa_merits_task_lists_on_legal_aid_application_id"
   end
 
-  create_table "legal_framework_submission_histories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "legal_framework_submission_histories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "submission_id"
     t.string "url"
     t.string "http_method"
@@ -697,7 +697,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "legal_framework_submissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "legal_framework_submissions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.uuid "request_id"
     t.string "error_message"
@@ -721,7 +721,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["target_application_id"], name: "index_linked_applications_on_target_application_id"
   end
 
-  create_table "malware_scan_results", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "malware_scan_results", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "uploader_type"
     t.uuid "uploader_id"
     t.boolean "virus_found", null: false
@@ -733,7 +733,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["uploader_type", "uploader_id"], name: "index_malware_scan_results_on_uploader_type_and_uploader_id"
   end
 
-  create_table "matter_oppositions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "matter_oppositions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.text "reason", default: "", null: false
     t.datetime "created_at", null: false
@@ -742,7 +742,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["legal_aid_application_id"], name: "index_matter_oppositions_on_legal_aid_application_id"
   end
 
-  create_table "offices", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "offices", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "ccms_id"
@@ -758,7 +758,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["provider_id"], name: "index_offices_providers_on_provider_id"
   end
 
-  create_table "opponents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "opponents", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
@@ -770,7 +770,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["opposable_type", "opposable_id"], name: "index_opponents_on_opposable", unique: true
   end
 
-  create_table "opponents_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "opponents_applications", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "proceeding_id", null: false
     t.boolean "has_opponents_application"
     t.string "reason_for_applying"
@@ -779,7 +779,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["proceeding_id"], name: "index_opponents_applications_on_proceeding_id"
   end
 
-  create_table "organisations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "organisations", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.string "ccms_type_code", null: false
     t.string "ccms_type_text", null: false
@@ -787,7 +787,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "other_assets_declarations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "other_assets_declarations", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.decimal "second_home_value"
     t.decimal "second_home_mortgage"
@@ -804,7 +804,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["legal_aid_application_id"], name: "index_other_assets_declarations_on_legal_aid_application_id", unique: true
   end
 
-  create_table "parties_mental_capacities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "parties_mental_capacities", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.boolean "understands_terms_of_court_order"
     t.text "understands_terms_of_court_order_details"
@@ -813,7 +813,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["legal_aid_application_id"], name: "index_parties_mental_capacities_on_legal_aid_application_id"
   end
 
-  create_table "partners", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "partners", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
     t.date "date_of_birth"
@@ -837,13 +837,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["legal_aid_application_id"], name: "index_partners_on_legal_aid_application_id"
   end
 
-  create_table "permissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "permissions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "role"
     t.string "description"
     t.index ["role"], name: "index_permissions_on_role", unique: true
   end
 
-  create_table "policy_disregards", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "policy_disregards", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.boolean "england_infected_blood_support"
     t.boolean "vaccine_damage_payments"
     t.boolean "variant_creutzfeldt_jakob_disease"
@@ -858,7 +858,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["legal_aid_application_id"], name: "index_policy_disregards_on_legal_aid_application_id"
   end
 
-  create_table "proceedings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "proceedings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.integer "proceeding_case_id"
     t.boolean "lead_proceeding", default: false, null: false
@@ -894,7 +894,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["proceeding_case_id"], name: "index_proceedings_on_proceeding_case_id", unique: true
   end
 
-  create_table "proceedings_linked_children", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "proceedings_linked_children", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "proceeding_id"
     t.uuid "involved_child_id"
     t.datetime "created_at", null: false
@@ -903,7 +903,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["proceeding_id", "involved_child_id"], name: "index_proceeding_involved_child", unique: true
   end
 
-  create_table "prohibited_steps", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "prohibited_steps", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "proceeding_id", null: false
     t.boolean "uk_removal"
     t.string "details"
@@ -913,7 +913,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["proceeding_id"], name: "index_prohibited_steps_on_proceeding_id"
   end
 
-  create_table "providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "providers", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "username", null: false
     t.string "type"
     t.text "roles"
@@ -940,7 +940,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["username"], name: "index_providers_on_username", unique: true
   end
 
-  create_table "regular_transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "regular_transactions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.uuid "transaction_type_id", null: false
     t.decimal "amount", null: false
@@ -955,7 +955,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["transaction_type_id"], name: "index_regular_transactions_on_transaction_type_id"
   end
 
-  create_table "savings_amounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "savings_amounts", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.decimal "offline_current_accounts"
     t.decimal "cash"
@@ -977,7 +977,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["legal_aid_application_id"], name: "index_savings_amounts_on_legal_aid_application_id"
   end
 
-  create_table "scheduled_mailings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "scheduled_mailings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.string "mailer_klass", null: false
     t.string "mailer_method", null: false
@@ -992,7 +992,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.string "govuk_message_id"
   end
 
-  create_table "scope_limitations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "scope_limitations", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "proceeding_id", null: false
     t.integer "scope_type"
     t.string "code", null: false
@@ -1005,7 +1005,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["proceeding_id"], name: "index_scope_limitations_on_proceeding_id"
   end
 
-  create_table "settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "settings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "mock_true_layer_data", default: false, null: false
@@ -1022,7 +1022,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.boolean "public_law_family", default: false, null: false
   end
 
-  create_table "specific_issues", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "specific_issues", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "proceeding_id", null: false
     t.string "details"
     t.datetime "created_at", null: false
@@ -1030,7 +1030,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["proceeding_id"], name: "index_specific_issues_on_proceeding_id"
   end
 
-  create_table "state_machine_proxies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "state_machine_proxies", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id"
     t.string "type"
     t.string "aasm_state"
@@ -1039,7 +1039,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.string "ccms_reason"
   end
 
-  create_table "statement_of_cases", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "statement_of_cases", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.text "statement"
     t.datetime "created_at", precision: nil, null: false
@@ -1057,7 +1057,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "transaction_types", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "transaction_types", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.string "operation"
     t.datetime "created_at", precision: nil, null: false
@@ -1069,13 +1069,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["parent_id"], name: "index_transaction_types_on_parent_id"
   end
 
-  create_table "true_layer_banks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "true_layer_banks", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.text "banks"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "undertakings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "undertakings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.boolean "offered"
     t.string "additional_information"
@@ -1084,7 +1084,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["legal_aid_application_id"], name: "index_undertakings_on_legal_aid_application_id"
   end
 
-  create_table "uploaded_evidence_collections", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "uploaded_evidence_collections", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.uuid "provider_uploader_id"
     t.datetime "created_at", null: false
@@ -1093,7 +1093,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["provider_uploader_id"], name: "index_uploaded_evidence_collections_on_provider_uploader_id"
   end
 
-  create_table "urgencies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "urgencies", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "legal_aid_application_id", null: false
     t.string "nature_of_urgency", null: false
     t.boolean "hearing_date_set"
@@ -1104,7 +1104,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["legal_aid_application_id"], name: "index_urgencies_on_legal_aid_application_id"
   end
 
-  create_table "vary_orders", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "vary_orders", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "proceeding_id", null: false
     t.string "details"
     t.datetime "created_at", null: false
@@ -1112,7 +1112,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
     t.index ["proceeding_id"], name: "index_vary_orders_on_proceeding_id"
   end
 
-  create_table "vehicles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "vehicles", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.decimal "estimated_value"
     t.decimal "payment_remaining"
     t.date "purchased_on"
@@ -1158,8 +1158,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_17_104841) do
   add_foreign_key "legal_aid_applications", "providers"
   add_foreign_key "legal_framework_merits_task_lists", "legal_aid_applications", on_delete: :cascade
   add_foreign_key "legal_framework_submissions", "legal_aid_applications"
-  add_foreign_key "linked_applications", "legal_aid_applications", column: "associated_application_id"
-  add_foreign_key "linked_applications", "legal_aid_applications", column: "lead_application_id"
+  add_foreign_key "linked_applications", "legal_aid_applications", column: "associated_application_id", validate: false
+  add_foreign_key "linked_applications", "legal_aid_applications", column: "lead_application_id", validate: false
   add_foreign_key "matter_oppositions", "legal_aid_applications", on_delete: :cascade
   add_foreign_key "offices", "firms"
   add_foreign_key "offices_providers", "offices"

--- a/lib/tasks/fixes/ap_5580_migrate_child_relationship_question.rake
+++ b/lib/tasks/fixes/ap_5580_migrate_child_relationship_question.rake
@@ -1,0 +1,93 @@
+def uniq_proceeding_relationships(application)
+  application.proceedings.map(&:relationship_to_child).uniq
+end
+
+def all_proceeding_states(application)
+  application.legal_framework_merits_task_list.task_list.tasks[:proceedings].keys.each_with_object([]) do |proceeding, i|
+    proc_tasks = application.legal_framework_merits_task_list.task_list.tasks[:proceedings][proceeding][:tasks]
+    i << proc_tasks.find { |task| task.name == :client_relationship_to_proceeding }.state
+  end
+end
+
+def all_proceedings_complete?(application)
+  all_proceeding_states(application).all?(:complete)
+end
+
+namespace :fixes do
+  desc "Move unanswered child relationship questions from proceedings to application"
+  task :ap_5580, [:dry_run] => :environment do |_task, args|
+    args.with_defaults(dry_run: "true")
+    dry_run = args[:dry_run].to_s.downcase.strip != "false"
+
+    if dry_run
+      Rails.logger.info "----------------------------------------"
+      Rails.logger.info "dry_run enabled."
+      Rails.logger.info "No actual changes will be made."
+      Rails.logger.info "----------------------------------------"
+    end
+
+    # possibly affected applications
+    paa = LegalFramework::MeritsTaskList.where("serialized_data LIKE :input", input: "%client_relationship_to_proceeding%").map(&:legal_aid_application)
+    result = { total: paa.count, discarded: 0, completed: 0, issues: 0, fixes: 0, data: [] }
+    paa.each do |application|
+      application_proceedings = application.legal_framework_merits_task_list.task_list.tasks[:proceedings]
+      count = application_proceedings.each_key { |k| application_proceedings[k][:tasks].count { |task| task.name == :client_relationship_to_proceeding } }.count
+
+      output_array = [
+        application.id,
+        application.application_ref,
+        count,
+      ]
+      if application.discarded?
+        output_array << "no problem, discarded"
+        result[:discarded] += 1
+      elsif all_proceedings_complete?(application)
+        output_array << "no problem, completed"
+        result[:completed] += 1
+        output_array << application.proceedings.map(&:relationship_to_child).uniq
+      elsif dry_run
+        proceeding_states = all_proceeding_states(application).uniq
+        output_array << [
+          [application_proceedings.keys],
+          proceeding_states,
+          proceeding_states.count == 1 ? "fixable" : "cannot auto repair",
+        ]
+        result[:issues] += 1
+      else
+        result[:issues] += 1
+        proceeding_states = all_proceeding_states(application).uniq
+
+        if proceeding_states.count == 1 && uniq_proceeding_relationships(application).count == 1
+          ActiveRecord::Base.transaction do
+            # create new framework task
+            new_task = LegalFramework::SerializableMeritsTask.new(:client_relationship_to_children)
+            # Add it to the application object
+            application.legal_framework_merits_task_list.task_list.tasks[:application] << new_task
+            application.legal_framework_merits_task_list.task_list.tasks[:application].flatten!
+            # loop proceedings and delete the client_relationship_to_proceeding tasks
+            application.legal_framework_merits_task_list.task_list.tasks[:proceedings].each_key do |proceeding|
+              application.legal_framework_merits_task_list.task_list.tasks[:proceedings][proceeding][:tasks].reject! { |task| task.name == :client_relationship_to_proceeding }
+            end
+            # save the new list of tasks
+            application.legal_framework_merits_task_list.serialized_data = application.legal_framework_merits_task_list.task_list.to_yaml
+            application.legal_framework_merits_task_list.save!
+
+            # move the single answer from proceeding to applicant
+            application.applicant.update!(relationship_to_children: uniq_proceeding_relationships(application).first)
+          end
+
+          result[:fixes] += 1
+          output_array << %w[fixed]
+        else
+          output_array << [
+            [application_proceedings.keys],
+            proceeding_states,
+            "cannot auto repair",
+          ]
+        end
+      end
+      result[:data] << [output_array.compact_blank].flatten!
+    end
+    pp result
+  end
+end

--- a/spec/lib/tasks/fixes/ap_5580_spec.rb
+++ b/spec/lib/tasks/fixes/ap_5580_spec.rb
@@ -1,0 +1,227 @@
+require "rails_helper"
+
+RSpec.describe "ap_5580:", type: :task do
+  subject(:task) do
+    Rake::Task["fixes:ap_5580"]
+  end
+
+  before do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+    allow(Rails.logger).to receive(:info)
+    allow($stdout).to receive(:write) # comment this out if using binding.pry in this file
+    create(:legal_framework_merits_task_list, serialized_data:, legal_aid_application:)
+    create(:proceeding, :pb007, legal_aid_application:, relationship_to_child: "biological")
+  end
+
+  let(:legal_aid_application) do
+    travel_to Date.parse("2025-02-21") do
+      create(:legal_aid_application, :with_applicant)
+    end
+  end
+  let(:proceedings) { legal_aid_application.proceedings }
+
+  describe "dry-run of fixes:ap_5580" do
+    context "when there is an application with a two proceedings and both have an unanswered question" do
+      let(:serialized_data) { double_proceeding_with_question[:input] }
+
+      it "logs the message" do
+        expect { task.execute }.to output(double_proceeding_with_question[:output]).to_stdout
+      end
+
+      it "does not affect the tasks" do
+        task.execute
+        expect(legal_aid_application.legal_framework_merits_task_list).to have_task_in_state(:PB004, :client_relationship_to_proceeding, :not_started)
+        expect(legal_aid_application.legal_framework_merits_task_list).to have_task_in_state(:PB005, :client_relationship_to_proceeding, :not_started)
+        expect(legal_aid_application.legal_framework_merits_task_list).not_to have_task_in_state(:application, :client_relationship_to_children, :not_started)
+      end
+    end
+
+    context "when there is an application with a single proceeding with an unanswered question" do
+      let(:serialized_data) { single_proceeding_with_question[:input] }
+
+      it "logs the message" do
+        expect { task.execute }.to output(single_proceeding_with_question[:output]).to_stdout
+      end
+
+      it "does not affect the tasks" do
+        task.execute
+        expect(legal_aid_application.legal_framework_merits_task_list).to have_task_in_state(:PB057, :client_relationship_to_proceeding, :not_started)
+        expect(legal_aid_application.legal_framework_merits_task_list).not_to have_task_in_state(:application, :client_relationship_to_children, :not_started)
+      end
+    end
+
+    context "when there is an application with a single proceeding with an answered question" do
+      let(:serialized_data) { single_proceeding_with_answered_question[:input] }
+
+      it "logs the message" do
+        expect { task.execute }.to output(single_proceeding_with_answered_question[:output]).to_stdout
+      end
+
+      it "does not affect the tasks" do
+        task.execute
+        expect(legal_aid_application.legal_framework_merits_task_list).to have_task_in_state(:PB057, :client_relationship_to_proceeding, :complete)
+        expect(legal_aid_application.legal_framework_merits_task_list).not_to have_task_in_state(:application, :client_relationship_to_children, :not_started)
+      end
+    end
+
+    context "when there is an application with no proceeding" do
+      let(:serialized_data) { single_proceeding_without_question[:input] }
+
+      it "logs the message" do
+        expect { task.execute }.to output(single_proceeding_without_question[:output]).to_stdout
+      end
+    end
+  end
+
+  describe "live run of fixes:ap_5580" do
+    context "when there is an application with a two proceedings and both have an unanswered question" do
+      let(:serialized_data) { double_proceeding_with_question[:input] }
+
+      it "logs the message" do
+        expect { task.execute(dry_run: false) }.to output(double_proceeding_with_question[:update_output]).to_stdout
+      end
+
+      it "creates the new task" do
+        task.execute(dry_run: false)
+
+        expect(legal_aid_application.legal_framework_merits_task_list).not_to have_task_in_state(:PB004, :client_relationship_to_proceeding, :not_started)
+        expect(legal_aid_application.legal_framework_merits_task_list).not_to have_task_in_state(:PB005, :client_relationship_to_proceeding, :not_started)
+        expect(legal_aid_application.legal_framework_merits_task_list).to have_task_in_state(:application, :client_relationship_to_children, :not_started)
+      end
+
+      it "copies the answer to the applicant" do
+        task.execute(dry_run: false)
+        expect(legal_aid_application.applicant.reload.relationship_to_children).to eq proceedings.map(&:relationship_to_child).uniq.first
+      end
+    end
+
+    context "when there is an application with a single proceeding with an unanswered question" do
+      let(:serialized_data) { single_proceeding_with_question[:input] }
+
+      it "logs the message" do
+        expect { task.execute(dry_run: false) }.to output(single_proceeding_with_question[:update_output]).to_stdout
+      end
+
+      it "creates the new task" do
+        task.execute(dry_run: false)
+        expect(legal_aid_application.legal_framework_merits_task_list).not_to have_task_in_state(:PB057, :client_relationship_to_proceeding, :not_started)
+        expect(legal_aid_application.legal_framework_merits_task_list).to have_task_in_state(:application, :client_relationship_to_children, :not_started)
+      end
+
+      it "copies the answer to the applicant" do
+        task.execute(dry_run: false)
+        expect(legal_aid_application.applicant.reload.relationship_to_children).to eq proceedings.map(&:relationship_to_child).uniq.first
+      end
+    end
+
+    context "when there is an application with a single proceeding with an answered question" do
+      let(:serialized_data) { single_proceeding_with_answered_question[:input] }
+
+      it "logs the message" do
+        expect { task.execute(dry_run: false) }.to output(single_proceeding_with_answered_question[:output]).to_stdout
+      end
+
+      it "does not affect the tasks" do
+        task.execute(dry_run: false)
+        expect(legal_aid_application.legal_framework_merits_task_list).to have_task_in_state(:PB057, :client_relationship_to_proceeding, :complete)
+        expect(legal_aid_application.legal_framework_merits_task_list).not_to have_task_in_state(:application, :client_relationship_to_children, :not_started)
+      end
+    end
+
+    context "when there is an application with no proceeding" do
+      let(:serialized_data) { single_proceeding_without_question[:input] }
+
+      it "logs the message" do
+        expect { task.execute(dry_run: false) }.to output(single_proceeding_without_question[:output]).to_stdout
+      end
+
+      it "does not affect the tasks" do
+        task.execute
+        expect(legal_aid_application.legal_framework_merits_task_list).not_to have_task_in_state(:application, :client_relationship_to_children, :not_started)
+      end
+    end
+  end
+end
+
+def single_proceeding_without_question
+  {
+    input: "--- !ruby/object:LegalFramework::SerializableMeritsTaskList\nlfa_response:\n  :request_id: 7ebd1d6d-a3be-4151-a5db-c8ece94c72ff\n  :success: true\n  :application:\n    :tasks:\n      :opponent_name: &1 []\n      :children_application: &2 []\n  :proceedings:\n  - :ccms_code: PB057\n    :tasks:\n      :children_proceeding: &3 []\ntasks:\n  :application:\n  - !ruby/object:LegalFramework::SerializableMeritsTask\n    name: :opponent_name\n    dependencies: *1\n    state: :complete\n  - !ruby/object:LegalFramework::SerializableMeritsTask\n    name: :children_application\n    dependencies: *2\n    state: :complete\n  :proceedings:\n    :PB057:\n      :name: Care order\n      :tasks:\n      - !ruby/object:LegalFramework::SerializableMeritsTask\n        name: :children_proceeding\n        dependencies: *3\n        state: :complete",
+    output: "{total: 0, discarded: 0, completed: 0, issues: 0, fixes: 0, data: []}\n",
+  }
+end
+
+def single_proceeding_with_question
+  {
+    input: "--- !ruby/object:LegalFramework::SerializableMeritsTaskList\nlfa_response:\n  :request_id: 7ebd1d6d-a3be-4151-a5db-c8ece94c72ff\n  :success: true\n  :application:\n    :tasks:\n      :opponent_name: &1 []\n      :children_application: &2 []\n  :proceedings:\n  - :ccms_code: PB057\n    :tasks:\n      :children_proceeding: &3 []\n      :client_relationship_to_proceeding: &4 []\ntasks:\n  :application:\n  - !ruby/object:LegalFramework::SerializableMeritsTask\n    name: :opponent_name\n    dependencies: *1\n    state: :complete\n  - !ruby/object:LegalFramework::SerializableMeritsTask\n    name: :children_application\n    dependencies: *2\n    state: :complete\n  :proceedings:\n    :PB057:\n      :name: Care order\n      :tasks:\n      - !ruby/object:LegalFramework::SerializableMeritsTask\n        name: :children_proceeding\n        dependencies: *3\n        state: :complete\n      - !ruby/object:LegalFramework::SerializableMeritsTask\n        name: :client_relationship_to_proceeding\n        dependencies: *4\n        state: :not_started\n",
+    output: <<~STRING,
+      {total: 1,
+       discarded: 0,
+       completed: 0,
+       issues: 1,
+       fixes: 0,
+       data:
+        [["#{legal_aid_application.id}",
+          "#{legal_aid_application.application_ref}",
+          1,
+          :PB057,
+          :not_started,
+          "fixable"]]}
+    STRING
+    update_output: <<~STRING,
+      {total: 1,
+       discarded: 0,
+       completed: 0,
+       issues: 1,
+       fixes: 1,
+       data: [["#{legal_aid_application.id}", "#{legal_aid_application.application_ref}", 1, "fixed"]]}
+    STRING
+  }
+end
+
+def single_proceeding_with_answered_question
+  {
+    input: "--- !ruby/object:LegalFramework::SerializableMeritsTaskList\nlfa_response:\n  :request_id: 7ebd1d6d-a3be-4151-a5db-c8ece94c72ff\n  :success: true\n  :application:\n    :tasks:\n      :opponent_name: &1 []\n      :children_application: &2 []\n  :proceedings:\n  - :ccms_code: PB057\n    :tasks:\n      :children_proceeding: &3 []\n      :client_relationship_to_proceeding: &4 []\ntasks:\n  :application:\n  - !ruby/object:LegalFramework::SerializableMeritsTask\n    name: :opponent_name\n    dependencies: *1\n    state: :complete\n  - !ruby/object:LegalFramework::SerializableMeritsTask\n    name: :children_application\n    dependencies: *2\n    state: :complete\n  :proceedings:\n    :PB057:\n      :name: Care order\n      :tasks:\n      - !ruby/object:LegalFramework::SerializableMeritsTask\n        name: :children_proceeding\n        dependencies: *3\n        state: :complete\n      - !ruby/object:LegalFramework::SerializableMeritsTask\n        name: :client_relationship_to_proceeding\n        dependencies: *4\n        state: :complete\n",
+    output: <<~STRING,
+      {total: 1,
+       discarded: 0,
+       completed: 1,
+       issues: 0,
+       fixes: 0,
+       data:
+        [["#{legal_aid_application.id}",
+          "#{legal_aid_application.application_ref}",
+          1,
+          "no problem, completed",
+          "biological"]]}
+    STRING
+  }
+end
+
+def double_proceeding_with_question
+  {
+    input: "--- !ruby/object:LegalFramework::SerializableMeritsTaskList\nlfa_response:\n  :request_id: 42ef6c04-2bf7-49e7-beae-48cc63e5cd6e\n  :success: true\n  :application:\n    :tasks:\n      :opponent_name: &1 []\n      :children_application: &2 []\n  :proceedings:\n  - :ccms_code: PB004\n    :tasks:\n      :children_proceeding: &3\n      - children_application\n      :client_relationship_to_proceeding: &4 []\n  - :ccms_code: PB005\n    :tasks:\n      :children_proceeding: &5\n      - children_application\n      :client_relationship_to_proceeding: &6 []\ntasks:\n  :application:\n  - !ruby/object:LegalFramework::SerializableMeritsTask\n    name: :opponent_name\n    dependencies: *1\n    state: :not_started\n  - !ruby/object:LegalFramework::SerializableMeritsTask\n    name: :children_application\n    dependencies: *2\n    state: :not_started\n  :proceedings:\n    :PB004:\n      :name: Emergency protection order - extend\n      :tasks:\n      - !ruby/object:LegalFramework::SerializableMeritsTask\n        name: :children_proceeding\n        dependencies: *3\n        state: :waiting_for_dependency\n      - !ruby/object:LegalFramework::SerializableMeritsTask\n        name: :client_relationship_to_proceeding\n        dependencies: *4\n        state: :not_started\n    :PB005:\n      :name: Emergency protection order - discharge\n      :tasks:\n      - !ruby/object:LegalFramework::SerializableMeritsTask\n        name: :children_proceeding\n        dependencies: *5\n        state: :waiting_for_dependency\n      - !ruby/object:LegalFramework::SerializableMeritsTask\n        name: :client_relationship_to_proceeding\n        dependencies: *6\n        state: :not_started\n",
+    output: <<~STRING,
+      {total: 1,
+       discarded: 0,
+       completed: 0,
+       issues: 1,
+       fixes: 0,
+       data:
+        [["#{legal_aid_application.id}",
+          "#{legal_aid_application.application_ref}",
+          2,
+          :PB004,
+          :PB005,
+          :not_started,
+          "fixable"]]}
+    STRING
+    update_output: <<~STRING,
+      {total: 1,
+       discarded: 0,
+       completed: 0,
+       issues: 1,
+       fixes: 1,
+       data: [["#{legal_aid_application.id}", "#{legal_aid_application.application_ref}", 2, "fixed"]]}
+    STRING
+  }
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5580)

This PR is to move the SCA parental responsibility merits question from proceedings to application

### Rake task
The new rake task deletes any unanswered `client_relationship_to_proceeding` questions and creates a new, unanswered application level question
It has been tested against an export of production use `rake fixes:ap_5580` to run it in dry_run mode, use `rake fixes:ap_5580\[false\]` to actually run it

## Work in progress
- [ ] pull in the moved questions from the other branch
- [ ] extend the rake task to test for new questions being present and moving any partially answered questions in the DB

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
