### PR TITLE
Chore: make merits report summary card column widths one-third/two-thirds

### DIFF
--- a/app/views/providers/merits_reports/_applied_previously.html.erb
+++ b/app/views/providers/merits_reports/_applied_previously.html.erb
@@ -6,11 +6,11 @@
                          html_attributes: { id: "app-check-your-answers__applied_previously__card" }) do |card|
         card.with_summary_list(actions: false, html_attributes: { id: "app-check-your-answers__applied_previously__summary" }) do |summary_list|
           summary_list.with_row(html_attributes: { id: "app-check-your-answers__applied_previously" }) do |row|
-            row.with_key(text: t(".has_applied_before"), classes: "govuk-!-width-one-half")
+            row.with_key(text: t(".has_applied_before"), classes: "govuk-!-width-one-third")
             row.with_value(text: yes_no(legal_aid_application.applicant.applied_previously))
           end
           summary_list.with_row(html_attributes: { id: "app-check-your-answers__previous_reference" }) do |row|
-            row.with_key(text: t(".previous_application_reference"), classes: "govuk-!-width-one-half")
+            row.with_key(text: t(".previous_application_reference"))
             row.with_value(text: legal_aid_application.applicant.previous_reference.presence || "-")
           end
         end

--- a/app/views/providers/merits_reports/_delegated_functions.html.erb
+++ b/app/views/providers/merits_reports/_delegated_functions.html.erb
@@ -20,17 +20,17 @@
                              html_attributes: { id: "app-check-your-answers__delegated_functions__#{proceeding.name}" }) do |card|
             card.with_summary_list(actions: false, html_attributes: { id: "app-check-your-answers__delegated_functions__#{proceeding.name}__summary" }) do |summary_list|
               summary_list.with_row(html_attributes: { id: "app-check-your-answers__used_delegated_functions_reported_on__#{proceeding.name}" }) do |row|
-                row.with_key(text: t(".reported_on"), classes: "govuk-!-width-one-half")
+                row.with_key(text: t(".reported_on"), classes: "govuk-!-width-one-third")
                 row.with_value(text: proceeding.used_delegated_functions_reported_on)
               end
 
               summary_list.with_row(html_attributes: { id: "app-check-your-answers__used_delegated_functions_on__#{proceeding.name}" }) do |row|
-                row.with_key(text: t(".used_on"), classes: "govuk-!-width-one-half")
+                row.with_key(text: t(".used_on"))
                 row.with_value(text: proceeding.used_delegated_functions_on)
               end
 
               summary_list.with_row(html_attributes: { id: "app-check-your-answers__delegated_functions_days_to_report__#{proceeding.name}" }) do |row|
-                row.with_key(text: t(".days_to_report"), classes: "govuk-!-width-one-half")
+                row.with_key(text: t(".days_to_report"))
                 row.with_value(text: distance_of_time_in_words(proceeding.used_delegated_functions_reported_on, proceeding.used_delegated_functions_on))
               end
             end

--- a/app/views/providers/merits_reports/_proceeding_details.html.erb
+++ b/app/views/providers/merits_reports/_proceeding_details.html.erb
@@ -8,7 +8,7 @@
         card.with_summary_list(actions: false, html_attributes: { id: "app-check-your-answers__proceeding_details__summary" }) do |summary_list|
           legal_aid_application.proceedings_by_name.each_with_index do |proceeding, i|
             summary_list.with_row(classes: "app-check-your-answers__#{proceeding.name}__row") do |row|
-              row.with_key(text: "#{t('.proceeding')} #{i + 1}", classes: "govuk-!-width-one-half")
+              row.with_key(text: "#{t('.proceeding')} #{i + 1}", classes: "govuk-!-width-one-third")
               row.with_value { proceeding.meaning }
             end
           end

--- a/app/views/shared/check_answers/_emergency_costs.html.erb
+++ b/app/views/shared/check_answers/_emergency_costs.html.erb
@@ -3,18 +3,18 @@
                        html_attributes: { id: "app-check-your-answers__emergency_cost_override__card" }) do |card|
       card.with_summary_list(actions: !read_only, html_attributes: { id: "app-check-your-answers__emergency_cost_override__summary" }) do |summary_list|
         summary_list.with_row(html_attributes: { id: "app-check-your-answers__emergency_cost_override" }) do |row|
-          row.with_key(text: t(".request_higher_limit"), classes: "govuk-!-width-one-half")
+          row.with_key(text: t(".request_higher_limit"), classes: "govuk-!-width-one-third")
           row.with_value { yes_no(@legal_aid_application.emergency_cost_override) }
         end
 
         if @legal_aid_application.emergency_cost_override
           summary_list.with_row(html_attributes: { id: "app-check-your-answers__emergency_cost_requested" }) do |row|
-            row.with_key(text: t(".new_cost_limit"), classes: "govuk-!-width-one-half")
+            row.with_key(text: t(".new_cost_limit"))
             row.with_value { gds_number_to_currency(@legal_aid_application.emergency_cost_requested, precision: 2) }
           end
 
           summary_list.with_row(html_attributes: { id: "app-check-your-answers__emergency_cost_reasons" }) do |row|
-            row.with_key(text: t(".new_limit_reasons"), classes: "govuk-!-width-one-half")
+            row.with_key(text: t(".new_limit_reasons"))
             row.with_value { @legal_aid_application.emergency_cost_reasons }
           end
         end

--- a/app/views/shared/check_answers/_substantive_costs.html.erb
+++ b/app/views/shared/check_answers/_substantive_costs.html.erb
@@ -1,15 +1,15 @@
 <%= govuk_summary_list(card: { title: heading }, actions: false) do |summary_list| %>
   <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__emergency_cost_override" }) do |row| %>
-    <%= row.with_key(text: t(".request_higher_limit"), classes: "govuk-!-width-one-half") %>
+    <%= row.with_key(text: t(".request_higher_limit"), classes: "govuk-!-width-one-third") %>
     <%= row.with_value { yes_no(@legal_aid_application.substantive_cost_override) } %>
   <% end %>
   <% if @legal_aid_application.substantive_cost_override %>
     <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__cost_requested" }) do |row| %>
-      <%= row.with_key(text: t(".new_cost_limit"), classes: "govuk-!-width-one-half") %>
+      <%= row.with_key(text: t(".new_cost_limit")) %>
       <%= row.with_value { gds_number_to_currency(@legal_aid_application.substantive_cost_requested, precision: 2) } %>
     <% end %>
     <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__emergency_cost_reasons" }) do |row| %>
-      <%= row.with_key(text: t(".new_limit_reasons"), classes: "govuk-!-width-one-half") %>
+      <%= row.with_key(text: t(".new_limit_reasons")) %>
       <%= row.with_value { @legal_aid_application.substantive_cost_reasons } %>
     <% end %>
   <% end %>

--- a/app/views/shared/check_answers/merits/_separate_representation.html.erb
+++ b/app/views/shared/check_answers/merits/_separate_representation.html.erb
@@ -5,7 +5,7 @@
     <%= govuk_summary_card(title: t(".heading")) do |card|
           card.with_summary_list(actions: false) do |summary_list|
             summary_list.with_row(html_attributes: { id: "app-check-your-answers__separate_representation_required" }) do |row|
-              row.with_key(text: t(".separate_representation"), classes: "govuk-!-width-one-half")
+              row.with_key(text: t(".separate_representation"), classes: "govuk-!-width-one-third")
               row.with_value(text: t(".confirmed"))
             end
           end


### PR DESCRIPTION
## What
Make merits report summary card column widths one-third/two-thirds

Inline with means report, CYA and R&P pages. Agreed with devs

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
