### PR TITLE
FIX: remove webdack gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ gem "sentry-ruby"
 gem "sentry-sidekiq"
 gem "simple_command"
 gem "tzinfo-data"
-gem "webdack-uuid_migration", "~> 1.5.0"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.1.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -758,8 +758,6 @@ GEM
       descendants_tracker (~> 0.0, >= 0.0.3)
     warden (1.2.9)
       rack (>= 2.0.9)
-    webdack-uuid_migration (1.5.0)
-      activerecord (>= 4.0)
     webmock (3.25.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -876,7 +874,6 @@ DEPENDENCIES
   tzinfo-data
   vcr
   view_component
-  webdack-uuid_migration (~> 1.5.0)
   webmock
   webrick
 

--- a/db/migrate/20180807211758_create_legal_aid_applications.rb
+++ b/db/migrate/20180807211758_create_legal_aid_applications.rb
@@ -1,6 +1,6 @@
 class CreateLegalAidApplications < ActiveRecord::Migration[5.2]
   def change
-    create_table :legal_aid_applications do |t|
+    create_table :legal_aid_applications, id: :uuid do |t|
       t.string :application_ref
 
       t.timestamps

--- a/db/migrate/20180820112730_create_applicant.rb
+++ b/db/migrate/20180820112730_create_applicant.rb
@@ -1,6 +1,6 @@
 class CreateApplicant < ActiveRecord::Migration[5.2]
   def change
-    create_table :applicants do |t|
+    create_table :applicants, id: :uuid do |t|
       t.string :name
       t.date :date_of_birth
       t.timestamps

--- a/db/migrate/20180829144026_create_proceeding_types.rb
+++ b/db/migrate/20180829144026_create_proceeding_types.rb
@@ -1,6 +1,6 @@
 class CreateProceedingTypes < ActiveRecord::Migration[5.2]
   def change
-    create_table :proceeding_types do |t|
+    create_table :proceeding_types, id: :uuid do |t|
       t.string :code, index: true
       t.string :ccms_code
       t.string :meaning

--- a/db/migrate/20180829150801_create_legal_aid_application_proceeding_types.rb
+++ b/db/migrate/20180829150801_create_legal_aid_application_proceeding_types.rb
@@ -1,6 +1,6 @@
 class CreateLegalAidApplicationProceedingTypes < ActiveRecord::Migration[5.2]
   def change
-    create_table :application_proceeding_types do |t|
+    create_table :application_proceeding_types, id: :uuid do |t|
       t.references :legal_aid_application
       t.references :proceeding_type
       t.timestamps

--- a/db/migrate/20181011143410_create_addresses.rb
+++ b/db/migrate/20181011143410_create_addresses.rb
@@ -1,6 +1,6 @@
 class CreateAddresses < ActiveRecord::Migration[5.2]
   def change
-    create_table :addresses do |t|
+    create_table :addresses, id: :uuid do |t|
       t.string :address_line_one
       t.string :address_line_two
       t.string :city

--- a/db/migrate/20181018165405_id_to_uuid_fk.rb
+++ b/db/migrate/20181018165405_id_to_uuid_fk.rb
@@ -1,17 +1,7 @@
-require 'webdack/uuid_migration/helpers'
-
 class IdToUuidFk < ActiveRecord::Migration[5.2]
   def change
-    reversible do |dir|
-      dir.up do
-        primary_key_and_all_references_to_uuid :applicants
-        primary_key_and_all_references_to_uuid :legal_aid_applications
-        primary_key_and_all_references_to_uuid :proceeding_types
-      end
-
-      dir.down do
-        raise ActiveRecord::IrreversibleMigration
-      end
-    end
+    ####
+    # Migration removed as it only added webdack uuid migrations
+    ####
   end
 end

--- a/db/migrate/20181018165537_uuid_migration.rb
+++ b/db/migrate/20181018165537_uuid_migration.rb
@@ -1,16 +1,7 @@
-require 'webdack/uuid_migration/helpers'
-
 class UuidMigration < ActiveRecord::Migration[5.2]
   def change
-    reversible do |dir|
-      dir.up do
-        primary_key_to_uuid :addresses
-        primary_key_to_uuid :application_proceeding_types
-      end
-
-      dir.down do
-        raise ActiveRecord::IrreversibleMigration
-      end
-    end
+    ####
+    # Migration removed as it only added webdack uuid migrations
+    ####
   end
 end


### PR DESCRIPTION
## What

This is a follow up/replacement for #5727 

The [webdack_uuid-migration gem](https://github.com/kreatio-sw/webdack-uuid_migration) was used 5 years ago to change tables and has only been referenced in migration files, not actively used, since.

This version (as opposed to the original!) removes the gem and modifies the migration files affected.
It adds `id: :uuid` to the affected tables and removes the contents of the webdack migrations

## Benefits

* A new user will be able to spin up a local database using `rails db:migrate`
* removes a little used gem and reduces our lock file and dependabot updates
* reduces our dependency attack surface

## Cons

* should we be amending old migrations?  It won't affect production as the tables already exist


## Discussion
How do people feel about older migrations being modified?
The opinion online is that devs should use rails db:schema:load or rails db:prepare instead of rails db:migrate and running everything since day one.

I found one medium article saying they deleted migrations older than 3 months!? 🤔
https://medium.com/clutter-engineering/cleaning-up-old-rails-migrations-1b55b638abb5

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
