### PR TITLE
AP-5789: Prevent phantom vehicle submissions

### DIFF
--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -1,6 +1,14 @@
 class Vehicle < ApplicationRecord
   belongs_to :legal_aid_application
 
+  def complete?
+    [
+      estimated_value.present?,
+      more_than_three_years_old.in?([true, false]),
+      used_regularly.in?([true, false]),
+    ].all?(true)
+  end
+
   def purchased_on
     self[:purchased_on].nil? ? inferred_purchase_date : self[:purchased_on]
   end

--- a/app/services/flow/steps/provider_capital/own_homes_step.rb
+++ b/app/services/flow/steps/provider_capital/own_homes_step.rb
@@ -3,7 +3,13 @@ module Flow
     module ProviderCapital
       OwnHomesStep = Step.new(
         path: ->(application) { Steps.urls.providers_legal_aid_application_means_own_home_path(application) },
-        forward: ->(application) { application.own_home_no? ? :vehicles : :property_details },
+        forward: lambda do |application|
+          if application.own_home_no?
+            application.vehicles.any? ? :add_other_vehicles : :vehicles
+          else
+            :property_details
+          end
+        end,
         carry_on_sub_flow: ->(application) { !application.own_home_no? },
         check_answers: ->(application) { application.checking_non_passported_means? ? :check_capital_answers : :check_passported_answers },
       )

--- a/app/views/providers/means/add_other_vehicles/show.html.erb
+++ b/app/views/providers/means/add_other_vehicles/show.html.erb
@@ -10,7 +10,13 @@
     <%= govuk_summary_list(classes: "summary_list_action_width_auto") do |summary_list| %>
       <% @vehicles.each_with_index do |vehicle, index| %>
         <%= summary_list.with_row(html_attributes: { id: "transaction_#{index}" }) do |row| %>
-          <%= row.with_key { t(".vehicle_worth", amount: gds_number_to_currency(vehicle.estimated_value)) } %>
+          <% if vehicle.complete?
+               row.with_key { t(".vehicle_worth", amount: gds_number_to_currency(vehicle.estimated_value)) }
+               row.with_value { "" }
+             else
+               row.with_key { t(".vehicle_incomplete_key") }
+               row.with_value { t(".vehicle_incomplete_value") }
+             end %>
           <%= row.with_action(
                 text: t("generic.change"),
                 href: providers_legal_aid_application_means_vehicle_detail_path(@legal_aid_application, vehicle),

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1250,6 +1250,8 @@ en:
           page_title: Does your client have any other vehicles?
           existing: "You have added %{count}"
           vehicle_worth: Vehicle worth %{amount}
+          vehicle_incomplete_key: Vehicle record
+          vehicle_incomplete_value: Incomplete
           remove: Remove
           warning:
             delete: Are you sure you want to delete this vehicle?

--- a/features/step_definitions/employment_setup_steps.rb
+++ b/features/step_definitions/employment_setup_steps.rb
@@ -9,6 +9,7 @@ Given(/^an applicant named (\S+) (\S+) has completed his true layer interaction$
                                              :with_everything,
                                              :provider_assessing_means,
                                              :with_proceedings,
+                                             without_vehicle: true,
                                              applicant: @applicant,
                                              provider_step: "client_completed_means",
                                              provider: @registered_provider
@@ -16,7 +17,6 @@ Given(/^an applicant named (\S+) (\S+) has completed his true layer interaction$
   FactoryBot.create_list :bank_transaction, 2, :credit, bank_account:, amount: rand(1...1_500.0).round(2)
   FactoryBot.create_list :bank_transaction, 3, :debit, bank_account:,  amount: rand(1...1_500.0).round(2)
   create(:legal_framework_merits_task_list, :da001, legal_aid_application: @legal_aid_application)
-
   HMRC::CreateResponsesService.call(@legal_aid_application)
   sleep 0.5 # give time for the after_update on HMRC::Response to do its thing
 end

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -735,6 +735,9 @@ FactoryBot.define do
     end
 
     trait :with_everything do
+      transient do
+        without_vehicle { false }
+      end
       populate_vehicle { true }
       with_applicant
       with_non_passported_state_machine
@@ -758,6 +761,10 @@ FactoryBot.define do
       with_savings_amount
       with_open_banking_consent
       with_consent
+
+      after :create do |application, evaluator|
+        application.vehicles.destroy_all if evaluator.without_vehicle
+      end
     end
 
     trait :with_everything_and_address do

--- a/spec/models/vehicle_spec.rb
+++ b/spec/models/vehicle_spec.rb
@@ -4,6 +4,28 @@ RSpec.describe Vehicle do
   describe "#purchased_on" do
     let(:vehicle) { create(:vehicle, purchased_on:, more_than_three_years_old:) }
 
+    describe "#complete?" do
+      subject { vehicle.complete? }
+
+      context "when all questions have been answered" do
+        let(:vehicle) { create(:vehicle, estimated_value: 10_000, used_regularly: true, more_than_three_years_old: true) }
+
+        it { is_expected.to be true }
+      end
+
+      context "when questions responses are partially complete" do
+        let(:vehicle) { create(:vehicle, estimated_value: 10_000) }
+
+        it { is_expected.to be false }
+      end
+
+      context "when questions responses are completely missing" do
+        let(:vehicle) { create(:vehicle) }
+
+        it { is_expected.to be false }
+      end
+    end
+
     context "when purchased_on is populated" do
       let(:purchased_on) { 6.months.ago.to_date }
       let(:more_than_three_years_old) { nil }

--- a/spec/requests/providers/means/add_other_vehicles_controller_spec.rb
+++ b/spec/requests/providers/means/add_other_vehicles_controller_spec.rb
@@ -30,11 +30,23 @@ RSpec.describe Providers::Means::AddOtherVehiclesController do
       end
 
       context "and a vehicle has been added" do
+        let(:setup) { create(:vehicle, estimated_value: 1_234, used_regularly: true, more_than_three_years_old: true, legal_aid_application:) }
+
+        it "returns the expected page with the correct heading" do
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("You have added 1 vehicle")
+          expect(response.body).to have_css("dt", text: "Vehicle worth £1,234")
+        end
+      end
+
+      context "and an incomplete vehicle has been added" do
         let(:setup) { create_list(:vehicle, 1, legal_aid_application:) }
 
         it "returns the expected page with the correct heading" do
           expect(response).to have_http_status(:ok)
           expect(response.body).to include("You have added 1 vehicle")
+          expect(response.body).to have_css("dt", text: "Vehicle record")
+          expect(response.body).to have_css("dd", text: "Incomplete")
         end
       end
 

--- a/spec/services/flow/steps/provider_capital/own_homes_step_spec.rb
+++ b/spec/services/flow/steps/provider_capital/own_homes_step_spec.rb
@@ -20,7 +20,17 @@ RSpec.describe Flow::Steps::ProviderCapital::OwnHomesStep, type: :request do
     context "when the user selects that the applicant does not own their home" do
       let(:own_home) { "no" }
 
-      it { is_expected.to eq :vehicles }
+      context "and they have previously said there is a vehicle" do
+        let(:legal_aid_application) { create(:legal_aid_application, own_home:) }
+
+        before { create(:vehicle, legal_aid_application:) }
+
+        it { is_expected.to eq :add_other_vehicles }
+      end
+
+      context "and they have previously said there is no vehicle" do
+        it { is_expected.to eq :vehicles }
+      end
     end
   end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5789)

We have seen a few occurrences of providers getting stuck on CFE submission because partially complete vehicles were being submitted.

On the last incident, we tracked the logs and the user started a new vehicle and hit save as draft.  the next log shows them restarting from the capital introductions page.  It's not clear if this was a glitch or if they used the browser back button.

This PR takes a couple of steps to mitigate this...

It updates the add another vehicle page to show that a record is incomplete
![image](https://github.com/user-attachments/assets/1fd913a8-58e5-4d09-a751-13d8328319ab)

It also re-routes the page so that if the provider has said yes to vehicle, they will not see the yes/no question on a second pass through, they will see the above page with an incomplete record warning

I discussed validating this page so that they cannot submit if there are incomplete records, but agreed with design that we would investigate that in the future if people ignore the incomplete table entries

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
