### PR TITLE
Chore: Change UAT ingress to default-non-prod

### DIFF
--- a/helm_deploy/apply-for-legal-aid/values-uat.yaml
+++ b/helm_deploy/apply-for-legal-aid/values-uat.yaml
@@ -10,7 +10,7 @@ service:
 
 ingress:
   enabled: true
-  className: default
+  className: default-non-prod
   annotations:
     external-dns.alpha.kubernetes.io/aws-weight: '100'
   path: /


### PR DESCRIPTION
## What
Change UAT ingress to default-non-prod

Following recommendations from CP.

see https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/does-my-app-need-ingress.html#does-my-app-need-an-ingress

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
