### PR TITLE
Fix: Stop displaying change link for second appeals in read_only mode

### DIFF
--- a/app/views/shared/check_answers/merits/_second_appeal.html.erb
+++ b/app/views/shared/check_answers/merits/_second_appeal.html.erb
@@ -1,9 +1,11 @@
 <%= govuk_summary_card(title: t(".heading"), html_attributes: { id: "app-check-your-answers__second_appeal" }, heading_level: 3) do |card|
-      card.with_action do
-        govuk_link_to(t("generic.change"),
-                      providers_legal_aid_application_second_appeal_path(@legal_aid_application),
-                      visually_hidden_text: t(".heading"),
-                      id: "app-check-your-answers__second_appeal_heading")
+      unless read_only
+        card.with_action do
+          govuk_link_to(t("generic.change"),
+                        providers_legal_aid_application_second_appeal_path(@legal_aid_application),
+                        visually_hidden_text: t(".heading"),
+                        id: "app-check-your-answers__second_appeal_heading")
+        end
       end
 
       card.with_summary_list(actions: false) do |summary_list|


### PR DESCRIPTION


## What
Prevent change link for second appeal question appearing on read-only pages

[Came out of this ticket](https://dsdmoj.atlassian.net/browse/AP-5709)

BUG identified during PLF playback. 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
