### PR TITLE
AP-5792: Fix evidence category naming after delete

### DIFF
--- a/app/controllers/providers/uploaded_evidence_collections_controller.rb
+++ b/app/controllers/providers/uploaded_evidence_collections_controller.rb
@@ -23,7 +23,7 @@ module Providers
     def list
       DocumentCategoryAnalyser.call(legal_aid_application)
       @service = UploadedEvidence::ListService.call(self)
-      @required_documents = @service.required_documents
+      @allowed_documents = @service.allowed_documents
       @attachment_type_options = @service.attachment_type_options
       @uploaded_evidence_collection = @service.uploaded_evidence_collection
       render partial: "uploaded_files", locals: { attachments: @service.uploaded_evidence_collection.original_attachments }
@@ -37,7 +37,7 @@ module Providers
       @error_message = @service.error_message
       @evidence_type_translation = @service.evidence_type_translation
       @mandatory_evidence_errors = @service.mandatory_evidence_errors
-      @required_documents = @service.required_documents
+      @allowed_documents = @service.allowed_documents
       @submission_form = @service.submission_form
       @successful_upload = @service.successful_upload
       @successfully_deleted = @service.successfully_deleted

--- a/app/services/uploaded_evidence/base.rb
+++ b/app/services/uploaded_evidence/base.rb
@@ -28,7 +28,7 @@ module UploadedEvidence
     end
 
     def attachment_type_options
-      @attachment_type_options = required_documents.map { |rd| [rd, attachment_type_name(rd)] }
+      @attachment_type_options = allowed_documents.map { |rd| [rd, attachment_type_name(rd)] }
       @attachment_type_options << %w[uncategorised Uncategorised]
       @attachment_type_options
     end
@@ -40,7 +40,7 @@ module UploadedEvidence
     end
 
     def evidence_type_translation
-      return unless required_documents.include?("benefit_evidence")
+      return unless allowed_documents.include?("benefit_evidence")
 
       I18n.t(".shared.forms.received_benefit_confirmation.form.providers.received_benefit_confirmations.#{passporting_benefit}")
     end
@@ -57,8 +57,8 @@ module UploadedEvidence
       @upload_form ||= Providers::UploadedEvidenceCollectionForm.new(uploaded_evidence_collection_params)
     end
 
-    def required_documents
-      @required_documents = legal_aid_application.allowed_document_categories
+    def allowed_documents
+      @allowed_documents = legal_aid_application.allowed_document_categories
     end
 
     def submission_form
@@ -66,7 +66,7 @@ module UploadedEvidence
     end
 
     def populate_upload_form
-      required_documents
+      allowed_documents
       @upload_form = Providers::UploadedEvidenceCollectionForm.new(model: uploaded_evidence_collection)
       attachment_type_options
       evidence_type_translation

--- a/app/services/uploaded_evidence/deletion_service.rb
+++ b/app/services/uploaded_evidence/deletion_service.rb
@@ -16,7 +16,7 @@ module UploadedEvidence
     end
 
     def attachment_type_options
-      attachment_type_options = required_documents.map { |rd| [rd, rd.humanize] }
+      attachment_type_options = allowed_documents.map { |rd| [rd, rd.humanize] }
       attachment_type_options << %w[uncategorised Uncategorised]
       attachment_type_options
     end

--- a/app/services/uploaded_evidence/deletion_service.rb
+++ b/app/services/uploaded_evidence/deletion_service.rb
@@ -15,12 +15,6 @@ module UploadedEvidence
       @uploaded_evidence_collection ||= legal_aid_application.uploaded_evidence_collection || legal_aid_application.build_uploaded_evidence_collection
     end
 
-    def attachment_type_options
-      attachment_type_options = allowed_documents.map { |rd| [rd, rd.humanize] }
-      attachment_type_options << %w[uncategorised Uncategorised]
-      attachment_type_options
-    end
-
   private
 
     def delete_original_and_pdf_files

--- a/app/services/uploaded_evidence/uploader_service.rb
+++ b/app/services/uploaded_evidence/uploader_service.rb
@@ -9,7 +9,7 @@ module UploadedEvidence
       end
 
       DocumentCategoryAnalyser.call(legal_aid_application)
-      required_documents
+      allowed_documents
       attachment_type_options
 
       @next_action = :show

--- a/app/views/providers/uploaded_evidence_collections/_uploaded_files.html.erb
+++ b/app/views/providers/uploaded_evidence_collections/_uploaded_files.html.erb
@@ -36,7 +36,7 @@
                                                :first,
                                                :last,
                                                label: { text: t(".select_a_category_label", filename: attachment.document.filename), class: "govuk-visually-hidden" },
-                                               options: { selected: @required_documents.size > 1 ? attachment.attachment_type : @attachment_type_options.first },
+                                               options: { selected: @allowed_documents.size > 1 ? attachment.attachment_type : @attachment_type_options.first },
                                                class: [select_error],
                                                data: { categorisation_select: true, attachment_id: attachment.id }
                 end

--- a/spec/services/uploaded_evidence/base_spec.rb
+++ b/spec/services/uploaded_evidence/base_spec.rb
@@ -1,5 +1,5 @@
 require "rails_helper"
-
+require_relative "shared_examples_for_uploaded_evidence"
 module UploadedEvidence
   RSpec.describe Base do
     subject(:base_service_call) { described_class.call(controller) }
@@ -43,5 +43,7 @@ module UploadedEvidence
         end
       end
     end
+
+    it_behaves_like "An uploaded evidence service"
   end
 end

--- a/spec/services/uploaded_evidence/deletion_service_spec.rb
+++ b/spec/services/uploaded_evidence/deletion_service_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require_relative "shared_examples_for_uploaded_evidence"
 
 module UploadedEvidence
   RSpec.describe DeletionService do
@@ -23,7 +24,7 @@ module UploadedEvidence
       let(:params) { { delete_button: "Delete", attachment_id: attachment.id } }
       let(:service) { described_class.new(controller) }
 
-      it "Deletes the attachment" do
+      it "deletes the attachment" do
         expect { service.call }.to change(Attachment, :count).by(-1)
       end
 
@@ -37,5 +38,7 @@ module UploadedEvidence
         expect(service.next_action).to eq :show
       end
     end
+
+    it_behaves_like "An uploaded evidence service"
   end
 end

--- a/spec/services/uploaded_evidence/list_service_spec.rb
+++ b/spec/services/uploaded_evidence/list_service_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require_relative "shared_examples_for_uploaded_evidence"
 
 module UploadedEvidence
   RSpec.describe ListService do
@@ -37,5 +38,7 @@ module UploadedEvidence
         expect(service.attachment_type_options).to eq expected_attachment_type_options
       end
     end
+
+    it_behaves_like "An uploaded evidence service"
   end
 end

--- a/spec/services/uploaded_evidence/populate_upload_form_service_spec.rb
+++ b/spec/services/uploaded_evidence/populate_upload_form_service_spec.rb
@@ -30,10 +30,10 @@ module UploadedEvidence
       let(:service) { described_class.new(controller) }
       let(:dwp_override) { instance_double DWPOverride, passporting_benefit: "income_related_employment_and_support_allowance" }
 
-      it "populates the list of required documents" do
+      it "populates the list of allowed documents" do
         allow(laa).to receive(:allowed_document_categories).and_return(allowed_document_categories)
         service.call
-        expect(service.required_documents).to eq allowed_document_categories
+        expect(service.allowed_documents).to eq allowed_document_categories
       end
 
       it "populates the upload form" do

--- a/spec/services/uploaded_evidence/populate_upload_form_service_spec.rb
+++ b/spec/services/uploaded_evidence/populate_upload_form_service_spec.rb
@@ -1,18 +1,11 @@
 require "rails_helper"
+require_relative "shared_examples_for_uploaded_evidence"
 
 module UploadedEvidence
   RSpec.describe PopulateUploadFormService do
     let(:laa) { create(:legal_aid_application) }
     let(:params) { nil }
     let(:controller) { instance_double Providers::UploadedEvidenceCollectionsController, params:, legal_aid_application: laa }
-    let(:allowed_document_categories) { %w[gateway_evidence employment_evidence] }
-    let(:expected_attachment_type_options) do
-      [
-        ["gateway_evidence", "Gateway evidence"],
-        ["employment_evidence", "Employment evidence"],
-        %w[uncategorised Uncategorised],
-      ]
-    end
 
     describe ".call" do
       let(:service_instance) { instance_double described_class }
@@ -30,21 +23,9 @@ module UploadedEvidence
       let(:service) { described_class.new(controller) }
       let(:dwp_override) { instance_double DWPOverride, passporting_benefit: "income_related_employment_and_support_allowance" }
 
-      it "populates the list of allowed documents" do
-        allow(laa).to receive(:allowed_document_categories).and_return(allowed_document_categories)
-        service.call
-        expect(service.allowed_documents).to eq allowed_document_categories
-      end
-
       it "populates the upload form" do
         service.call
         expect(service.upload_form).to be_instance_of(Providers::UploadedEvidenceCollectionForm)
-      end
-
-      it "populates options for drop down list of document categories" do
-        allow(laa).to receive(:allowed_document_categories).and_return(allowed_document_categories)
-        service.call
-        expect(service.attachment_type_options).to eq expected_attachment_type_options
       end
 
       it "translates the name of the passporting benefit in the evidence type translation instance variable" do
@@ -54,5 +35,7 @@ module UploadedEvidence
         expect(service.evidence_type_translation).to eq "Income-related Employment and Support Allowance (ESA)"
       end
     end
+
+    it_behaves_like "An uploaded evidence service"
   end
 end

--- a/spec/services/uploaded_evidence/shared_examples_for_uploaded_evidence.rb
+++ b/spec/services/uploaded_evidence/shared_examples_for_uploaded_evidence.rb
@@ -1,0 +1,51 @@
+RSpec.shared_examples "An uploaded evidence service" do
+  describe "#attachment_type_options" do
+    let(:legal_aid_application) { create(:legal_aid_application) }
+    let(:controller) { instance_double Providers::UploadedEvidenceCollectionsController, legal_aid_application: }
+
+    # exhaustive but unrealistic example
+    let(:allowed_document_categories) do
+      %w[benefit_evidence
+         client_employment_evidence
+         part_employ_evidence
+         gateway_evidence
+         court_application_or_order
+         court_order
+         court_application
+         expert_report
+         parental_responsibility
+         local_authority_assessment
+         grounds_of_appeal
+         counsel_opinion
+         judgement
+         plf_court_order]
+    end
+
+    let(:expected_attachment_type_options) do
+      [
+        ["benefit_evidence", "Benefit evidence"],
+        ["client_employment_evidence", "Client's employment evidence"],
+        ["part_employ_evidence", "Partner's employment evidence"],
+        ["gateway_evidence", "Gateway evidence"],
+        ["court_application_or_order", "Court application or order"],
+        ["court_order", "Court order"],
+        ["court_application", "Court application"],
+        ["expert_report", "Expert report"],
+        ["parental_responsibility", "Parental responsibility evidence"],
+        ["local_authority_assessment", "Assessment"],
+        ["grounds_of_appeal", "Grounds of appeal"],
+        ["counsel_opinion", "Counsel's opinion"],
+        ["judgement", "Judgement"],
+        ["plf_court_order", "Court order"],
+        %w[uncategorised Uncategorised],
+      ]
+    end
+
+    it "returns array of [key, value] arrays for contructing select list of document categories" do
+      allow(legal_aid_application).to receive(:allowed_document_categories).and_return(allowed_document_categories)
+
+      service = described_class.new(controller)
+      expect(service.attachment_type_options).to eq expected_attachment_type_options
+    end
+  end
+end


### PR DESCRIPTION
## What
BUG: when delete is hit the document category's select list names change to a humanized version of their value.

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5792)

To replicate just add evidence, categorise, then delete one of the documents

## BEFORE
<img width="735" alt="Screenshot 2025-02-28 at 15 31 29" src="https://github.com/user-attachments/assets/4a961e25-63ca-4921-aebf-54e3c7cd8a97" />


## AFTER
<img width="774" alt="Screenshot 2025-02-28 at 15 30 53" src="https://github.com/user-attachments/assets/ad7dea93-32be-49aa-9818-eb2c7a23876a" />

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
