### PR TITLE
AP-5837: make review reasons more clear on means report

### DIFF
--- a/app/assets/stylesheets/print-styles.scss
+++ b/app/assets/stylesheets/print-styles.scss
@@ -100,6 +100,11 @@
     max-width: 200px;
     height: auto;
   }
+
+  // Remove grey box that was appearing on the print version of the page
+  .govuk-template {
+    background-color: govuk-colour("white");
+  }
 }
 
 @page {

--- a/app/views/providers/means_reports/_with_cfe_result_details.html.erb
+++ b/app/views/providers/means_reports/_with_cfe_result_details.html.erb
@@ -50,21 +50,14 @@
                        end %>
   <h2 class="govuk-heading-m print-no-break-after"><%= t("providers.means.check_income_answers.dependants.heading-h2") %></h2>
   <%= render "shared/check_answers/dependants", individual: individual_text, read_only: true, means_report: true %>
-
-  <%= render "caseworker_review" %>
 <% end %>
 
 <%= render "capital_result" %>
 
-  <h2 class="govuk-heading-m print-no-break-after"><%= t(".assets_heading") %></h2>
-  <% individual = "_with_partner" if @legal_aid_application.applicant.has_partner_with_no_contrary_interest? %>
-  <%= render "shared/check_answers/assets", means_report: true, read_only: true, individual: %>
+<h2 class="govuk-heading-m print-no-break-after"><%= t(".assets_heading") %></h2>
+<% individual = "_with_partner" if @legal_aid_application.applicant.has_partner_with_no_contrary_interest? %>
+<%= render "shared/check_answers/assets", means_report: true, read_only: true, individual: %>
 
-  <% if @legal_aid_application.passported? && @manual_review_determiner.manual_review_required? %>
-      <div class="govuk-!-padding-bottom-8"></div>
-      <%= render "caseworker_review" %>
-  <% end %>
-
-  <% if @legal_aid_application.uploading_bank_statements? %>
-    <%= render "uploaded_bank_statements" %>
-  <% end %>
+<% if @legal_aid_application.uploading_bank_statements? %>
+  <%= render "uploaded_bank_statements" %>
+<% end %>

--- a/app/views/providers/means_reports/show.html.erb
+++ b/app/views/providers/means_reports/show.html.erb
@@ -3,7 +3,11 @@
   <% @cfe_result = cfe_result if @cfe_result.nil? %>
   <% @manual_review_determiner = manual_review_determiner if @manual_review_determiner.nil? %>
 
+  <p class="govuk-body"><%= govuk_tag(text: t(".review_required")) if @manual_review_determiner.manual_review_required? %></p>
+
   <%= render "shared/application_ref", legal_aid_application: @legal_aid_application %>
+
+  <%= render "caseworker_review" if @manual_review_determiner.manual_review_required? %>
 
   <h2 class="govuk-heading-m print-no-break-after"><%= t(".client_details_heading") %></h2>
   <%= render(

--- a/config/initializers/grover.rb
+++ b/config/initializers/grover.rb
@@ -3,6 +3,7 @@ Grover.configure do |config|
     format: "A4",
     emulate_media: "print",
     prefer_css_page_size: true,
+    print_background: true,
     bypass_csp: true,
     cache: false,
     wait_until: "networkidle2",

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1625,10 +1625,11 @@ en:
           ineligible: Applicant is ineligible
           non_passported: Non-Passported application
       show:
+        heading: Means report
+        review_required: Review required
         client_details_heading: Client details
         partner_details_heading: Partner details
         evidence_upload_heading: Supporting evidence
-        heading: Means report
       with_cfe_result_details:
         assets_heading: *assets_heading
         capital_result_heading: *capital_result_heading


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5837)

- Move caseworker review to top of means report
- Update grover to print background colours

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
