### PR TITLE
AP-5651: Part 2 - remove change of name column

### DIFF
--- a/db/migrate/20250312140551_remove_confirmed_not_change_of_name_from_prohibited_steps.rb
+++ b/db/migrate/20250312140551_remove_confirmed_not_change_of_name_from_prohibited_steps.rb
@@ -1,0 +1,7 @@
+class RemoveConfirmedNotChangeOfNameFromProhibitedSteps < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured do
+      remove_column :prohibited_steps, :confirmed_not_change_of_name, :boolean, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_05_080311) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_12_140551) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -916,7 +916,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_05_080311) do
     t.string "details"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "confirmed_not_change_of_name"
     t.index ["proceeding_id"], name: "index_prohibited_steps_on_proceeding_id"
   end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5651)

Remove `confirmed_not_change_of_name` column. It is not being displayed anywhere and is just providing validation so there seems to be no issue with removing it

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
