### PR TITLE
Update:  Vehicle model and factory bot handling

### DIFF
--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -1,5 +1,6 @@
 class Vehicle < ApplicationRecord
   belongs_to :legal_aid_application
+  self.ignored_columns += %w[purchased_on]
 
   def complete?
     [
@@ -9,13 +10,7 @@ class Vehicle < ApplicationRecord
     ].all?(true)
   end
 
-  def purchased_on
-    self[:purchased_on].nil? ? inferred_purchase_date : self[:purchased_on]
-  end
-
-private
-
-  def inferred_purchase_date
+  def cfe_civil_purchase_date
     more_than_three_years_old? ? 4.years.ago.to_date : 2.years.ago.to_date
   end
 end

--- a/app/services/cfe_civil/components/vehicles.rb
+++ b/app/services/cfe_civil/components/vehicles.rb
@@ -28,7 +28,7 @@ module CFECivil
           {
             value: vehicle.estimated_value.to_f,
             loan_amount_outstanding: vehicle.payment_remaining.to_f,
-            date_of_purchase: vehicle.purchased_on&.strftime("%Y-%m-%d"),
+            date_of_purchase: vehicle.cfe_civil_purchase_date&.strftime("%Y-%m-%d"),
             in_regular_use: vehicle.used_regularly,
           }
         end

--- a/app/services/reports/mis/application_detail_csv_line.rb
+++ b/app/services/reports/mis/application_detail_csv_line.rb
@@ -102,7 +102,7 @@ module Reports
           "Vehicle 1 value",
           "Vehicle 1 Outstanding loan?",
           "Vehicle 1 Loan remaining",
-          "Vehicle 1 Date purchased",
+          "Vehicle 1 >3 years old",
           "Vehicle 1 In Regular use?",
           "Current acct?",
           "Savings acct?",
@@ -305,7 +305,7 @@ module Reports
         @line << vehicles.first.estimated_value
         @line << (nil_or_zero?(vehicles.first.payment_remaining) ? "No" : "Yes")
         @line << (nil_or_zero?(vehicles.first.payment_remaining) ? "" : vehicles.first.payment_remaining)
-        @line << vehicles.first.purchased_on&.strftime("%Y-%m-%d")
+        @line << vehicles.first.cfe_civil_purchase_date&.strftime("%Y-%m-%d")
         @line << yesno(vehicles.first.used_regularly?)
       end
 

--- a/spec/factories/vehicles.rb
+++ b/spec/factories/vehicles.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
       estimated_value { Faker::Commerce.price(range: 2000..10_000) }
       owner { "client" }
       payment_remaining { Faker::Commerce.price(range: 100..1_000) }
-      purchased_on { Faker::Date.between(from: 20.years.ago, to: 2.days.ago) }
+      more_than_three_years_old { true }
       used_regularly { Faker::Boolean.boolean }
     end
 
@@ -14,7 +14,7 @@ FactoryBot.define do
       estimated_value { Faker::Commerce.price(range: 2000..10_000) }
       owner { "partner" }
       payment_remaining { Faker::Commerce.price(range: 100..1_000) }
-      purchased_on { Faker::Date.between(from: 20.years.ago, to: 2.days.ago) }
+      more_than_three_years_old { true }
       used_regularly { Faker::Boolean.boolean }
     end
 

--- a/spec/models/vehicle_spec.rb
+++ b/spec/models/vehicle_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Vehicle do
   describe "#purchased_on" do
-    let(:vehicle) { create(:vehicle, purchased_on:, more_than_three_years_old:) }
+    let(:vehicle) { create(:vehicle, more_than_three_years_old:) }
 
     describe "#complete?" do
       subject { vehicle.complete? }
@@ -26,32 +26,19 @@ RSpec.describe Vehicle do
       end
     end
 
-    context "when purchased_on is populated" do
-      let(:purchased_on) { 6.months.ago.to_date }
-      let(:more_than_three_years_old) { nil }
+    context "when more than three years old" do
+      let(:more_than_three_years_old) { true }
 
-      it "returns the purchased on date" do
-        expect(vehicle.purchased_on).to eq purchased_on
+      it "returns a date 4 years ago" do
+        expect(vehicle.cfe_civil_purchase_date).to eq 4.years.ago.to_date
       end
     end
 
-    context "when purchased_on is nil" do
-      let(:purchased_on) { nil }
+    context "when less than three years old" do
+      let(:more_than_three_years_old) { false }
 
-      context "when more than three years old" do
-        let(:more_than_three_years_old) { true }
-
-        it "returns a date 4 years ago" do
-          expect(vehicle.purchased_on).to eq 4.years.ago.to_date
-        end
-      end
-
-      context "when less than three years old" do
-        let(:more_than_three_years_old) { false }
-
-        it "returns a date 2 years ago" do
-          expect(vehicle.purchased_on).to eq 2.years.ago.to_date
-        end
+      it "returns a date 2 years ago" do
+        expect(vehicle.cfe_civil_purchase_date).to eq 2.years.ago.to_date
       end
     end
   end

--- a/spec/services/ccms/requestors/case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_spec.rb
@@ -35,7 +35,7 @@ module CCMS
         let(:last_name_at_birth) { nil }
         let(:proceeding) { legal_aid_application.proceedings.detect { |p| p.ccms_code == "DA001" } }
         let(:chances_of_success) { proceeding.chances_of_success }
-        let(:vehicles) { create_list(:vehicle, 1, estimated_value: 3030, payment_remaining: 881, purchased_on: Date.new(2008, 8, 22), used_regularly: true) }
+        let(:vehicles) { create_list(:vehicle, 1, estimated_value: 3030, payment_remaining: 881, more_than_three_years_old: true, used_regularly: true) }
         let(:domestic_abuse_summary) { create(:domestic_abuse_summary, :police_notified_true) }
 
         let(:other_assets_declaration) do

--- a/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
+++ b/spec/services/ccms/requestors/case_add_requestor_xml_blocks/non_passported_variable_attributes_spec.rb
@@ -397,7 +397,7 @@ module CCMS
           end
 
           context "when the applicant has vehicle" do
-            before { vehicle.update! estimated_value: 6500, payment_remaining: 3215.66, purchased_on: 5.years.ago.to_date, used_regularly: regular_use }
+            before { vehicle.update! estimated_value: 6500, payment_remaining: 3215.66, more_than_three_years_old: true, used_regularly: regular_use }
 
             let(:regular_use) { true }
 

--- a/spec/services/ccms/requestors/special_children_act_case_add_requestor_spec.rb
+++ b/spec/services/ccms/requestors/special_children_act_case_add_requestor_spec.rb
@@ -38,7 +38,7 @@ module CCMS
         let(:proceeding) { legal_aid_application.proceedings.detect { |p| p.ccms_code == "PB003" } }
         let(:last_name_at_birth) { nil }
         let(:chances_of_success) { proceeding.chances_of_success }
-        let(:vehicles) { create_list(:vehicle, 1, estimated_value: 3030, payment_remaining: 881, purchased_on: Date.new(2008, 8, 22), used_regularly: true) }
+        let(:vehicles) { create_list(:vehicle, 1, estimated_value: 3030, payment_remaining: 881, more_than_three_years_old: true, used_regularly: true) }
         let(:domestic_abuse_summary) { create(:domestic_abuse_summary, :police_notified_true) }
 
         let(:other_assets_declaration) do

--- a/spec/services/cfe_civil/components/partner_spec.rb
+++ b/spec/services/cfe_civil/components/partner_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe CFECivil::Components::Partner do
                legal_aid_application:,
                estimated_value: 2345.0,
                payment_remaining: 321.0,
-               purchased_on: Date.new(2020, 5, 18),
+               more_than_three_years_old: true,
                used_regularly: true,
                owner: "partner")
       end
@@ -69,7 +69,7 @@ RSpec.describe CFECivil::Components::Partner do
             vehicles: [
               value: 2345.0,
               loan_amount_outstanding: 321.0,
-              date_of_purchase: "2020-05-18",
+              date_of_purchase: 4.years.ago.to_date,
               in_regular_use: true,
             ],
             regular_transactions: [],

--- a/spec/services/cfe_civil/components/vehicles_spec.rb
+++ b/spec/services/cfe_civil/components/vehicles_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe CFECivil::Components::Vehicles do
              legal_aid_application:,
              estimated_value: 2345.0,
              payment_remaining: 321.0,
-             purchased_on: Date.new(2020, 5, 18),
+             more_than_three_years_old: true,
              used_regularly: true,
              owner: "client")
       create(:vehicle,
              legal_aid_application:,
              estimated_value: 3254.0,
              payment_remaining: 123.0,
-             purchased_on: Date.new(2022, 6, 15),
+             more_than_three_years_old: true,
              used_regularly: true,
              owner: "partner")
     end
@@ -37,7 +37,7 @@ RSpec.describe CFECivil::Components::Vehicles do
           vehicles: [
             value: 2345.0,
             loan_amount_outstanding: 321.0,
-            date_of_purchase: "2020-05-18",
+            date_of_purchase: 4.years.ago.to_date,
             in_regular_use: true,
           ],
         }.to_json)
@@ -52,7 +52,7 @@ RSpec.describe CFECivil::Components::Vehicles do
           vehicles: [
             value: 3254.0,
             loan_amount_outstanding: 123.0,
-            date_of_purchase: "2022-06-15",
+            date_of_purchase: 4.years.ago.to_date,
             in_regular_use: true,
           ],
         }.to_json)

--- a/spec/services/cfe_civil/submission_builder_spec.rb
+++ b/spec/services/cfe_civil/submission_builder_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe CFECivil::SubmissionBuilder, :vcr do
                                   1,
                                   estimated_value: 5_000,
                                   payment_remaining: 250,
-                                  purchased_on: Date.new(2023, 1, 10),
+                                  more_than_three_years_old: true,
                                   used_regularly: true),
              other_assets_declaration: build(:other_assets_declaration, :all_nil))
     end
@@ -95,7 +95,7 @@ RSpec.describe CFECivil::SubmissionBuilder, :vcr do
                                   1,
                                   estimated_value: 5_000,
                                   payment_remaining: 250,
-                                  purchased_on: Date.new(2023, 1, 10),
+                                  more_than_three_years_old: true,
                                   used_regularly: true),
              other_assets_declaration: build(:other_assets_declaration, :all_nil))
     end

--- a/spec/services/reports/mis/application_detail_csv_line_spec.rb
+++ b/spec/services/reports/mis/application_detail_csv_line_spec.rb
@@ -373,13 +373,13 @@ module Reports
               expect(value_for("Vehicle 1 value")).to eq ""
               expect(value_for("Vehicle 1 Outstanding loan?")).to eq ""
               expect(value_for("Vehicle 1 Loan remaining")).to eq ""
-              expect(value_for("Vehicle 1 Date purchased")).to eq ""
+              expect(value_for("Vehicle 1 >3 years old")).to eq ""
               expect(value_for("Vehicle 1 In Regular use?")).to eq ""
             end
           end
 
           context "when there is a vehicle" do
-            let(:purchase_date) { Date.new(2020, 1, 1) }
+            let(:more_than_three_years_old) { true }
             let(:used_regularly) { true }
 
             before do
@@ -389,7 +389,7 @@ module Reports
                           estimated_value: 12_000,
                           payment_remaining:,
                           used_regularly:,
-                          purchased_on: purchase_date)
+                          more_than_three_years_old: more_than_three_years_old)
             end
 
             context "and it's in regular use, no loan outstanding" do
@@ -400,7 +400,7 @@ module Reports
                 expect(value_for("Vehicle 1 value")).to eq 12_000
                 expect(value_for("Vehicle 1 Outstanding loan?")).to eq "No"
                 expect(value_for("Vehicle 1 Loan remaining")).to eq ""
-                expect(value_for("Vehicle 1 Date purchased")).to eq "2020-01-01"
+                expect(value_for("Vehicle 1 >3 years old")).to eq 4.years.ago.strftime("%Y-%m-%d")
                 expect(value_for("Vehicle 1 In Regular use?")).to eq "Yes"
               end
             end
@@ -414,7 +414,7 @@ module Reports
                 expect(value_for("Vehicle 1 value")).to eq 12_000
                 expect(value_for("Vehicle 1 Outstanding loan?")).to eq "No"
                 expect(value_for("Vehicle 1 Loan remaining")).to eq ""
-                expect(value_for("Vehicle 1 Date purchased")).to eq "2020-01-01"
+                expect(value_for("Vehicle 1 >3 years old")).to eq 4.years.ago.strftime("%Y-%m-%d")
                 expect(value_for("Vehicle 1 In Regular use?")).to eq "No"
               end
             end
@@ -427,7 +427,7 @@ module Reports
                 expect(value_for("Vehicle 1 value")).to eq 12_000
                 expect(value_for("Vehicle 1 Outstanding loan?")).to eq "Yes"
                 expect(value_for("Vehicle 1 Loan remaining")).to eq 4_566
-                expect(value_for("Vehicle 1 Date purchased")).to eq "2020-01-01"
+                expect(value_for("Vehicle 1 >3 years old")).to eq 4.years.ago.strftime("%Y-%m-%d")
                 expect(value_for("Vehicle 1 In Regular use?")).to eq "Yes"
               end
             end


### PR DESCRIPTION
## What

We migrated from purchase date to boolean, more than three years old, question in Feb 2020

Production has zero vehicles of (5K+ stored) with a purchased_on date

Therefore we should remove the column and stop interpolating a fake date _if_ it is empty

This removes, and renames, the helper methods to be clearer and updates the factories to remove the obsolete column

It also updates the reporting and test usages to use the new handling

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
