### PR TITLE
Test: turn on modsec-non-prod for staging

### DIFF
--- a/helm_deploy/apply-for-legal-aid/values-staging.yaml
+++ b/helm_deploy/apply-for-legal-aid/values-staging.yaml
@@ -22,7 +22,7 @@ service:
 ## rule triggered once on the SoC page so this has been implemented and will be monitored
 ingress:
   enabled: true
-  className: modsec
+  className: modsec-non-prod
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: "apply-for-legal-aid-laa-apply-for-legalaid-staging-green"
     external-dns.alpha.kubernetes.io/aws-weight: "100"


### PR DESCRIPTION
## What
Test the upgraded nginx modsec controller on non-prod environments

To mitigate problems on 15/04/2025 when they switch over to it on all production environments

From Cloud-platform:
```txt
We have deployed a non-prod modsec ingress controller to the cluster with the latest nginx and modsec rules (and upped the PCRE limit to tackle some of the errors you might have experienced with the recent failed upgrade).
You can test your existing ingress controller workloads by moving over your non prod workloads to the new non prod modsec controller and checking for any issues before the 15th. Please let us know what issues you hit asap.
To move your workloads over you just need to update your ingress className  from modsec => modsec-non-prod.
````

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
