### PR TITLE
AP-5776 Fix bypassing evidence validation bug

### DIFF
--- a/app/controllers/providers/application_merits_task/court_order_copies_controller.rb
+++ b/app/controllers/providers/application_merits_task/court_order_copies_controller.rb
@@ -18,7 +18,7 @@ module Providers
 
         if @form.valid?
           @form.save!
-          return go_forward(@form.copy_of_court_order?)
+          go_forward(@form.copy_of_court_order?)
         else
           render :show
         end

--- a/app/controllers/providers/application_merits_task/court_order_copies_controller.rb
+++ b/app/controllers/providers/application_merits_task/court_order_copies_controller.rb
@@ -13,7 +13,15 @@ module Providers
 
         delete_evidence(plf_court_order_evidence) if plf_court_order_attached? && @form.plf_court_order.eql?("false")
 
-        render :show unless update_task_save_continue_or_draft(:application, :court_order_copy)
+        update_task(:application, :court_order_copy)
+        return continue_or_draft if draft_selected?
+
+        if @form.valid?
+          @form.save!
+          return go_forward(@form.copy_of_court_order?)
+        else
+          render :show
+        end
       end
 
       def form_params

--- a/app/forms/providers/application_merits_task/plf_court_order_form.rb
+++ b/app/forms/providers/application_merits_task/plf_court_order_form.rb
@@ -6,6 +6,10 @@ module Providers
       attr_accessor :plf_court_order
 
       validates :plf_court_order, inclusion: %w[true false], unless: :draft?
+
+      def copy_of_court_order?
+        plf_court_order == "true"
+      end
     end
   end
 end

--- a/app/services/flow/steps/provider_merits/child_care_assessment_result_step.rb
+++ b/app/services/flow/steps/provider_merits/child_care_assessment_result_step.rb
@@ -10,7 +10,7 @@ module Flow
           proceeding = application.proceedings.find(application.provider_step_params["merits_task_list_id"])
           Flow::MeritsLoop.forward_flow(application, proceeding.ccms_code.to_sym)
         end,
-        check_answers: :check_merits_answers,
+        check_answers: :uploaded_evidence_collections,
       )
     end
   end

--- a/app/services/flow/steps/provider_merits/court_order_copies_step.rb
+++ b/app/services/flow/steps/provider_merits/court_order_copies_step.rb
@@ -4,7 +4,13 @@ module Flow
       CourtOrderCopiesStep = Step.new(
         path: ->(application) { Steps.urls.providers_legal_aid_application_court_order_copy_path(application) },
         forward: ->(application) { Flow::MeritsLoop.forward_flow(application, :application) },
-        check_answers: :check_merits_answers,
+        check_answers: lambda { |_application, copy_of_court_order|
+          if copy_of_court_order
+            :uploaded_evidence_collections
+          else
+            :check_merits_answers
+          end
+        },
       )
     end
   end

--- a/features/providers/check_merits_answers.feature
+++ b/features/providers/check_merits_answers.feature
@@ -123,6 +123,7 @@ Feature: Check merits answers
   @javascript
   Scenario: On a PLF application where a proceeding has child care assessment merits task list item
     Given I complete the journey as far as check merits answers with a PLF proceeding child care assessment question
+    And csrf is enabled
     Then I should be on the 'check_merits_answers' page showing 'Check your answers'
     And the following sections should exist:
       | tag | section |
@@ -153,7 +154,6 @@ Feature: Check merits answers
     Then I should be on a page with title 'Upload supporting evidence'
 
     When I upload an evidence file named 'hello_world.pdf'
-    And I sleep for 2 seconds
     Then I should see 'hello_world.pdf'
     And I select a category of "Assessment" for the file "hello_world.pdf"
 

--- a/features/providers/check_merits_answers.feature
+++ b/features/providers/check_merits_answers.feature
@@ -150,6 +150,14 @@ Feature: Check merits answers
 
     When I choose "Positive"
     And I click "Save and continue"
+    Then I should be on a page with title 'Upload supporting evidence'
+
+    When I upload an evidence file named 'hello_world.pdf'
+    And I sleep for 2 seconds
+    Then I should see 'hello_world.pdf'
+    And I select a category of "Assessment" for the file "hello_world.pdf"
+
+    When I click "Save and continue"
     Then I should be on the 'check_merits_answers' page showing 'Check your answers'
     And the govuk-summary-card titled "Assessment of your client" should contain:
       | question | answer |
@@ -171,6 +179,10 @@ Feature: Check merits answers
     And I should see "How will the negative assessment be challenged?"
     And I fill "proceeding-merits-task-child-care-assessment-details-field" with "I will challenge the negative assessment by..."
     And I click "Save and continue"
+    Then I should be on a page with title 'Upload supporting evidence'
+    Then I should see 'hello_world.pdf'
+
+    When I click "Save and continue"
     Then I should be on the 'check_merits_answers' page showing 'Check your answers'
     And the govuk-summary-card titled "Assessment of your client" should contain:
       | question | answer |

--- a/features/providers/public_law_family/merits_child_care_assessment_question_flow.feature
+++ b/features/providers/public_law_family/merits_child_care_assessment_question_flow.feature
@@ -153,6 +153,10 @@ Feature: Public law family merits appeal question flow
 
     When I fill "proceeding-merits-task-child-care-assessment-details-field-error" with "I will challenge the negative assessment by..."
     And I click "Save and continue"
+    Then I should be on a page with title 'Upload supporting evidence'
+    Then I should see 'hello_world.pdf'
+
+    When I click "Save and continue"
     Then I should be on the 'check_merits_answers' page showing 'Check your answers'
     And the govuk-summary-card titled "Assessment of your client" should contain:
       | question | answer |

--- a/features/support/steps_helper.rb
+++ b/features/support/steps_helper.rb
@@ -20,7 +20,7 @@ Then("I should be on a page showing {string} with a date of {int} days ago using
 end
 
 Then("I should be on the {string} page showing {string}") do |view_name, title|
-  expect(page.current_path).to end_with(view_name)
+  expect(page).to have_current_path(/#{view_name}/)
   expect(page).to have_content(/#{title.starts_with?('?') ? title.gsub('?', '[?]') : title}/)
 end
 

--- a/spec/forms/providers/application_merits_task/plf_court_order_form_spec.rb
+++ b/spec/forms/providers/application_merits_task/plf_court_order_form_spec.rb
@@ -38,6 +38,26 @@ module Providers::ApplicationMeritsTask
       end
     end
 
+    describe "#copy_of_court_order?" do
+      subject(:form) { described_class.new(params) }
+
+      context "when plf_court_order is 'true'" do
+        let(:plf_court_order) { "true" }
+
+        it "returns true" do
+          expect(form.copy_of_court_order?).to be true
+        end
+      end
+
+      context "when plf_court_order is 'false'" do
+        let(:plf_court_order) { "false" }
+
+        it "returns false" do
+          expect(form.copy_of_court_order?).to be false
+        end
+      end
+    end
+
     describe "#save" do
       subject(:save_form) { described_class.new(params).save }
 

--- a/spec/requests/providers/application_merits_task/court_order_copies_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/court_order_copies_controller_spec.rb
@@ -121,6 +121,26 @@ module Providers
             expect(response).to redirect_to submitted_providers_legal_aid_applications_path
           end
         end
+
+        context "when checking merits answers" do
+          let(:legal_aid_application) { create(:legal_aid_application, :with_public_law_family_prohibited_steps_order, :checking_merits_answers) }
+
+          context "when the user chooses yes" do
+            let(:params) { { legal_aid_application: { plf_court_order: true } } }
+
+            it "redirects to the upload supporting evidence page" do
+              expect(response).to redirect_to(providers_legal_aid_application_uploaded_evidence_collection_path)
+            end
+          end
+
+          context "when the user chooses no" do
+            let(:params) { { legal_aid_application: { plf_court_order: false } } }
+
+            it "redirects to the check merits answers page" do
+              expect(response).to redirect_to(providers_legal_aid_application_check_merits_answers_path)
+            end
+          end
+        end
       end
     end
   end

--- a/spec/services/flow/steps/provider_merits/child_care_assessment_result_step_spec.rb
+++ b/spec/services/flow/steps/provider_merits/child_care_assessment_result_step_spec.rb
@@ -24,6 +24,6 @@ RSpec.describe Flow::Steps::ProviderMerits::ChildCareAssessmentResultStep, type:
   describe "#check_answers" do
     subject { described_class.check_answers }
 
-    it { is_expected.to eq :check_merits_answers }
+    it { is_expected.to eq :uploaded_evidence_collections }
   end
 end

--- a/spec/services/flow/steps/provider_merits/court_order_copies_step_spec.rb
+++ b/spec/services/flow/steps/provider_merits/court_order_copies_step_spec.rb
@@ -20,8 +20,18 @@ RSpec.describe Flow::Steps::ProviderMerits::CourtOrderCopiesStep, type: :request
   end
 
   describe "#check_answers" do
-    subject { described_class.check_answers }
+    subject { described_class.check_answers.call(legal_aid_application, copy_of_court_order) }
 
-    it { is_expected.to eq :check_merits_answers }
+    context "when `copy_of_court_order` is `true`" do
+      let(:copy_of_court_order) { true }
+
+      it { is_expected.to eq(:uploaded_evidence_collections) }
+    end
+
+    context "when `copy_of_court_order` is `false`" do
+      let(:copy_of_court_order) { false }
+
+      it { is_expected.to eq :check_merits_answers }
+    end
   end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5776)

Having come from the Checking Merits Answers page, redirect to supporting evidence page when the `copy of court order` answer is changed from `No` to `Yes` so the provider can upload the court order. 

Same for the `child_care_assessment` page and question.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
