### PR TITLE
Fix: Sass css compilation deprecation warnings

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,7 @@ $govuk-global-styles: true;
 $govuk-new-link-styles: true;
 $govuk-new-typography-scale: true;
 $govuk-assets-path: "/";
+$govuk-new-organisation-colours: true;
 
 @import "govuk-frontend/dist/govuk/index";
 @import "@ministryofjustice/frontend/moj/settings/measurements";

--- a/app/assets/stylesheets/providers/search_results.scss
+++ b/app/assets/stylesheets/providers/search_results.scss
@@ -1,10 +1,11 @@
 // stylelint-disable selector-max-id
+@use "sass:color";
 
 %highlight {
   margin-right: 1px;
   padding: 2px 0 0;
   border-bottom: 3px solid govuk-colour("yellow");
-  background-color: mix(govuk-colour("white"), govuk-colour("yellow"), 50%);
+  background-color: color.mix(govuk-colour("white"), govuk-colour("yellow"), 50%);
 }
 
 #search-field {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "stylelint": "stylelint app/assets/stylesheets",
     "test": "jest",
     "build": "esbuild app/javascript/*.* --bundle --loader:.gif=dataurl --sourcemap --minify --outdir=app/assets/builds --public-path=assets --target=es6",
-    "build:css": "sass ./app/assets/stylesheets/application.scss:./app/assets/builds/application.css --style=compressed --load-path=node_modules --quiet-deps",
+    "build:css": "sass ./app/assets/stylesheets/application.scss:./app/assets/builds/application.css --style=compressed --load-path=node_modules --quiet-deps --silence-deprecation slash-div --silence-deprecation import",
     "postinstall": "rm -rf node_modules/resolve/test/resolver/multirepo node_modules/eslint-plugin-react/node_modules/resolve/test/resolver/multirepo"
   },
   "dependencies": {


### PR DESCRIPTION
## What

This addresses the sass warning within our control, `mix` -> `color.mix`

It also addresses the warnings about future breaking changes by ignoring more govuk and Dart deprecation warnings

Pro: 
* quieter yarn builds

Con:
* risk of future updates taking us by surprise because we've been ignoring the warnings!

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
