### PR TITLE
AP-5790: Fix PLF add another restriction

### DIFF
--- a/app/views/providers/has_other_proceedings/show.html.erb
+++ b/app/views/providers/has_other_proceedings/show.html.erb
@@ -39,6 +39,7 @@
     <% if @form.remaining_proceedings.zero? %>
       <h2 class="govuk-heading-l"><%= content_for(:page_title) %></h2>
       <p class="govuk-body"><%= t(".no_more_proceedings.caption") %></p>
+      <%= form.hidden_field :has_other_proceeding, value: "false" %>
     <% else %>
       <%= form.govuk_collection_radio_buttons :has_other_proceeding, yes_no_options, :value, :label,
                                               legend: { text: content_for(:page_title), tag: "h2", size: "m" } do %>

--- a/features/cassettes/All_available_proceedings_have_been_selected/When_I_see_the_has_other_proceedings_page.yml
+++ b/features/cassettes/All_available_proceedings_have_been_selected/When_I_see_the_has_other_proceedings_page.yml
@@ -1,0 +1,155 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
+    body:
+      encoding: UTF-8
+      string: '{"current_proceedings":["PBM40","PBM40E","PBM45","PBM45E"],"allowed_categories":["MAT"],"search_term":""}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v2.12.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Thu, 27 Feb 2025 12:04:13 GMT
+      content-type:
+      - application/json; charset=utf-8
+      content-length:
+      - '27'
+      connection:
+      - keep-alive
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      x-permitted-cross-domain-policies:
+      - none
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      vary:
+      - Accept, Origin
+      etag:
+      - W/"cf26ca1ee8f9c63a951189dc0c043e1f"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - d59a627f66b8960ce50e38653038e0ff
+      x-runtime:
+      - '0.069246'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":false,"data":[]}'
+  recorded_at: Thu, 27 Feb 2025 12:04:13 GMT
+- request:
+    method: post
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
+    body:
+      encoding: UTF-8
+      string: '{"current_proceedings":["PBM40","PBM40E","PBM45","PBM45E"],"allowed_categories":["MAT"],"search_term":""}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v2.12.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Thu, 27 Feb 2025 12:04:13 GMT
+      content-type:
+      - application/json; charset=utf-8
+      content-length:
+      - '27'
+      connection:
+      - keep-alive
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      x-permitted-cross-domain-policies:
+      - none
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      vary:
+      - Accept, Origin
+      etag:
+      - W/"cf26ca1ee8f9c63a951189dc0c043e1f"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 704185d97f2af8f41a48ce5c16f8c698
+      x-runtime:
+      - '0.082332'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":false,"data":[]}'
+  recorded_at: Thu, 27 Feb 2025 12:04:13 GMT
+- request:
+    method: get
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/PBM40
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v2.12.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Thu, 27 Feb 2025 12:04:15 GMT
+      content-type:
+      - application/json; charset=utf-8
+      content-length:
+      - '320'
+      connection:
+      - keep-alive
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      x-permitted-cross-domain-policies:
+      - none
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      vary:
+      - Accept, Origin
+      etag:
+      - W/"634b8c627a1b078b5d1fffcb51ca2121"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - e3fdb2f83d711f4c32377333848ea3b0
+      x-runtime:
+      - '0.005977'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"client_involvement_type":[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
+        of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
+        party"}]}'
+  recorded_at: Thu, 27 Feb 2025 12:04:15 GMT
+recorded_with: VCR 6.3.1

--- a/features/providers/public_law_family/all_proceedings_chosen.feature
+++ b/features/providers/public_law_family/all_proceedings_chosen.feature
@@ -1,0 +1,10 @@
+Feature: All available proceedings have been selected
+
+  @javascript @vcr
+  Scenario: When I see the has_other_proceedings page
+    Given I have started an application, added all available PLF proceedings, and reached the proceedings list
+    Then I should see "No more proceedings can be added to the ones you have chosen"
+
+    When I click "Save and continue"
+    Then I should be on a page with title "Placement order - parent or parental responsibility"
+    Then I should see "Proceeding 1 of 4"

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -519,6 +519,57 @@ Given("I have started an application and reached the proceedings list") do
   steps %(Then I should be on a page showing 'Do you want to add another proceeding?')
 end
 
+Given("I have started an application, added all available PLF proceedings, and reached the proceedings list") do
+  @legal_aid_application = create(:legal_aid_application,
+                                  :with_applicant_and_address_lookup)
+  create(:proceeding, :pbm40, legal_aid_application: @legal_aid_application)
+  create(:proceeding,
+         :with_scope_limitations,
+         :without_df_date,
+         legal_aid_application: @legal_aid_application,
+         substantive_cost_limitation: 25_000,
+         delegated_functions_cost_limitation: 2_250,
+         name: "placement_order_parent_or_parental_responsibility_plf_enforcement",
+         ccms_code: "PBM40E",
+         matter_type: "public law family (PLF)",
+         category_of_law: "Family",
+         category_law_code: "MAT",
+         ccms_matter_code: "KPBLB",
+         meaning: "Placement order - parent or parental responsibility - enforcement",
+         description: "To represent a parent or person with parental responsibility on an application for a placement order. Enforcement only.")
+  create(:proceeding,
+         :with_scope_limitations,
+         :without_df_date,
+         legal_aid_application: @legal_aid_application,
+         substantive_cost_limitation: 25_000,
+         delegated_functions_cost_limitation: 2_250,
+         ccms_code: "PBM45",
+         matter_type: "public law family (PLF)",
+         category_of_law: "Family",
+         category_law_code: "MAT",
+         ccms_matter_code: "KPBLB",
+         name: "declaration_of_parentage",
+         meaning: "Adoption order - parent or parental responsibility",
+         description: "To represent a parent or person with parental responsibility on an application for an adoption order.")
+  create(:proceeding,
+         :with_scope_limitations,
+         :without_df_date,
+         legal_aid_application: @legal_aid_application,
+         substantive_cost_limitation: 25_000,
+         delegated_functions_cost_limitation: 2_250,
+         ccms_code: "PBM45E",
+         matter_type: "public law family (PLF)",
+         category_of_law: "Family",
+         category_law_code: "MAT",
+         ccms_matter_code: "KPBLB",
+         name: "declaration_of_parentage_enforcement",
+         meaning: "Adoption order - parent or parental responsibility - enforcement",
+         description: "To represent a parent or person with parental responsibility on an application for a placement order. Enforcement only.")
+  login_as @legal_aid_application.provider
+  visit(providers_legal_aid_application_has_other_proceedings_path(@legal_aid_application))
+  steps %(Then I should be on a page showing 'You have added all the allowed proceedings')
+end
+
 Given("I have started an application with multiple proceedings and reached the check your answers page") do
   @legal_aid_application = create(
     :legal_aid_application,

--- a/spec/factories/proceedings.rb
+++ b/spec/factories/proceedings.rb
@@ -46,6 +46,13 @@ FactoryBot.define do
       no_scope_limitations { false }
     end
 
+    trait :with_scope_limitations do
+      after(:create) do |proceeding, evaluator|
+        create(:scope_limitation, :emergency, proceeding:) unless evaluator.no_scope_limitations
+        create(:scope_limitation, :substantive, proceeding:) unless evaluator.no_scope_limitations
+      end
+    end
+
     trait :da001 do
       lead_proceeding { true }
       ccms_code { "DA001" }
@@ -460,5 +467,9 @@ FactoryBot.define do
     ccms_matter_code { "KPBLB" }
     client_involvement_type_ccms_code { "A" }
     client_involvement_type_description { "Applicant/Claimant/Petitioner" }
+    after(:create) do |proceeding, evaluator|
+      create(:scope_limitation, :emergency, proceeding:) unless evaluator.no_scope_limitations
+      create(:scope_limitation, :substantive, proceeding:) unless evaluator.no_scope_limitations
+    end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5790)

This adds a test for the user adding all available proceedings and hitting Save and Continue on the has_other_proceedings page

It then restores the hidden false value that was in an earlier PR but seems to have been accidentally deleted on a rebase

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
