### PR TITLE
AP-5651: Remove change of name checkbox

### DIFF
--- a/app/controllers/providers/proceeding_merits_task/prohibited_steps_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/prohibited_steps_controller.rb
@@ -29,8 +29,7 @@ module Providers
           params
             .expect(
               proceeding_merits_task_prohibited_steps: %i[uk_removal
-                                                          details
-                                                          confirmed_not_change_of_name],
+                                                          details],
             )
         end
       end

--- a/app/forms/providers/proceeding_merits_task/prohibited_steps_form.rb
+++ b/app/forms/providers/proceeding_merits_task/prohibited_steps_form.rb
@@ -3,14 +3,12 @@ module Providers
     class ProhibitedStepsForm < BaseForm
       form_for ::ProceedingMeritsTask::ProhibitedSteps
 
-      attr_accessor :uk_removal, :details, :proceeding_id, :confirmed_not_change_of_name
+      attr_accessor :uk_removal, :details, :proceeding_id
 
       before_validation :clear_details, if: :uk_removal?
 
       validates :uk_removal, inclusion: { in: %w[true false] }
       validates :details, presence: true, if: :requires_details?
-      validates :confirmed_not_change_of_name, inclusion: { in: %w[true] },
-                                               if: :requires_details?
 
     private
 

--- a/app/models/proceeding_merits_task/prohibited_steps.rb
+++ b/app/models/proceeding_merits_task/prohibited_steps.rb
@@ -1,5 +1,7 @@
 module ProceedingMeritsTask
   class ProhibitedSteps < ApplicationRecord
+    self.ignored_columns += %w[confirmed_not_change_of_name]
+
     belongs_to :proceeding
   end
 end

--- a/app/views/providers/proceeding_merits_task/prohibited_steps/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/prohibited_steps/show.html.erb
@@ -9,21 +9,10 @@
                     template: :basic,
                     back_link: {},
                     form:) do %>
-    <%= form.govuk_radio_buttons_fieldset :uk_removal, legend: { size: "xl", tag: "h1", text: page_title }, classes: "govuk-!-padding-bottom-4" do %>
+    <%= form.govuk_radio_buttons_fieldset :uk_removal, legend: { size: "xl", tag: "h1", text: page_title } do %>
       <%= form.govuk_radio_button :uk_removal, true, link_errors: true, label: { text: t("generic.yes") } %>
       <%= form.govuk_radio_button :uk_removal, false, label: { text: t("generic.no") } do %>
         <%= form.govuk_text_area :details, label: { text: t(".no-hint") }, rows: 5 %>
-
-        <%= form.govuk_check_boxes_fieldset :confirmed_not_change_of_name, multiple: false, legend: nil do %>
-          <%= form.govuk_check_box(
-                :confirmed_not_change_of_name,
-                true,
-                "",
-                multiple: false,
-                link_errors: true,
-                label: { text: t(".confirmed_not_change_of_name") },
-              ) %>
-        <% end %>
       <% end %>
     <% end %>
 

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -322,8 +322,6 @@ en:
               inclusion: Select yes if the prohibited step is to remove your client from the UK
             details:
               blank: Enter information to explain what you would like prohibited
-            confirmed_not_change_of_name:
-              inclusion: You must confirm this prohibited steps proceeding is not for a change of name application
         proceeding_merits_task/opponents_application:
           attributes:
             has_opponents_application:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -499,7 +499,6 @@ en:
         show:
           h1-heading: Is the prohibited step to prevent removal from the UK?
           no-hint: What are you asking to be prohibited?
-          confirmed_not_change_of_name: I confirm this prohibited steps proceeding is not for a change of name application
       relationship_to_child:
         biological_parent:
           error: Select yes if your client is the biological parent of any children involved

--- a/spec/forms/providers/proceeding_merits_task/prohibited_steps_form_spec.rb
+++ b/spec/forms/providers/proceeding_merits_task/prohibited_steps_form_spec.rb
@@ -9,13 +9,11 @@ module Providers
         {
           uk_removal:,
           details:,
-          confirmed_not_change_of_name:,
         }
       end
 
       let(:uk_removal) { "true" }
       let(:details) { "" }
-      let(:confirmed_not_change_of_name) { "" }
 
       describe "#valid?" do
         context "when all fields are valid" do
@@ -37,17 +35,11 @@ module Providers
             it "is invalid" do
               expect(prohibited_steps_form).not_to be_valid
               expect(prohibited_steps_form.errors).to be_added(:details, :blank)
-              expect(prohibited_steps_form.errors).to be_added(
-                :confirmed_not_change_of_name,
-                :inclusion,
-                value: "",
-              )
             end
           end
 
           context "and required fields are provided" do
             let(:details) { "some text input" }
-            let(:confirmed_not_change_of_name) { "true" }
 
             it { expect(prohibited_steps_form).to be_valid }
           end

--- a/spec/requests/providers/proceeding_merits_task/prohibited_steps_controller_spec.rb
+++ b/spec/requests/providers/proceeding_merits_task/prohibited_steps_controller_spec.rb
@@ -43,13 +43,11 @@ module Providers
 
         let(:uk_removal) { "true" }
         let(:details) { "" }
-        let(:confirmed_not_change_of_name) { "" }
         let(:params) do
           {
             proceeding_merits_task_prohibited_steps: {
               uk_removal:,
               details:,
-              confirmed_not_change_of_name:,
             },
           }
         end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5651)

Remove change of name checkbox from question as it is already asked earlier in the application. Remove associated translation values and specs. Remove padding class as it is not being used correctly, so was having no effect and it doesn't seem necessary.

Ignore `confirmed_not_change_of_name` column that will be removed in another PR

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
