### PR TITLE
AP-5881: update benefit check error handling

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -51,6 +51,7 @@ private
       access_denied: :forbidden,
       assessment_already_completed: :ok,
       internal_server_error: :internal_server_error,
+      benefit_checker_down: :internal_server_error,
     }
   end
 

--- a/app/controllers/providers/check_benefits_controller.rb
+++ b/app/controllers/providers/check_benefits_controller.rb
@@ -20,7 +20,7 @@ module Providers
   private
 
     def check_benefits
-      redirect_to problem_index_path unless legal_aid_application.add_benefit_check_result
+      redirect_to error_path(:benefit_checker_down) unless legal_aid_application.add_benefit_check_result
     end
 
     def known_issue_prevents_benefit_check?

--- a/app/views/errors/show/_benefit_checker_down.html.erb
+++ b/app/views/errors/show/_benefit_checker_down.html.erb
@@ -1,0 +1,4 @@
+<% t(".text").each do |paragraph| %>
+    <p><%= paragraph %></p>
+<% end %>
+<%= link_to t(".link"), in_progress_providers_legal_aid_applications_path %>

--- a/config/locales/cy/errors.yml
+++ b/config/locales/cy/errors.yml
@@ -36,6 +36,13 @@ cy:
         permission_text: uoy ot elbissecca yltnerruc ton si egap ehT
       internal_server_error:
         page_title: ecivres ruo htiw gnorw tnew gnihtemos ,yrroS
+      benefit_checker_down:
+        page_title: melborp a si ereht ,yrroS
+        text:
+          - .retal niaga yrT
+          - .srewsna ruoy devas eW
+          - .niaga gnikrow s’ti ecno noitacilppa siht eunitnoc nac uoY .gnidnopser ton si htiw tcennoc ot gniyrt er’ew ecivres ehT
+        link: snoitacilppa ruoy ot kcaB
   problem:
     index:
       title: ecivres eht htiw melborp a si ereht ,yrroS

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -40,6 +40,13 @@ en:
         permission_text: The page is not currently accessible to you
       internal_server_error:
         page_title: Sorry, something went wrong with our service
+      benefit_checker_down:
+        page_title: Sorry, there is a problem
+        text:
+          - Try again later.
+          - We saved your answers.
+          - The service we’re trying to connect with is not responding. You can continue this application once it’s working again.
+        link: Back to your applications
   problem:
     index:
       title: Sorry, there is a problem with the service

--- a/spec/requests/errors_controller_spec.rb
+++ b/spec/requests/errors_controller_spec.rb
@@ -261,4 +261,32 @@ RSpec.describe ErrorsController, :show_exceptions do
       end
     end
   end
+
+  describe "GET /error/benefit_checker_down" do
+    subject(:get_error) { get error_path(:benefit_checker_down) }
+
+    it "responds with internal_server_error/500 status" do
+      get_error
+      expect(response).to have_http_status(:internal_server_error)
+    end
+
+    it "renders benefit_checker_down" do
+      get_error
+      expect(response).to render_template("errors/show/_benefit_checker_down")
+    end
+
+    it "displays the correct header" do
+      get_error
+      expect(page)
+        .to have_css("h1", text: "Sorry, there is a problem")
+    end
+
+    context "with Welsh locale", :use_welsh_locale do
+      it "displays the correct content" do
+        get error_path(:benefit_checker_down, locale: :cy)
+        expect(page)
+          .to have_css("h1", text: "melborp a si ereht ,yrroS")
+      end
+    end
+  end
 end

--- a/spec/requests/providers/check_benefits_controller_spec.rb
+++ b/spec/requests/providers/check_benefits_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Providers::CheckBenefitsController do
 
       it "redirects to the Problem page" do
         get_request
-        expect(response).to redirect_to(problem_index_path)
+        expect(response).to redirect_to(error_path(:benefit_checker_down))
       end
     end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5881)

Update the check_benefits controller to change the redirect from the generic, problem, page to the specific,
benefit_checker_down, error page

The new error page will output a 500 error so it should still trigger alerts in prometheus/open search/sentry

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
