### PR TITLE
AP-5432: Fix incorrect closing h tag

### DIFF
--- a/app/views/shared/check_answers/_assets.html.erb
+++ b/app/views/shared/check_answers/_assets.html.erb
@@ -18,7 +18,7 @@
   <% if read_only %>
     <%= render "shared/check_answers/client_online_bank_accounts", read_only: %>
 
-    <h2 class="govuk-heading-l print-no-break-after"><%= t(".total_in_online_bank_accounts_heading") %></h3>
+    <h2 class="govuk-heading-l print-no-break-after"><%= t(".total_in_online_bank_accounts_heading") %></h2>
     <%= render "shared/check_answers/total_in_online_bank_accounts", read_only: %>
   <% end %>
 


### PR DESCRIPTION
## What
AP-5432: Fix incorrect closing h tag

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5432)

Typo/Missed in [previous PR](https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/7660) 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
