### PR TITLE
Fix: Update applicant age handling

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -50,7 +50,7 @@ class Applicant < ApplicationRecord
   end
 
   def age
-    return age_for_means_test_purposes if no_means_test_required? || legal_aid_application&.special_children_act_proceedings?
+    return age_for_means_test_purposes if legal_aid_application&.non_means_tested?
 
     AgeCalculator.call(date_of_birth, legal_aid_application.calculation_date)
   end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -479,6 +479,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_public_law_family_non_means_tested_proceeding do
+      after(:create) do |application|
+        application.proceedings << create(:proceeding, :pbm40)
+      end
+    end
+
     trait :with_opponents_application_proceeding do
       after(:create) do |application|
         application.proceedings << create(:proceeding, :da001, :opponents_application)

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -179,6 +179,18 @@ RSpec.describe Applicant do
         expect(age).to be 48
       end
     end
+
+    context "when the application has non-means-tested plf proceedings" do
+      let(:legal_aid_application) { create(:legal_aid_application, :with_public_law_family_non_means_tested_proceeding, applicant:) }
+
+      before do
+        applicant.age_for_means_test_purposes = 49
+      end
+
+      it "returns age stored in age_for_means_test_purposes" do
+        expect(age).to be 49
+      end
+    end
   end
 
   describe "#under_18?" do


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5708)

The age handling for applicants had handlers for under 18 and SCA but could not handle PLF non-means tested applications.

Applicant and legal_aid_application both had methods of tracking non-means tested status and it had some duplicated methods, this uses the legal_aid_application method for applicant to remove some of the duplication and ensure consistent rules application if we add more non-means tested extensions in the future


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
