### PR TITLE
AP-5842: Update capital logic on review pages

### DIFF
--- a/app/views/shared/review_application/_questions_and_answers.html.erb
+++ b/app/views/shared/review_application/_questions_and_answers.html.erb
@@ -66,13 +66,14 @@
 
     <h2 class="govuk-heading-l"><%= t("providers.means.check_income_answers.dependants.heading-h2") %></h2>
     <%= render "shared/check_answers/dependants", read_only: true %>
-
   <% end %>
 
-  <% individual = @source_application.applicant.has_partner_with_no_contrary_interest? ? "_with_partner" : nil %>
-  <h2 class="govuk-heading-l"><%= t(".capital-section-heading#{individual}") %></h2>
+  <% unless @legal_aid_application.non_means_tested? %>
+    <% individual = @source_application.applicant.has_partner_with_no_contrary_interest? ? "_with_partner" : nil %>
+    <h2 class="govuk-heading-l"><%= t(".capital-section-heading#{individual}") %></h2>
 
-  <%= render "shared/check_answers/assets", read_only: true, individual: %>
+    <%= render "shared/check_answers/assets", read_only: true, individual: %>
+  <% end %>
 
   <section class="merits page_break_before">
     <%= render(

--- a/features/providers/review_and_print.feature
+++ b/features/providers/review_and_print.feature
@@ -16,7 +16,7 @@ Feature: Review and print your application
       | h3  | Linking |
       | h3  | All applications with a family link to this one |
       | h3  | Copying |
-      
+
       | h2  | What you're applying for |
       | h3  | Extend, variation or discharge - Part IV |
       | h3  | Variation or discharge under section 5 protection from harassment act 1997 |
@@ -34,7 +34,7 @@ Feature: Review and print your application
       | h2  | Your client's outgoings |
       | h3  | Payments your client pays |
       | h3  | Payments your client pays in cash|
-      
+
       | h2  | Housing benefit |
       | h3  | Housing benefit details |
 
@@ -51,7 +51,7 @@ Feature: Review and print your application
 
       | h2  | Bank accounts |
       | h3  | Your client's accounts |
-      
+
       | h2  | Savings and assets |
       | h3  | Your client's savings or investments |
       | h3  | Your client's assets |
@@ -71,7 +71,7 @@ Feature: Review and print your application
 
       | h2  | Variation or discharge under section 5 protection from harassment act 1997 |
       | h3  | Chances of success |
-      
+
       | h2  | Print your application |
 
     Then the following sections should not exist:
@@ -123,7 +123,7 @@ Feature: Review and print your application
 
       | h2  | Bank accounts |
       | h3  | Your client's offline accounts |
-      
+
       | h2  | Savings and assets |
       | h3  | Your client's savings or investments |
       | h3  | Your client's assets |
@@ -143,7 +143,7 @@ Feature: Review and print your application
 
       | h2  | Variation or discharge under section 5 protection from harassment act 1997 |
       | h3  | Chances of success |
-      
+
       | h2  | Print your application |
 
     Then the following sections should not exist:
@@ -189,7 +189,7 @@ Feature: Review and print your application
 
       | h2  | Cases linked to this one |
       | h3  | Linking |
-      
+
       | h2  | What you're applying for |
       | h3  | Extend, variation or discharge - Part IV |
       | h3  | Variation or discharge under section 5 protection from harassment act 1997 |
@@ -227,7 +227,7 @@ Feature: Review and print your application
 
       | h2  | Variation or discharge under section 5 protection from harassment act 1997 |
       | h3  | Chances of success |
-      
+
       | h2  | Print your application |
 
     Then the following sections should not exist:
@@ -237,11 +237,11 @@ Feature: Review and print your application
       | h3  | Payments your client gets |
       | h3  | Payments your client gets in cash |
       | h3  | Student finance |
-      
+
       | h2  | Your client's outgoings |
       | h3  | Payments your client pays |
       | h3  | Payments your client pays in cash|
-      
+
       | h2  | Housing Benefit |
       | h3  | Housing benefit details |
 
@@ -262,7 +262,6 @@ Feature: Review and print your application
       | h2  | Client |
       | h2  | What you're applying for |
       | h2  | Inherent jurisdiction high court injunction |
-      | h2  | Your client's capital |
       | h2  | Print your application |
 
     And I should see 'Print the application and get the person acting for'
@@ -271,6 +270,7 @@ Feature: Review and print your application
     Then the following sections should not exist:
       | tag | section |
       | h3  | Income |
+      | h2  | Your client's capital |
       | h3  | Regular payments |
 
     And I should not see any change links
@@ -284,7 +284,6 @@ Feature: Review and print your application
       | h1  | Review and print your application |
       | h2  | Client |
       | h2  | What you're applying for |
-      | h2  | Your client's capital |
       | h2  | Case details |
       | h2  | Print your application |
 
@@ -295,6 +294,7 @@ Feature: Review and print your application
 
     And the following sections should not exist:
       | tag | section |
+      | h2  | Your client's capital |
       | h2  | Emergency cost limit |
 
     And I should not see any change links


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5842)

The capital section should be excluded from the review and print pages when the application is non-means tested
But one of the recent CYA updates accidentally removed it from a non-means test check and included it on all applications

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
