### PR TITLE
AP-5239: Remove SCA feature flag

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -24,7 +24,6 @@ module Admin
                                 enable_ccms_submission
                                 linked_applications
                                 collect_hmrc_data
-                                special_childrens_act
                                 public_law_family])
     end
 

--- a/app/forms/proceedings/substantive_defaults_form.rb
+++ b/app/forms/proceedings/substantive_defaults_form.rb
@@ -17,7 +17,7 @@ module Proceedings
                   :substantive_scope_limitation_code,
                   :additional_params
 
-    validates :accepted_substantive_defaults, presence: true, unless: proc { draft? || model.special_childrens_act? }
+    validates :accepted_substantive_defaults, presence: true, unless: proc { draft? || model.special_children_act? }
 
     def initialize(*args)
       super

--- a/app/forms/settings/setting_form.rb
+++ b/app/forms/settings/setting_form.rb
@@ -8,7 +8,6 @@ module Settings
                   :enable_ccms_submission,
                   :linked_applications,
                   :collect_hmrc_data,
-                  :special_childrens_act,
                   :public_law_family
 
     validates :mock_true_layer_data,
@@ -17,7 +16,6 @@ module Settings
               :enable_ccms_submission,
               :linked_applications,
               :collect_hmrc_data,
-              :special_childrens_act,
               :public_law_family,
               presence: true
   end

--- a/app/models/legal_aid_application.rb
+++ b/app/models/legal_aid_application.rb
@@ -203,7 +203,7 @@ class LegalAidApplication < ApplicationRecord
   end
 
   def special_children_act_related_proceedings?
-    proceedings.any? { |proceeding| proceeding.special_childrens_act? && proceeding.sca_type.eql?("related") }
+    proceedings.any? { |proceeding| proceeding.special_children_act? && proceeding.sca_type.eql?("related") }
   end
 
   def client_court_ordered_parental_responsibility?

--- a/app/models/proceeding.rb
+++ b/app/models/proceeding.rb
@@ -62,7 +62,7 @@ class Proceeding < ApplicationRecord
     "P_#{proceeding_case_id}"
   end
 
-  def special_childrens_act?
+  def special_children_act?
     ccms_matter_code == "KPBLW"
   end
 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -31,10 +31,6 @@ class Setting < ApplicationRecord
     setting.collect_hmrc_data
   end
 
-  def self.special_childrens_act?
-    setting.special_childrens_act
-  end
-
   def self.public_law_family?
     setting.public_law_family
   end

--- a/app/services/ccms/attribute_value_generator.rb
+++ b/app/services/ccms/attribute_value_generator.rb
@@ -120,7 +120,7 @@ module CCMS
       # as it is used to generate CCMS data. For the sake of CCMS we don't care if they've answered the question
       # as Client Involvement Type or using the merits task, just that there is a child subject on the application
       legal_aid_application.proceedings.any? do |proceeding|
-        proceeding.special_childrens_act? &&
+        proceeding.special_children_act? &&
           (legal_aid_application.applicant.relationship_to_children.eql?("child_subject") || proceeding.client_involvement_type_ccms_code.eql?("W"))
       end
     end

--- a/app/services/flow/proceeding_loop.rb
+++ b/app/services/flow/proceeding_loop.rb
@@ -44,11 +44,11 @@ module Flow
         when "client_involvement_type"
           :delegated_functions
         when "delegated_functions", "confirm_delegated_functions_date"
-          current_proceeding.used_delegated_functions? && !current_proceeding.special_childrens_act? ? :emergency_defaults : :substantive_defaults
+          current_proceeding.used_delegated_functions? && !current_proceeding.special_children_act? ? :emergency_defaults : :substantive_defaults
         when "emergency_defaults"
           current_proceeding.accepted_emergency_defaults ? :substantive_defaults : :emergency_level_of_service
         when "substantive_defaults"
-          if current_proceeding.accepted_substantive_defaults || current_proceeding.special_childrens_act?
+          if current_proceeding.accepted_substantive_defaults || current_proceeding.special_children_act?
             if @application.checking_answers? && next_incomplete_proceeding.nil?
               :limitations
             else

--- a/app/services/flow/steps/provider_proceeding_loop/substantive_defaults_step.rb
+++ b/app/services/flow/steps/provider_proceeding_loop/substantive_defaults_step.rb
@@ -8,7 +8,7 @@ module Flow
         end,
         forward: lambda do |application|
           proceeding = Proceeding.find(application.provider_step_params["id"])
-          if proceeding.accepted_substantive_defaults || proceeding.special_childrens_act?
+          if proceeding.accepted_substantive_defaults || proceeding.special_children_act?
             Flow::ProceedingLoop.next_step(application)
           else
             :substantive_level_of_service

--- a/app/services/legal_framework/proceeding_types/all.rb
+++ b/app/services/legal_framework/proceeding_types/all.rb
@@ -18,11 +18,6 @@ module LegalFramework
           @plf = pt_hash["ccms_matter_code"] == "KPBLB"
         end
 
-        # TODO: remove the below when the SCA feature flag is removed
-        def not_sca?
-          [@sca_core, @sca_related].all?(false)
-        end
-
         # TODO: remove the below when the PLF feature flag is removed
         def not_plf?
           @plf == false
@@ -43,9 +38,6 @@ module LegalFramework
         raise NoMatchingProceedingsFoundError, "No proceedings matched" if parsed_body.is_a?(Hash) && parsed_body["success"] == false
 
         result = parsed_body.map { |pt_hash| ProceedingTypeStruct.new(pt_hash) }
-        # TODO: remove the below when the SCA feature flag is removed
-        # filter out SCA applications
-        result.select!(&:not_sca?) unless Setting.special_childrens_act?
 
         # TODO: remove the below when the PLF feature flag is removed
         # Filter out PLF applications

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -67,16 +67,6 @@
         ) %>
 
     <%= form.govuk_collection_radio_buttons(
-          :special_childrens_act,
-          yes_no_options,
-          :value,
-          :label,
-          inline: true,
-          hint: { text: t(".hints.special_childrens_act") },
-          legend: { text: t(".labels.special_childrens_act") },
-        ) %>
-
-    <%= form.govuk_collection_radio_buttons(
           :public_law_family,
           yes_no_options,
           :value,

--- a/app/views/providers/has_national_insurance_numbers/show.html.erb
+++ b/app/views/providers/has_national_insurance_numbers/show.html.erb
@@ -7,9 +7,7 @@
 
   <%= page_template page_title: t(".page_title"), template: :basic, form: do %>
 
-    <%= form.govuk_radio_buttons_fieldset(:has_national_insurance_number,
-                                          legend: { text: page_title, size: "xl", tag: "h1" },
-                                          hint: { text: Setting.special_childrens_act? ? nil : t(".hint") }) do %>
+    <%= form.govuk_radio_buttons_fieldset(:has_national_insurance_number, legend: { text: page_title, size: "xl", tag: "h1" }) do %>
 
       <%= form.govuk_radio_button(
             :has_national_insurance_number,

--- a/app/views/providers/proceeding_loop/delegated_functions/show.html.erb
+++ b/app/views/providers/proceeding_loop/delegated_functions/show.html.erb
@@ -9,12 +9,12 @@
     <h1 class="govuk-heading-xl"><%= page_title %></h1>
     <%= form.govuk_radio_buttons_fieldset(:used_delegated_functions,
                                           legend: { size: "m", tag: "h2", text: t(".question") },
-                                          hint: { text: @proceeding.special_childrens_act? ? t(".sca_hint") : "" }) do %>
+                                          hint: { text: @proceeding.special_children_act? ? t(".sca_hint") : "" }) do %>
       <%= form.govuk_radio_button :used_delegated_functions, true, label: { text: t("generic.yes") } do %>
-         <%= form.govuk_date_field :used_delegated_functions_on,
-                                   legend: { text: t("shared.forms.date_input_fields.used_delegated_functions_on_label"), class: "govuk-label govuk-date-input__label" },
-                                   hint: { text: t("shared.forms.date_input_fields.used_delegated_functions_on_hint", options: number_of_days_ago(5)) } %>
-        <% end %>
+        <%= form.govuk_date_field :used_delegated_functions_on,
+                                  legend: { text: t("shared.forms.date_input_fields.used_delegated_functions_on_label"), class: "govuk-label govuk-date-input__label" },
+                                  hint: { text: t("shared.forms.date_input_fields.used_delegated_functions_on_hint", options: number_of_days_ago(5)) } %>
+      <% end %>
       <%= form.govuk_radio_button :used_delegated_functions, false, label: { text: t("generic.no") } %>
     <% end %>
 

--- a/app/views/providers/proceeding_loop/substantive_defaults/show.html.erb
+++ b/app/views/providers/proceeding_loop/substantive_defaults/show.html.erb
@@ -14,7 +14,7 @@
     <p><strong><%= t(".scope_header") %></strong> <%= form.object.substantive_scope_limitation_meaning %></p>
     <p><strong><%= t(".scope_description_header") %></strong> <%= form.object.substantive_scope_limitation_description %></p>
 
-    <% if !@proceeding.special_childrens_act? %>
+    <% if !@proceeding.special_children_act? %>
       <%= form.govuk_radio_buttons_fieldset :accepted_substantive_defaults,
                                             inline: false,
                                             legend: { size: "m", tag: "h2", text: t(".question") } do %>

--- a/app/views/providers/start/index.html.erb
+++ b/app/views/providers/start/index.html.erb
@@ -5,27 +5,16 @@
     <p class="govuk-body"><%= t(".intro") %></p>
 
     <p class="govuk-body"><%= t(".use_service.list_title") %></p>
-    <ul class="govuk-list govuk-list--bullet">
-      <% t(".use_service.list").each do |item| %>
-        <li><%= item %></li>
-      <% end %>
-    </ul>
+
+    <%= govuk_list t(".use_service.list"), type: :bullet %>
 
     <p class="govuk-body"><%= t(".dont_use_service.list_title") %></p>
-    <ul class="govuk-list govuk-list--bullet">
-      <% if Setting.linked_applications? %>
-        <% t(".dont_use_service.linked_applications_list").each do |item| %>
-          <li><%= item %></li>
-        <% end %>
-      <% else t(".dont_use_service.list").each do |item| %>
-        <li><%= item %></li>
-      <% end %>
-    <% end %>
-  </ul>
 
-  <p class="govuk-body"><%= t(".use_ccms_para_html") %></p>
-  <p class="govuk-body"><%= t(".progress_saved") %></p>
+    <%= govuk_list Setting.linked_applications? ? t(".dont_use_service.linked_applications_list") : t(".dont_use_service.list"), type: :bullet %>
 
-  <%= govuk_start_button(text: t("generic.sign_in"), href: providers_confirm_office_path, html_attributes: { id: "start" }) %>
-</div>
+    <p class="govuk-body"><%= t(".use_ccms_para_html") %></p>
+    <p class="govuk-body"><%= t(".progress_saved") %></p>
+
+    <%= govuk_start_button(text: t("generic.sign_in"), href: providers_confirm_office_path, html_attributes: { id: "start" }) %>
+  </div>
 </div>

--- a/app/views/providers/start/index.html.erb
+++ b/app/views/providers/start/index.html.erb
@@ -9,9 +9,6 @@
       <% t(".use_service.list").each do |item| %>
         <li><%= item %></li>
       <% end %>
-      <% if Setting.special_childrens_act? %>
-        <li><%= t(".use_service.sca_option") %></li>
-      <% end %>
     </ul>
 
     <p class="govuk-body"><%= t(".dont_use_service.list_title") %></p>
@@ -21,14 +18,14 @@
           <li><%= item %></li>
         <% end %>
       <% else t(".dont_use_service.list").each do |item| %>
-          <li><%= item %></li>
+        <li><%= item %></li>
       <% end %>
-      <% end %>
-    </ul>
+    <% end %>
+  </ul>
 
-    <p class="govuk-body"><%= t(".use_ccms_para_html") %></p>
-    <p class="govuk-body"><%= t(".progress_saved") %></p>
+  <p class="govuk-body"><%= t(".use_ccms_para_html") %></p>
+  <p class="govuk-body"><%= t(".progress_saved") %></p>
 
-    <%= govuk_start_button(text: t("generic.sign_in"), href: providers_confirm_office_path, html_attributes: { id: "start" }) %>
-  </div>
+  <%= govuk_start_button(text: t("generic.sign_in"), href: providers_confirm_office_path, html_attributes: { id: "start" }) %>
+</div>
 </div>

--- a/app/views/shared/check_answers/_proceeding_details.html.erb
+++ b/app/views/shared/check_answers/_proceeding_details.html.erb
@@ -20,7 +20,7 @@
             row.with_value { proceeding.used_delegated_functions_on&.strftime("%-d %B %Y") || t(".delegated_function_details.not_used") }
           end
 
-          if proceeding.used_delegated_functions? && !proceeding.special_childrens_act?
+          if proceeding.used_delegated_functions? && !proceeding.special_children_act?
             summary_list.with_row(html_attributes: { id: "app-check-your-answers__#{proceeding.name}_emergency_level_of_service_#{proceeding.id}" }) do |row|
               row.with_key(text: t(".level_of_service.emergency.question"))
               row.with_value { proceeding.send(:emergency_level_of_service_name) }

--- a/app/views/shared/check_answers/merits/_merits_proceeding_section.html.erb
+++ b/app/views/shared/check_answers/merits/_merits_proceeding_section.html.erb
@@ -25,7 +25,7 @@
       end %>
 <% end %>
 
-<% if proceeding.attempts_to_settle || proceeding.section8? || proceeding.specific_issue || proceeding.prohibited_steps || proceeding.special_childrens_act? %>
+<% if proceeding.attempts_to_settle || proceeding.section8? || proceeding.specific_issue || proceeding.prohibited_steps || proceeding.special_children_act? %>
   <% if proceeding.attempts_to_settle %>
      <%= govuk_summary_card(title: t(".attempts_to_settle_heading"), html_attributes: { id: "app-check-your-answers__#{proceeding.id}_attempts_to_settle" }, heading_level: 3) do |card|
            unless read_only
@@ -43,7 +43,7 @@
          end %>
   <% end %>
 
-  <% if proceeding.section8? || (proceeding.special_childrens_act? && proceeding.client_involvement_type_ccms_code.in?(["A", "D"])) %>
+  <% if proceeding.section8? || (proceeding.special_children_act? && proceeding.client_involvement_type_ccms_code.in?(["A", "D"])) %>
      <%= govuk_summary_card(title: t(".linked_children_heading"), html_attributes: { id: "app-check-your-answers__#{proceeding.id}_linked_children" }, heading_level: 3) do |card|
            unless read_only
              card.with_action do
@@ -115,7 +115,7 @@
       end %>
 <% end %>
 
-<% unless proceeding.special_childrens_act? %>
+<% unless proceeding.special_children_act? %>
   <% if proceeding.vary_order %>
     <%= govuk_summary_card(title: t(".vary_order_heading"), html_attributes: { id: "app-check-your-answers__#{proceeding.id}_vary_order" }, heading_level: 3) do |card|
           unless read_only

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -81,7 +81,6 @@ en:
           enable_evidence_upload: Enable the new evidence upload feature
           linked_applications: Enable linking and copying cases
           collect_hmrc_data: Collect HMRC data
-          special_childrens_act: Enable Special Childrens Act
           public_law_family: Enable Public Law Family
         hints:
           mock_true_layer_data: Select Yes and TrueLayer data will be replaced by mock data from %{bank_transaction_filename}
@@ -93,7 +92,6 @@ en:
           enable_evidence_upload: Select Yes to enable the new evidence upload feature for solicitors
           linked_applications: Select Yes to enable the linking and copying cases feature for solicitors
           collect_hmrc_data: Select Yes to enable calls to HMRC for employment data
-          special_childrens_act: Select Yes to enable the special childrens act matter type
           public_law_family: Select Yes to enable Public Law Family feature
 
       update:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -838,10 +838,6 @@ en:
     has_national_insurance_numbers:
       show:
         page_title: Does your client have a National Insurance number?
-        hint: |
-          We'll use your client's National Insurance number to check if they receive
-          a passported benefit. If you do not have it you may have to do a means
-          assessment for them.
         nino_label: Enter National Insurance number
     has_other_involved_children:
       show:
@@ -1856,7 +1852,7 @@ en:
           list:
             - domestic abuse, except DAPO (domestic abuse protection orders)
             - section 8
-          sca_option: special children act
+            - special children act
         dont_use_service:
           list_title: "But do not use this service if:"
           list:

--- a/db/migrate/20250313140248_remove_sca_from_settings.rb
+++ b/db/migrate/20250313140248_remove_sca_from_settings.rb
@@ -1,0 +1,7 @@
+class RemoveSCAFromSettings < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured do
+      remove_column :settings, :special_childrens_act, :boolean, null: false, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_12_140551) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_13_140248) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -1024,7 +1024,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_12_140551) do
     t.datetime "cfe_compare_run_at"
     t.boolean "linked_applications", default: false, null: false
     t.boolean "collect_hmrc_data", default: false, null: false
-    t.boolean "special_childrens_act", default: false, null: false
     t.boolean "public_law_family", default: false, null: false
   end
 

--- a/features/providers/special_children_act/secure_accomodation_order_cit.feature
+++ b/features/providers/special_children_act/secure_accomodation_order_cit.feature
@@ -2,7 +2,6 @@ Feature: Adding an SCA Secure Accommodation Order proceeding sets all client_inv
   @javascript @vcr
   Scenario: When a provider is adding proceedings and only adds a Secure Accommodation Order
     Given I start the journey as far as the applicant page
-    And the feature flag for special_childrens_act is enabled
 
     When I enter name 'Test', 'User'
     Then I choose 'No'

--- a/features/providers/start_page.feature
+++ b/features/providers/start_page.feature
@@ -6,7 +6,6 @@ Feature: Start page
     Given I am logged in as a provider
     And the feature flag for collect_hmrc_data is enabled
     And the feature flag for linked_applications is enabled
-    And the feature flag for special_childrens_act is enabled
     And the feature flag for public_law_family is enabled
 
     When I visit the application service

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Setting do
         expect(rec.alert_via_sentry?).to be true
         expect(rec.linked_applications?).to be false
         expect(rec.collect_hmrc_data?).to be false
-        expect(rec.special_childrens_act?).to be false
         expect(rec.public_law_family?).to be false
       end
     end
@@ -31,7 +30,6 @@ RSpec.describe Setting do
           alert_via_sentry: false,
           linked_applications: true,
           collect_hmrc_data: true,
-          special_childrens_act: true,
           public_law_family: true,
         )
       end
@@ -46,7 +44,6 @@ RSpec.describe Setting do
         expect(rec.alert_via_sentry?).to be false
         expect(rec.linked_applications?).to be true
         expect(rec.collect_hmrc_data?).to be true
-        expect(rec.special_childrens_act?).to be true
         expect(rec.public_law_family?).to be true
       end
     end
@@ -64,7 +61,6 @@ RSpec.describe Setting do
       expect(described_class.alert_via_sentry?).to be true
       expect(described_class.linked_applications?).to be false
       expect(described_class.collect_hmrc_data?).to be false
-      expect(described_class.special_childrens_act?).to be false
       expect(described_class.public_law_family?).to be false
     end
   end

--- a/spec/requests/admin/settings_controller_spec.rb
+++ b/spec/requests/admin/settings_controller_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe Admin::SettingsController do
           linked_applications: "true",
           collect_hmrc_data: "true",
           home_address: "true",
-          special_childrens_act: "true",
           public_law_family: "true",
         },
       }
@@ -60,7 +59,6 @@ RSpec.describe Admin::SettingsController do
       expect(setting.allow_welsh_translation?).to be(true)
       expect(setting.linked_applications?).to be(true)
       expect(setting.collect_hmrc_data?).to be(true)
-      expect(setting.special_childrens_act?).to be(true)
       expect(setting.public_law_family?).to be(true)
     end
 

--- a/spec/services/legal_framework/proceeding_types/all_spec.rb
+++ b/spec/services/legal_framework/proceeding_types/all_spec.rb
@@ -4,43 +4,25 @@ RSpec.describe LegalFramework::ProceedingTypes::All do
   subject(:all) { described_class.new(legal_aid_application) }
 
   before do
-    allow(Setting).to receive_messages(special_childrens_act?: sca_enabled, public_law_family?: plf_enabled)
+    allow(Setting).to receive_messages(public_law_family?: plf_enabled)
     stub_request(:post, uri).to_return(body:)
   end
 
   let(:legal_aid_application) { create :legal_aid_application }
   let(:body) { all_proceeding_types_payload }
   let(:uri) { "#{Rails.configuration.x.legal_framework_api_host}/proceeding_types/filter" }
-  let(:sca_enabled) { false }
   let(:plf_enabled) { false }
 
   describe ".call" do
     subject(:call) { all.call }
 
-    context "when the special children act setting is on" do
-      let(:sca_enabled) { true }
-
+    context "when the plf flag is off" do
       it "returns the expected proceedings" do
         expect(call.map(&:ccms_code)).to match_array %w[DA001 SE097 DA003 SE016E DA006 PB003]
       end
     end
 
-    context "when the special children act setting and public law family settings are off" do
-      it "returns the expected proceedings" do
-        expect(call.map(&:ccms_code)).to match_array %w[DA001 SE097 DA003 SE016E DA006]
-      end
-    end
-
-    context "when the public law family setting is on" do
-      let(:plf_enabled) { true }
-
-      it "returns the expected proceedings" do
-        expect(call.map(&:ccms_code)).to match_array %w[DA001 SE097 DA003 SE016E DA006 PBM01]
-      end
-    end
-
-    context "when all matter types flags are on" do
-      let(:sca_enabled) { true }
+    context "when the plf flag is on" do
       let(:plf_enabled) { true }
 
       it "returns the expected proceedings" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5239)

- Remove all references to SCA feature flag as it is now on by default
- Rename everything from special_childrens_act to special_children_act, to keep codebase consistent and to match the name of the act
- Update view on start page to use list component from govuk components library

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
