### PR TITLE
AP-5526: Update validation on capital disregards add details page

### DIFF
--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -683,6 +683,8 @@ en:
               blank: Enter a date in the correct format for when the payment is received
               date_not_valid: Enter a date in the correct format for when the payment is received
               date_is_in_the_future: Date should be in the past
+              over_2_years_ago: Enter a date that is within the last 24 months
+              within_2_years: Enter a date that is over 24 months ago
         proceeding:
           attributes:
             client_involvement_type_ccms_code:

--- a/spec/forms/providers/means/capital_disregards/add_details_form_spec.rb
+++ b/spec/forms/providers/means/capital_disregards/add_details_form_spec.rb
@@ -104,6 +104,62 @@ RSpec.describe Providers::Means::CapitalDisregards::AddDetailsForm do
       end
     end
 
+    context "when the disregard is backdated benefits" do
+      context "and it is mandatory" do
+        let(:capital_disregard) { create(:capital_disregard, :mandatory) }
+
+        context "and the date is within the last 2 years" do
+          let(:date_received) { 2.years.ago }
+
+          it "is valid" do
+            expect(form).to be_valid
+          end
+
+          it "saves the date received" do
+            expect(application.capital_disregards.first.date_received).to eq(Time.zone.today - 2.years)
+          end
+        end
+
+        context "and the date is more than 2 years ago" do
+          let(:date_received) { 3.years.ago }
+
+          it "is invalid" do
+            expect(form).not_to be_valid
+          end
+
+          it "adds an error message" do
+            expect(form.errors[:date_received]).to include("Enter a date that is within the last 24 months")
+          end
+        end
+      end
+
+      context "and it is discretionary" do
+        context "and the date is more than 2 years ago" do
+          let(:date_received) { 3.years.ago }
+
+          it "is valid" do
+            expect(form).to be_valid
+          end
+
+          it "saves the date received" do
+            expect(application.capital_disregards.first.date_received).to eq(Time.zone.today - 3.years)
+          end
+        end
+
+        context "and the date is within the last 2 years" do
+          let(:date_received) { 2.years.ago }
+
+          it "is invalid" do
+            expect(form).not_to be_valid
+          end
+
+          it "adds an error message" do
+            expect(form.errors[:date_received]).to include("Enter a date that is over 24 months ago")
+          end
+        end
+      end
+    end
+
     context "when the payment reason is blank" do
       let(:capital_disregard) { create(:capital_disregard, name:) }
       let(:name) { "compensation_for_personal_harm" }
@@ -133,6 +189,62 @@ RSpec.describe Providers::Means::CapitalDisregards::AddDetailsForm do
       expect(application.capital_disregards.first.amount).to eq 123
       expect(application.capital_disregards.first.account_name).to eq "Barclays"
       expect(application.discretionary_capital_disregards.first.date_received).to eq Date.new(2024, 2, 1)
+    end
+
+    context "when the disregard is backdated benefits" do
+      context "and it is mandatory" do
+        let(:capital_disregard) { create(:capital_disregard, :mandatory) }
+
+        context "and the date is within the last 2 years" do
+          let(:date_received) { 2.years.ago }
+
+          it "is valid" do
+            expect(form).to be_valid
+          end
+
+          it "saves the date received" do
+            expect(application.capital_disregards.first.date_received).to eq(Time.zone.today - 2.years)
+          end
+        end
+
+        context "and the date is more than 2 years ago" do
+          let(:date_received) { 3.years.ago }
+
+          it "is invalid" do
+            expect(form).not_to be_valid
+          end
+
+          it "adds an error message" do
+            expect(form.errors[:date_received]).to include("Enter a date that is within the last 24 months")
+          end
+        end
+      end
+
+      context "and it is discretionary" do
+        context "and the date is more than 2 years ago" do
+          let(:date_received) { 3.years.ago }
+
+          it "is valid" do
+            expect(form).to be_valid
+          end
+
+          it "saves the date received" do
+            expect(application.capital_disregards.first.date_received).to eq(Time.zone.today - 3.years)
+          end
+        end
+
+        context "and the date is within the last 2 years" do
+          let(:date_received) { 2.years.ago }
+
+          it "is invalid" do
+            expect(form).not_to be_valid
+          end
+
+          it "adds an error message" do
+            expect(form.errors[:date_received]).to include("Enter a date that is over 24 months ago")
+          end
+        end
+      end
     end
   end
 end

--- a/spec/forms/providers/means/capital_disregards/add_details_form_spec.rb
+++ b/spec/forms/providers/means/capital_disregards/add_details_form_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Providers::Means::CapitalDisregards::AddDetailsForm do
   let(:payment_reason) { nil }
   let(:amount) { 123 }
   let(:account_name) { "Barclays" }
-  let(:date_received) { Date.new(2024, 2, 1) }
+  let(:date_received) { Date.new(2023, 2, 1) }
   let(:date_received_3i) { date_received.day }
   let(:date_received_2i) { date_received.month }
   let(:date_received_1i) { date_received.year }
@@ -36,7 +36,7 @@ RSpec.describe Providers::Means::CapitalDisregards::AddDetailsForm do
         .to have_attributes(
           amount: 123,
           account_name: "Barclays",
-          date_received: Date.new(2024, 2, 1),
+          date_received: Date.new(2023, 2, 1),
         )
     end
 
@@ -188,7 +188,7 @@ RSpec.describe Providers::Means::CapitalDisregards::AddDetailsForm do
     it "updates the capital_disregard" do
       expect(application.capital_disregards.first.amount).to eq 123
       expect(application.capital_disregards.first.account_name).to eq "Barclays"
-      expect(application.discretionary_capital_disregards.first.date_received).to eq Date.new(2024, 2, 1)
+      expect(application.discretionary_capital_disregards.first.date_received).to eq Date.new(2023, 2, 1)
     end
 
     context "when the disregard is backdated benefits" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5526)

Add validation on add details page. If backdated benefits content says a date should be over 24 months ago, enforce it with validation. If backdated benefits content says a date should be within the last 24 months, enforce it with validation.

Add error messages and update specs to reflect changes.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
