### PR TITLE
AP-5914: Update MOJ Frontend npm package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,7 +31,7 @@ updates:
     ignore:
       - dependency-name: "@ministryofjustice/frontend"
         versions:
-          - ">= 4.0.0"
+          - ">= 5.0.0"
     groups:
       moj-frontend:
         patterns:

--- a/app/assets/stylesheets/_imports.scss
+++ b/app/assets/stylesheets/_imports.scss
@@ -1,0 +1,9 @@
+@use "govuk-frontend/dist/govuk" as * with (
+  $govuk-new-organisation-colours: true,
+  $govuk-global-styles: true,
+  $govuk-new-typography-scale: true,
+  $govuk-assets-path: "/"
+);
+@forward "@ministryofjustice/frontend/moj/all" with (
+  $govuk-new-organisation-colours: true,
+);

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1,3 +1,5 @@
+@use "./imports" as *;
+
 .admin-page {
   .app-navigation {
     @media (min-width: 40.0625em) {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,46 +1,32 @@
-$govuk-global-styles: true;
-$govuk-new-link-styles: true;
-$govuk-new-typography-scale: true;
-$govuk-assets-path: "/";
-$govuk-new-organisation-colours: true;
-
-@import "govuk-frontend/dist/govuk/index";
-@import "@ministryofjustice/frontend/moj/settings/measurements";
-@import "@ministryofjustice/frontend/moj/objects/width-container";
-@import "@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";
-@import "@ministryofjustice/frontend/moj/components/sortable-table/sortable-table";
-@import "@ministryofjustice/frontend/moj/components/primary-navigation/primary-navigation";
-@import "@ministryofjustice/frontend/moj/components/interruption-card/interruption-card";
-
 // Project specific
 
 // Everything below this comment should be project specific.
 // If you absolutely need to override gov.uk styles, don't,
 // instead create new classes or ids with a prefix based on the app name.
 
-@import "admin";
-@import "bank-selection";
-@import "check-your-answers";
-@import "govuk-mods";
-@import "helpers";
-@import "language-switcher";
-@import "layout";
-@import "long-email-truncation";
-@import "modal-dialogue";
-@import "dropzone";
-@import "no-wrap";
-@import "pagination";
-@import "print-styles";
-@import "submissions";
-@import "table-sort";
-@import "tables";
-@import "sort-transactions";
-@import "summary-card";
-@import "width-style-correction";
-@import "citizens/spinner";
-@import "providers/legal_aid_applications";
-@import "providers/search_results";
-@import "dropzone/src/dropzone";
-@import "dropzone/src/basic";
-@import "providers/summary_list_action_width";
-@import "primary_navigation";
+@forward "layout";
+@forward "admin";
+@forward "bank-selection";
+@forward "check-your-answers";
+@forward "govuk-mods";
+@forward "helpers";
+@forward "language-switcher";
+@forward "long-email-truncation";
+@forward "modal-dialogue";
+@forward "dropzone";
+@forward "no-wrap";
+@forward "pagination";
+@forward "print-styles";
+@forward "submissions";
+@forward "table-sort";
+@forward "tables";
+@forward "sort-transactions";
+@forward "summary-card";
+@forward "width-style-correction";
+@forward "citizens/spinner";
+@forward "providers/legal_aid_applications";
+@forward "providers/search_results";
+@forward "dropzone/src/dropzone";
+@forward "dropzone/src/basic";
+@forward "providers/summary_list_action_width";
+@forward "primary_navigation";

--- a/app/assets/stylesheets/check-your-answers.scss
+++ b/app/assets/stylesheets/check-your-answers.scss
@@ -1,4 +1,5 @@
 // Recommended - Use these styles for the check your answers pattern
+@use "./imports" as *;
 
 .app-check-your-answers {
   border-top: 1px solid $govuk-border-colour;

--- a/app/assets/stylesheets/dropzone.scss
+++ b/app/assets/stylesheets/dropzone.scss
@@ -1,4 +1,5 @@
 // stylelint-disable declaration-no-important, selector-max-id
+@use "./imports" as *;
 
 .dropzone {
   display: flex;

--- a/app/assets/stylesheets/helpers.scss
+++ b/app/assets/stylesheets/helpers.scss
@@ -1,4 +1,5 @@
 // stylelint-disable declaration-no-important
+@use "./imports" as *;
 
 .small-loading-image {
   height: 22px;

--- a/app/assets/stylesheets/language-switcher.scss
+++ b/app/assets/stylesheets/language-switcher.scss
@@ -1,3 +1,5 @@
+@use "./imports" as *;
+
 .language-switcher {
   margin-top: govuk-spacing(3);
   margin-bottom: govuk-spacing(3);

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1,4 +1,5 @@
 // stylelint-disable selector-max-id
+@use "./imports" as *;
 
 .govuk-header {
   #navigation {

--- a/app/assets/stylesheets/pagination.scss
+++ b/app/assets/stylesheets/pagination.scss
@@ -1,3 +1,5 @@
+@use "./imports" as *;
+
 .app-pagination__container .app-pagination__info {
   text-align: center;
 

--- a/app/assets/stylesheets/providers/legal_aid_applications.scss
+++ b/app/assets/stylesheets/providers/legal_aid_applications.scss
@@ -1,4 +1,5 @@
 // stylelint-disable declaration-no-important, selector-max-id, selector-no-qualifying-type
+@use "../imports" as *;
 
 #clear-search-div {
   padding-top: 5px;

--- a/app/assets/stylesheets/providers/search_results.scss
+++ b/app/assets/stylesheets/providers/search_results.scss
@@ -1,5 +1,6 @@
 // stylelint-disable selector-max-id
 @use "sass:color";
+@use "../imports" as *;
 
 %highlight {
   margin-right: 1px;

--- a/app/assets/stylesheets/sort-transactions.scss
+++ b/app/assets/stylesheets/sort-transactions.scss
@@ -1,4 +1,5 @@
 // stylelint-disable declaration-no-important
+@use "./imports" as *;
 
 .display-table {
   display: table

--- a/app/assets/stylesheets/table-sort.scss
+++ b/app/assets/stylesheets/table-sort.scss
@@ -1,4 +1,5 @@
 // stylelint-disable selector-no-qualifying-type
+@use "./imports" as *;
 
 .sort.js-sortable,
 th.select-all,

--- a/app/assets/stylesheets/tables.scss
+++ b/app/assets/stylesheets/tables.scss
@@ -1,5 +1,6 @@
 // Footers are usually used provide a summary of the table contents.
 // They are not part of the GOV.UK Design System so custom styles are required.
+@use "./imports" as *;
 
 .govuk-table__foot {
   border-top: 2px solid govuk-colour("black");

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,7 +1,8 @@
 import './src/jquery'
 
-import { initAll } from 'govuk-frontend'
-import { initAll as initAllMoJ } from '@ministryofjustice/frontend'
+import * as MOJFrontend from '@ministryofjustice/frontend'
+import * as GOVUKFrontend from 'govuk-frontend'
+
 import Rails from '@rails/ujs'
 
 // require polyfills via core-js
@@ -25,6 +26,6 @@ import './src/table-select-all'
 import './src/table-sort'
 import './src/worker_waiter'
 
-initAll()
-initAllMoJ()
+GOVUKFrontend.initAll()
+MOJFrontend.initAll()
 Rails.start()

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "stylelint": "stylelint app/assets/stylesheets",
     "test": "jest",
     "build": "esbuild app/javascript/*.* --bundle --loader:.gif=dataurl --sourcemap --minify --outdir=app/assets/builds --public-path=assets --target=es6",
-    "build:css": "sass ./app/assets/stylesheets/application.scss:./app/assets/builds/application.css --style=compressed --load-path=node_modules --quiet-deps --silence-deprecation slash-div --silence-deprecation import",
+    "build:css": "sass ./app/assets/stylesheets/application.scss:./app/assets/builds/application.css --style=compressed --load-path=. --load-path=node_modules --quiet-deps --silence-deprecation slash-div --silence-deprecation import",
     "postinstall": "rm -rf node_modules/resolve/test/resolver/multirepo node_modules/eslint-plugin-react/node_modules/resolve/test/resolver/multirepo"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "jest": "^29.7.0",
     "jquery": "^3.7.1",
     "js-search": "^2.0.1",
+    "moment": "^2.30.1",
     "sass": "^1.86.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "postinstall": "rm -rf node_modules/resolve/test/resolver/multirepo node_modules/eslint-plugin-react/node_modules/resolve/test/resolver/multirepo"
   },
   "dependencies": {
-    "@ministryofjustice/frontend": "<4.0.0",
+    "@ministryofjustice/frontend": "^4.0.1",
     "@rails/ujs": "^7.1.501",
     "axios": "^1.8.4",
     "core-js": "^3.41.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4585,6 +4585,11 @@ mitt@^3.0.1:
   resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
   integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
 
+moment@^2.30.1:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
+
 ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1383,10 +1383,10 @@
   dependencies:
     buffer "^6.0.3"
 
-"@ministryofjustice/frontend@<4.0.0":
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/@ministryofjustice/frontend/-/frontend-3.7.0.tgz#fd694f79d06f1c5a2ba581c1f5c89506810aa4a6"
-  integrity sha512-o84Sqy+1jqc1vaxIZfyG4VwJzdpDUK88O9COJFVLcFmW+Np80onlFlGAVjDUxNHYvtBdJx40w1dayq53wmtxgQ==
+"@ministryofjustice/frontend@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@ministryofjustice/frontend/-/frontend-4.0.1.tgz#5e9ed308e208982179e26e7884173bce553eec87"
+  integrity sha512-LljgnzLtTIw9z8mw/pK1xLIyR3TtHrFa9Z/i7X+6odzN5MlQ0dYLDXunoAhniXeOlXz5sNbdsmGuf/iNxv0keA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
## What

This PR updates the npm packages to:
* update `@ministryofjustice/frontend`
* add `moment` and `bare` to reduce warnings and noise on build

It then updates the scss files to import the external files using the new sass methods, `@use` and `@forward`

### Questions
- should we add the additional packages?  They reduce warnings, but significantly increase package dependancies

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
