### PR TITLE
AP-5651: Part 3 - Tidy up

### DIFF
--- a/app/models/proceeding_merits_task/prohibited_steps.rb
+++ b/app/models/proceeding_merits_task/prohibited_steps.rb
@@ -1,7 +1,5 @@
 module ProceedingMeritsTask
   class ProhibitedSteps < ApplicationRecord
-    self.ignored_columns += %w[confirmed_not_change_of_name]
-
     belongs_to :proceeding
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5651)

Remove ignore column as column has now been removed

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
