### PR TITLE
AP-5915: Remove modsec-non-prod

### DIFF
--- a/helm_deploy/apply-for-legal-aid/values-staging.yaml
+++ b/helm_deploy/apply-for-legal-aid/values-staging.yaml
@@ -22,7 +22,7 @@ service:
 ## rule triggered once on the SoC page so this has been implemented and will be monitored
 ingress:
   enabled: true
-  className: modsec-non-prod
+  className: modsec
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: "apply-for-legal-aid-laa-apply-for-legalaid-staging-green"
     external-dns.alpha.kubernetes.io/aws-weight: "100"


### PR DESCRIPTION
## What
Remove modsec-non-prod after 15/04/2025

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5915)

Once the new modsec nginx controller becomes the default on production environments on 15/04/2025

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
