### PR TITLE
Fix: correct width of child_care_assessment CYA section

### DIFF
--- a/app/views/shared/check_answers/_child_care_assessment.html.erb
+++ b/app/views/shared/check_answers/_child_care_assessment.html.erb
@@ -1,8 +1,8 @@
 <%= summary_list.with_row do |row|
-      row.with_key(text: t("shared.check_answers.child_care_assessment.assessed"), classes: "govuk-!-width-one-half")
+      row.with_key(text: t("shared.check_answers.child_care_assessment.assessed"), classes: "govuk-!-width-one-third")
       row.with_value(text: yes_no(child_care_assessment.assessed?))
 
-      row.with_key(text: t("shared.check_answers.child_care_assessment.assessed"), classes: "govuk-!-width-one-half")
+      row.with_key(text: t("shared.check_answers.child_care_assessment.assessed"), classes: "govuk-!-width-one-third")
       row.with_value(text: yes_no(child_care_assessment.assessed?))
 
       if child_care_assessment.assessed?


### PR DESCRIPTION
## What
Correct summary card column widths for child care assessment merits CYA 

[Came out of ticket](https://dsdmoj.atlassian.net/browse/AP-5709)

Make one-third/two-third not half/half to make it consistent with other merits CYA page summary
cards. This was noticed during PLF playback session.

## Before
![Screenshot 2025-02-27 at 16 58 14](https://github.com/user-attachments/assets/ea20834a-46d5-42ed-bfb9-ed1f149a0cd2)


## After
![Screenshot 2025-02-27 at 16 59 10](https://github.com/user-attachments/assets/f5ea01be-7605-43cd-9a76-47b105370937)


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
