### PR TITLE
Fix: prevent stdout in specs and prevent flicker

### DIFF
--- a/lib/tasks/fixes/ap_5580.rake
+++ b/lib/tasks/fixes/ap_5580.rake
@@ -48,7 +48,7 @@ namespace :fixes do
         ref: legal_aid_application.application_ref,
         proceedings: count,
         proceeding_states: all_client_relationship_to_proceeding_states(legal_aid_application).uniq,
-        proceeding_answers: uniq_proceeding_relationships(legal_aid_application),
+        proceeding_answers: uniq_proceeding_relationships(legal_aid_application).sort,
       }
 
       unless dry_run

--- a/spec/lib/tasks/fixes/ap_5580_spec.rb
+++ b/spec/lib/tasks/fixes/ap_5580_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "fixes:ap_5580", type: :task do
     Rails.application.load_tasks if Rake::Task.tasks.empty?
     Rake::Task["fixes:ap_5580"].reenable
     allow(Rails.logger).to receive(:info)
-    allow($stdout).to receive(:write) if ENV["CI"] # comment this out if using binding.pry in this file
+    allow($stdout).to receive(:write) # comment this out if using binding.pry in this file
     create(:legal_framework_merits_task_list, serialized_data:, legal_aid_application:)
   end
 


### PR DESCRIPTION
- **Fix: Prevent stdout during test run**
- **Fix: prevent flickering specs**

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

- stub stdout to prevent output during spec run locally as well as on CIV
e.g.
```ksh
All examples were filtered out; ignoring {focus: true}

Randomized with seed 62300
{affected: 1,
 submitted: 0,
 answered: 0,
 fixable: 1,
 investigate: 0,
 migrated: 1,
 data: [{id: "c306f9d4-8849-416d-80cd-23916f242f71", ref: "L-N3P-51V", proceedings: 1, proceeding_states: [:not_started], proceeding_answers: ["biological"], fixed: true}]}
...{affected: 1,
 submitted: 0,
 answered: 0,
 fixable: 1,
 investigate: 0,
 migrated: 0,
 data: [{id: "32aa9887-af64-49c6-aeb5-fc06f7b9d95a", ref: "L-UT9-5YY", proceedings: 2, proceeding_states: [:not_started], proceeding_answers: ["biological"]}]}
....{affected: 1,
```

- Sort proceeding relationships to prevent flicker
e.g. 
```ksh
       Diff:

       ┌ (Key) ──────────────────────────┐
       │ ‹-› in expected, not in actual  │
       │ ‹+› in actual, not in expected  │
       │ ‹ › in both expected and actual │
       └─────────────────────────────────┘

         {affected: 1,\n
          submitted: 1,\n
          answered: 1,\n
          fixable: 0,\n
          investigate: 1,\n
          migrated: 0,\n
          data:\n
           [{id: "98dcef51-0ce4-41a7-b37d-829e899693f0",\n
             ref: "L-YDF-P5M",\n
             proceedings: 2,\n
             proceeding_states: [:complete],\n
       -     proceeding_answers: ["biological", "court_order"]}]}\n
       +     proceeding_answers: ["court_order", "biological"]}]}\n
     # ./spec/lib/tasks/fixes/ap_5580_spec.rb:121:in 'block (5 levels) in <top (required)>'
```

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
