### PR TITLE
AP-5775: Changing merits answers that require evidence - not handled

### DIFF
--- a/app/controllers/concerns/providers/delete_attachments.rb
+++ b/app/controllers/concerns/providers/delete_attachments.rb
@@ -1,0 +1,16 @@
+module Providers
+  module DeleteAttachments
+  private
+
+    def find_attachments_starting_with(text)
+      legal_aid_application.attachments.find_all { |attachment| attachment[:attachment_type].start_with?(text) }
+    end
+
+    def delete_evidence(array)
+      array.each do |attachment|
+        attachment.document.purge_later
+        attachment.destroy!
+      end
+    end
+  end
+end

--- a/app/controllers/providers/application_merits_task/court_order_copies_controller.rb
+++ b/app/controllers/providers/application_merits_task/court_order_copies_controller.rb
@@ -3,10 +3,17 @@ module Providers
     class CourtOrderCopiesController < ProviderBaseController
       def show
         @form = ApplicationMeritsTask::PLFCourtOrderForm.new(model: legal_aid_application)
+        @display_banner = plf_court_order_attached?
       end
 
       def update
         @form = ApplicationMeritsTask::PLFCourtOrderForm.new(form_params)
+
+        if plf_court_order_attached? && @form.plf_court_order.eql?("false")
+          plf_court_order_evidence.delete
+          plf_court_order_pdf.delete if plf_court_order_pdf.present?
+        end
+
         render :show unless update_task_save_continue_or_draft(:application, :court_order_copy)
       end
 
@@ -16,6 +23,20 @@ module Providers
 
           params.expect(legal_aid_application: [:plf_court_order])
         end
+      end
+
+    private
+
+      def plf_court_order_attached?
+        plf_court_order_evidence.present?
+      end
+
+      def plf_court_order_evidence
+        legal_aid_application.attachments.find { |attachment| attachment[:attachment_type] == "plf_court_order" }
+      end
+
+      def plf_court_order_pdf
+        legal_aid_application.attachments.find { |attachment| attachment[:attachment_type] == "plf_court_order_pdf" }
       end
     end
   end

--- a/app/controllers/providers/proceeding_merits_task/child_care_assessments_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/child_care_assessments_controller.rb
@@ -1,6 +1,8 @@
 module Providers
   module ProceedingMeritsTask
     class ChildCareAssessmentsController < ProviderBaseController
+      include DeleteAttachments
+
       def show
         @form = ChildCareAssessmentForm.new(model: child_care_assessment)
         @display_banner = local_authority_assessment_attached?
@@ -12,10 +14,8 @@ module Providers
         if @form.assessed?
           save_continue_or_draft(@form)
         else
-          if local_authority_assessment_attached?
-            local_authority_assessment_evidence.delete
-            local_authority_assessment_pdf.delete if local_authority_assessment_pdf.present?
-          end
+          delete_evidence(local_authority_assessment_evidence) if local_authority_assessment_attached?
+
           render :show unless update_task_save_continue_or_draft(proceeding.ccms_code.to_sym, :client_child_care_assessment)
         end
       end
@@ -39,11 +39,7 @@ module Providers
       end
 
       def local_authority_assessment_evidence
-        legal_aid_application.attachments.find { |attachment| attachment[:attachment_type] == "local_authority_assessment" }
-      end
-
-      def local_authority_assessment_pdf
-        legal_aid_application.attachments.find { |attachment| attachment[:attachment_type] == "local_authority_assessment_pdf" }
+        @local_authority_assessment_evidence ||= find_attachments_starting_with("local_authority_assessment")
       end
 
       def form_params

--- a/app/controllers/providers/proceeding_merits_task/child_care_assessments_controller.rb
+++ b/app/controllers/providers/proceeding_merits_task/child_care_assessments_controller.rb
@@ -3,6 +3,7 @@ module Providers
     class ChildCareAssessmentsController < ProviderBaseController
       def show
         @form = ChildCareAssessmentForm.new(model: child_care_assessment)
+        @display_banner = local_authority_assessment_attached?
       end
 
       def update
@@ -11,6 +12,10 @@ module Providers
         if @form.assessed?
           save_continue_or_draft(@form)
         else
+          if local_authority_assessment_attached?
+            local_authority_assessment_evidence.delete
+            local_authority_assessment_pdf.delete if local_authority_assessment_pdf.present?
+          end
           render :show unless update_task_save_continue_or_draft(proceeding.ccms_code.to_sym, :client_child_care_assessment)
         end
       end
@@ -27,6 +32,18 @@ module Providers
 
       def legal_aid_application
         @legal_aid_application ||= proceeding.legal_aid_application
+      end
+
+      def local_authority_assessment_attached?
+        local_authority_assessment_evidence.present?
+      end
+
+      def local_authority_assessment_evidence
+        legal_aid_application.attachments.find { |attachment| attachment[:attachment_type] == "local_authority_assessment" }
+      end
+
+      def local_authority_assessment_pdf
+        legal_aid_application.attachments.find { |attachment| attachment[:attachment_type] == "local_authority_assessment_pdf" }
       end
 
       def form_params

--- a/app/views/providers/application_merits_task/court_order_copies/show.html.erb
+++ b/app/views/providers/application_merits_task/court_order_copies/show.html.erb
@@ -7,7 +7,7 @@
 
   <% if @display_banner %>
     <% notification_banner_title = t("generic.important") %>
-    <% notification_banner_text = t(".banner_text") %>
+    <% notification_banner_text = t("generic.uploaded_files_will_be_deleted") %>
   <% end %>
 
   <%= page_template page_title: t(".h1-heading"),

--- a/app/views/providers/application_merits_task/court_order_copies/show.html.erb
+++ b/app/views/providers/application_merits_task/court_order_copies/show.html.erb
@@ -4,7 +4,17 @@
       method: :patch,
       local: true,
     ) do |form| %>
-  <%= page_template page_title: t(".h1-heading"), template: :basic, form: do %>
+
+  <% if @display_banner %>
+    <% notification_banner_title = t("generic.important") %>
+    <% notification_banner_text = t(".banner_text") %>
+  <% end %>
+
+  <%= page_template page_title: t(".h1-heading"),
+                    template: :basic,
+                    form:,
+                    notification_banner_title:,
+                    notification_banner_text: do %>
     <%= form.govuk_radio_buttons_fieldset :plf_court_order, legend: { size: "xl", tag: "h1", text: page_title } do %>
       <%= form.govuk_radio_button :plf_court_order,
                                   true,

--- a/app/views/providers/proceeding_merits_task/child_care_assessments/show.html.erb
+++ b/app/views/providers/proceeding_merits_task/child_care_assessments/show.html.erb
@@ -5,9 +5,16 @@
       local: true,
     ) do |form| %>
 
+  <% if @display_banner %>
+    <% notification_banner_title = t("generic.important") %>
+    <% notification_banner_text = t("generic.uploaded_files_will_be_deleted") %>
+  <% end %>
+
   <%= page_template page_title: t(".h1-heading"),
                     head_title: "#{@proceeding.meaning} - " + t(".h1-heading"),
                     template: :basic,
+                    notification_banner_title:,
+                    notification_banner_text:,
                     form: do %>
     <%= form.govuk_collection_radio_buttons :assessed,
                                             yes_no_options(yes: t(".radio_hint_yes")),

--- a/config/locales/en/generic.yml
+++ b/config/locales/en/generic.yml
@@ -68,6 +68,7 @@ en:
     undefined: Undefined
     upload: Upload
     upload_file: Upload a file
+    uploaded_files_will_be_deleted: Any related files you uploaded will be deleted if you change your answer
     view: View
     'yes': 'Yes'
     yes_but_none: Yes, but none specified

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -692,7 +692,6 @@ en:
         show:
           h1-heading: Do you have a copy of the court order for this application?
           yes-hint: We will ask you to upload a copy of the court order at the end of this application
-          banner_text: Any related files you uploaded will be deleted if you change your answer
       nature_of_urgencies:
         show:
           h1-heading: What is the nature of the urgency?

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -692,6 +692,7 @@ en:
         show:
           h1-heading: Do you have a copy of the court order for this application?
           yes-hint: We will ask you to upload a copy of the court order at the end of this application
+          banner_text: Any related files you uploaded will be deleted if you change your answer
       nature_of_urgencies:
         show:
           h1-heading: What is the nature of the urgency?

--- a/spec/factories/attachments.rb
+++ b/spec/factories/attachments.rb
@@ -48,6 +48,11 @@ FactoryBot.define do
       attachment_name { "plf_court_order.pdf" }
     end
 
+    trait :local_authority_assessment do
+      attachment_type { "local_authority_assessment" }
+      attachment_name { "local_authority_assessment.pdf" }
+    end
+
     after(:build) do |attachment|
       filepath = Rails.root.join("spec/fixtures/files/documents/hello_world.pdf")
 

--- a/spec/factories/attachments.rb
+++ b/spec/factories/attachments.rb
@@ -43,6 +43,11 @@ FactoryBot.define do
       attachment_name { "uploaded_evidence_collection" }
     end
 
+    trait :plf_court_order do
+      attachment_type { "plf_court_order" }
+      attachment_name { "plf_court_order.pdf" }
+    end
+
     after(:build) do |attachment|
       filepath = Rails.root.join("spec/fixtures/files/documents/hello_world.pdf")
 

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -1268,6 +1268,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_plf_court_order_attached do
+      after :create do |application|
+        create(:attachment, :plf_court_order, legal_aid_application: application)
+      end
+    end
+
     trait :with_ccms_submission do
       after :create do |application|
         create(:ccms_submission, :case_created, legal_aid_application: application)

--- a/spec/factories/legal_aid_applications.rb
+++ b/spec/factories/legal_aid_applications.rb
@@ -1274,6 +1274,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_local_authority_assessment_attached do
+      after :create do |application|
+        create(:attachment, :local_authority_assessment, legal_aid_application: application)
+      end
+    end
+
     trait :with_ccms_submission do
       after :create do |application|
         create(:ccms_submission, :case_created, legal_aid_application: application)

--- a/spec/requests/providers/application_merits_task/court_order_copies_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/court_order_copies_controller_spec.rb
@@ -26,6 +26,20 @@ module Providers
 
           it_behaves_like "a provider not authenticated"
         end
+
+        context "when there is not PLF court order evidence already uploaded" do
+          it "does not display the banner" do
+            expect(response.body).to have_no_text("Any related files you uploaded will be deleted if you change your answer")
+          end
+        end
+
+        context "when there is PLF court order evidence already uploaded" do
+          let(:legal_aid_application) { create(:legal_aid_application, :with_public_law_family_prohibited_steps_order, :with_plf_court_order_attached) }
+
+          it "does display the banner" do
+            expect(response.body).to have_text("Any related files you uploaded will be deleted if you change your answer")
+          end
+        end
       end
 
       describe "PATCH /providers/applications/:legal_aid_application_id/court_order" do
@@ -61,6 +75,14 @@ module Providers
           it "redirects to the next page" do
             expect(response).to redirect_to(flow_forward_path)
           end
+
+          context "when there is PLF court order evidence already uploaded" do
+            let(:legal_aid_application) { create(:legal_aid_application, :with_public_law_family_prohibited_steps_order, :with_plf_court_order_attached) }
+
+            it "does not delete the uploaded evidence" do
+              expect(legal_aid_application.attachments.plf_court_order.first).not_to be_nil
+            end
+          end
         end
 
         context "when the user chooses no" do
@@ -72,6 +94,14 @@ module Providers
 
           it "redirects to the next page" do
             expect(response).to redirect_to(flow_forward_path)
+          end
+
+          context "when there is PLF court order evidence already uploaded" do
+            let(:legal_aid_application) { create(:legal_aid_application, :with_public_law_family_prohibited_steps_order, :with_plf_court_order_attached) }
+
+            it "deletes the uploaded evidence" do
+              expect(legal_aid_application.attachments.plf_court_order.first).to be_nil
+            end
           end
         end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5775)

Delete evidence if user changes their answer to the question that determines if evidence is needed. Add notification banner to warn them that their attachment will be deleted. Add tests to cover functionality

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
