### PR TITLE
Reduce BankHolidayUpdateWorker update interval

### DIFF
--- a/app/workers/bank_holiday_update_worker.rb
+++ b/app/workers/bank_holiday_update_worker.rb
@@ -3,10 +3,8 @@ class BankHolidayUpdateWorker
   include Sidekiq::Worker
   include Sidekiq::Status::Worker
 
-  UPDATE_INTERVAL = 2.days
-
   def perform
-    return true if last_updated.updated_at > UPDATE_INTERVAL.ago
+    return true if last_updated.updated_at > 1.month.ago
     return last_updated.touch if stored_data_current?
 
     lastest_data.save!

--- a/spec/workers/bank_holiday_update_worker_spec.rb
+++ b/spec/workers/bank_holiday_update_worker_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe BankHolidayUpdateWorker, vcr: { cassette_name: "gov_uk_bank_holid
   subject(:update_worker) { bank_holiday_update_worker.perform }
 
   let(:bank_holiday_update_worker) { described_class.new }
-  let(:stale_date) { Time.current.utc - described_class::UPDATE_INTERVAL - 2.hours }
+  let(:stale_date) { Time.current.utc - 1.month - 2.hours }
 
   context "when it is current" do
     before { create(:bank_holiday) }


### PR DESCRIPTION
## What

Reduce the BankHolidayUpdateWorker update interval from every 2 days to once a month.
Having an update interval in days seemed wasteful.

This also removes the `UPDATE_INTERVAL` constant as it is used once in this worker and once in spec.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
