### PR TITLE
AP-5791: Fix inconsistent font-size on PLF interrupt page

### DIFF
--- a/app/views/providers/proceedings_sca/interrupts/show.html.erb
+++ b/app/views/providers/proceedings_sca/interrupts/show.html.erb
@@ -1,11 +1,13 @@
 <%= page_template(page_title: t(".#{@type}.title_html"), template: :basic, column_width: "full") do %>
   <%= interruption_card(heading: t(".#{@type}.title_html")) do %>
+    <div class="govuk-body moj-interruption-card__body">
+      <% if I18n.exists?("providers.proceedings_sca.interrupts.show.#{@type}.paragraph") %>
+        <p><%= t(".#{@type}.paragraph") %></p>
+      <% end %>
 
-    <% if I18n.exists?("providers.proceedings_sca.interrupts.show.#{@type}.paragraph") %>
-      <p class="govuk-body moj-interruption-card__body"><%= t(".#{@type}.paragraph") %></p>
-    <% end %>
-    <p class="govuk-body moj-interruption-card__body"><%= t(".#{@type}.options") %></p>
-    <%= govuk_list t(".#{@type}.option_bullets_html"), type: :bullet, classes: "moj-interruption-card__body" %>
+      <p><%= t(".#{@type}.options") %></p>
+      <%= govuk_list(t(".#{@type}.option_bullets_html"), type: :bullet) %>
+    </div>
 
     <div class='govuk-button-group moj-interruption-card__actions'>
       <%= govuk_button_link_to t(".#{@type}.proceedings"), providers_legal_aid_application_sca_interrupt_path(@legal_aid_application, @type), method: :delete, inverse: true, role: "button" %>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -2038,6 +2038,9 @@ en:
             <<: *default
             title_html: This is not a public law family matter
             paragraph: This is because it does not relate to an application or order set out in schedule 1, part 1, paragraph 1 of LASPO.
+            option_bullets_html:
+              - select a different proceeding in this service or <a class="govuk-link govuk-link--inverse" href="https://portal.legalservices.gov.uk/">use CCMS</a>
+              - go back and change your answer
             proceedings: Select a different proceeding
       child_subjects:
         error: Select yes if your client is the child subject of this proceeding

--- a/spec/requests/providers/proceedings_sca/interrupts_controller_spec.rb
+++ b/spec/requests/providers/proceedings_sca/interrupts_controller_spec.rb
@@ -27,9 +27,54 @@ RSpec.describe Providers::ProceedingsSCA::InterruptsController do
         expect(response).to have_http_status(:ok)
       end
 
-      it "shows text for a supervision order and a button to select a different proceeding" do
-        expect(response.body).to include("For special children act, a supervision order cannot be varied, discharged or extended")
-        expect(response.body).to include("Remove the proceeding and select a new one")
+      context "when passed a type of 'heard_as_alternatives'" do
+        let(:display) { "heard_as_alternatives" }
+
+        it "shows the expected interrupt content" do
+          expect(page)
+            .to have_content("You cannot submit this application under special children act")
+            .and have_content("This is because it needs to be means and merits tested")
+            .and have_content("check for a different matter type in this service or use CCMS")
+            .and have_content("go back and change your answer")
+            .and have_content("Check for another matter type")
+        end
+      end
+
+      context "when passed a type of 'supervision'" do
+        let(:display) { "supervision" }
+
+        it "shows the expected interrupt content" do
+          expect(page)
+            .to have_content("For special children act, a supervision order cannot be varied, discharged or extended")
+            .and have_content("select a different proceeding or matter type")
+            .and have_content("go back and change your answer")
+            .and have_content("Remove the proceeding and select a new one")
+        end
+      end
+
+      context "when passed a type of 'child_subject'" do
+        let(:display) { "child_subject" }
+
+        it "shows the expected interrupt content" do
+          expect(page)
+            .to have_content("For special children act, your client must be the child subject of the proceeding")
+            .and have_content("select a different proceeding or matter type")
+            .and have_content("go back and change your answer")
+            .and have_content("Remove the proceeding and select a new one")
+        end
+      end
+
+      context "when passed a type of 'plf_none_selected'" do
+        let(:display) { "plf_none_selected" }
+
+        it "shows the expected interrupt content" do
+          expect(page)
+            .to have_content("This is not a public law family matter")
+            .and have_content("This is because it does not relate to an application or order set out in schedule 1, part 1, paragraph 1 of LASPO.")
+            .and have_content("select a different proceeding in this service or use CCMS")
+            .and have_content("go back and change your answer")
+            .and have_content("Select a different proceeding")
+        end
       end
 
       context "when passed an unknown type" do


### PR DESCRIPTION
## What
Fix inconsistent font-size on PLF interrupt page and amend content

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5791)

Noticed during PLF run through the font-sizes for paras and lists are different and the content itself needed
changing. designs added to ticket

## TODO
This PR changes the interrupt card pattern more generally in the app. This is to correct markup inline with the [moj interrupt card](https://design-patterns.service.justice.gov.uk/components/interruption-card/) which has 
- a font-size of 1.5rem
- a single body class div with nested (`<p>`) elements inheriting them 
- has the action outside/underneath this body element, if necessary

## BEFORE
<img width="998" alt="Screenshot 2025-03-03 at 13 10 35" src="https://github.com/user-attachments/assets/1db880fa-83eb-4289-9fb4-790b07ea253c" />


## AFTER
<img width="1016" alt="Screenshot 2025-03-03 at 15 39 15" src="https://github.com/user-attachments/assets/bc44cd30-0182-4c25-a77a-ce5ec7ebf000" />


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
