### PR TITLE
 LandD: Configure failed test reruns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,8 +202,13 @@ jobs:
         name: Stash Coverage Results
         command: |
           mkdir coverage_results
-          # suppress error if no file exists (can occur if running only failed tests)
-          cp -R coverage/.resultset.json coverage_results/.resultset-${CIRCLE_NODE_INDEX}-unit.json 2>/dev/null || :
+
+          # Only copy coverage if main run, not re-run
+          if [ ${CIRCLE_WORKFLOW_ID} = ${CIRCLE_WORKFLOW_WORKSPACE_ID} ]
+          then
+            # suppress error if no file exists (can occur if running only failed tests)
+            cp -R coverage/.resultset.json coverage_results/.resultset-${CIRCLE_NODE_INDEX}-unit.json 2>/dev/null || :
+          fi
     - persist_to_workspace:
         root: .
         paths:
@@ -237,8 +242,13 @@ jobs:
         name: Stash Coverage Results
         command: |
           mkdir coverage_results
-          # suppress error if no file exists (can occur if running only failed tests)
-          cp -R coverage/.resultset.json coverage_results/.resultset-${CIRCLE_NODE_INDEX}-integration.json 2>/dev/null || :
+
+          # Only copy coverage if main run, not re-run
+          if [ ${CIRCLE_WORKFLOW_ID} = ${CIRCLE_WORKFLOW_WORKSPACE_ID} ]
+          then
+            # suppress error if no file exists (can occur if running only failed tests)
+            cp -R coverage/.resultset.json coverage_results/.resultset-${CIRCLE_NODE_INDEX}-integration.json 2>/dev/null || :
+          fi
     - persist_to_workspace:
         root: .
         paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,13 +193,8 @@ jobs:
     - run:
         name: Run ruby tests
         command: |
-          TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings --timings-type=filename)
-          echo "${TESTFILES}"
-          bundle exec rspec --format progress \
-          --format RspecJunitFormatter \
-          -o /tmp/test-results/rspec/rspec.xml \
-          -- ${TESTFILES}
-
+          circleci tests glob "spec/**/*_spec.rb" | \
+          circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml" --verbose --split-by=timings --timings-type=filename
     - store_test_results:
         path: /tmp/test-results/rspec
 
@@ -207,7 +202,8 @@ jobs:
         name: Stash Coverage Results
         command: |
           mkdir coverage_results
-          cp -R coverage/.resultset.json coverage_results/.resultset-${CIRCLE_NODE_INDEX}-unit.json
+          # suppress error if no file exists (can occur if running only failed tests)
+          cp -R coverage/.resultset.json coverage_results/.resultset-${CIRCLE_NODE_INDEX}-unit.json 2>/dev/null || :
     - persist_to_workspace:
         root: .
         paths:
@@ -231,9 +227,8 @@ jobs:
     - run:
         name: Run integration tests
         command: |
-          TESTFILES=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings)
-          echo "${TESTFILES}"
-          bundle exec cucumber --format junit,fileattribute=true --out /tmp/test-results/cucumber --format pretty -- ${TESTFILES}
+          circleci tests glob "features/**/*.feature" | \
+          circleci tests run --command="xargs bundle exec cucumber --format junit,fileattribute=true --out /tmp/test-results/cucumber --format pretty" --verbose --split-by=timings
     - store_artifacts:
         path: tmp/capybara
     - store_test_results:
@@ -242,7 +237,8 @@ jobs:
         name: Stash Coverage Results
         command: |
           mkdir coverage_results
-          cp -R coverage/.resultset.json coverage_results/.resultset-${CIRCLE_NODE_INDEX}-integration.json
+          # suppress error if no file exists (can occur if running only failed tests)
+          cp -R coverage/.resultset.json coverage_results/.resultset-${CIRCLE_NODE_INDEX}-integration.json 2>/dev/null || :
     - persist_to_workspace:
         root: .
         paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,24 +195,56 @@ jobs:
         command: |
           circleci tests glob "spec/**/*_spec.rb" | \
           circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml" --verbose --split-by=timings --timings-type=filename
+
+    #### BEGIN old config for coverage results collation
+    # - store_test_results:
+    #     path: /tmp/test-results/rspec
+
+    # - run:
+    #     name: Stash Coverage Results
+    #     command: |
+    #       mkdir coverage_results
+
+    #       # Only copy coverage if main run, not re-run
+    #       # if [ ${CIRCLE_WORKFLOW_ID} = ${CIRCLE_WORKFLOW_WORKSPACE_ID} ]
+    #       # then
+    #         # suppress error if no file exists (can occur if running only failed tests)
+    #         cp -R coverage/.resultset.json coverage_results/.resultset-${CIRCLE_NODE_INDEX}-unit.json 2>/dev/null || :
+    #       # fi
+
+    # - persist_to_workspace:
+    #     root: .
+    #     paths:
+    #       - coverage_results
+    #### END old config for coverage results collation
+
+
+    # For a rerun that succeeds, restore the coverage files from the failed run
+    - restore_cache:
+        key: coverage-{{.Revision}}-{{.Environment.CIRCLE_NODE_INDEX}}
+    # # Save the coverage for rerunning failed tests. CircleCI will skip saving if this revision key has already been saved.
+    - save_cache:
+        key: coverage-{{.Revision}}-{{.Environment.CIRCLE_NODE_INDEX}}
+        paths:
+          - coverage_results
+        when: always
+    # # Needed to rerun failed tests
     - store_test_results:
         path: /tmp/test-results/rspec
-
-    - run:
-        name: Stash Coverage Results
-        command: |
-          mkdir coverage_results
-
-          # Only copy coverage if main run, not re-run
-          if [ ${CIRCLE_WORKFLOW_ID} = ${CIRCLE_WORKFLOW_WORKSPACE_ID} ]
-          then
-            # suppress error if no file exists (can occur if running only failed tests)
-            cp -R coverage/.resultset.json coverage_results/.resultset-${CIRCLE_NODE_INDEX}-unit.json 2>/dev/null || :
-          fi
+        when: always
+    # # Upload coverage file html so we can show it includes all the tests (not just rerun)
     - persist_to_workspace:
         root: .
         paths:
           - coverage_results
+        when: always
+    # # - run:
+    # #     name: Save html coverage
+    # #     command: go tool cover -html=cover.out -o cover.html
+    # #     when: always
+    - store_artifacts:
+        path: coverage_results
+        when: always
 
   integration_tests:
     parallelism: 10

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -29,6 +29,11 @@ RSpec.describe "Firm" do
       it "returns all permissions" do
         expect(firm.permissions.all).to contain_exactly(permission2, permission1)
       end
+
+      it "fails occasionalley" do
+        var = [1, 2, 3, 4].sample
+        expect(var).to eq 2
+      end
     end
   end
 


### PR DESCRIPTION
## What
Configure failed test reruns

To make use of failed test rerun feature
see https://circleci.com/docs/rerun-failed-tests/


## TODO

Unfortunately a rerun of a single failed test will, on success, break the subsequent coverage step. This is most likely due to the parallel node's rerun coverage result being only for the failed tests and this then overwrites/overrides the full runs coverage results for the node - i am guessing. _How can we resolve that issue?_ 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
