### PR TITLE
AP-5646: Update two year digit handling

### DIFF
--- a/app/forms/concerns/date_field_builder.rb
+++ b/app/forms/concerns/date_field_builder.rb
@@ -105,7 +105,8 @@ private
     when 4
       year
     when 2
-      year > Time.current.strftime("%y") ? "19#{year}" : "20#{year}"
+      century = @method.eql?(:date_of_birth) && year > Time.current.strftime("%y") ? "19" : "20"
+      "#{century}#{year}"
     else
       raise YearError, "Year is incorrect length"
     end

--- a/app/forms/concerns/date_field_builder.rb
+++ b/app/forms/concerns/date_field_builder.rb
@@ -105,7 +105,7 @@ private
     when 4
       year
     when 2
-      century = @method.eql?(:date_of_birth) && year > Time.current.strftime("%y") ? "19" : "20"
+      century = @method.eql?(:date_of_birth) && year.to_i > Time.current.strftime("%y").to_i ? "19" : "20"
       "#{century}#{year}"
     else
       raise YearError, "Year is incorrect length"

--- a/spec/forms/partners/details_form_spec.rb
+++ b/spec/forms/partners/details_form_spec.rb
@@ -118,6 +118,26 @@ RSpec.describe Partners::DetailsForm, type: :form do
       end
     end
 
+    context "with a two digit year greater than current year" do
+      let(:current_year) { Time.current.strftime("%y").to_i }
+      let(:date_of_birth) { Date.new(current_year + 1, 1, 1) }
+
+      it "sets the date of birth to be 19xx" do
+        partner_form.save!
+        expect(legal_aid_application.reload.partner).to have_attributes(date_of_birth: Date.new("19#{current_year + 1}".to_i, 1, 1))
+      end
+    end
+
+    context "with a two digit year less than current year" do
+      let(:current_year) { Time.current.strftime("%y").to_i }
+      let(:date_of_birth) { Date.new(current_year - 1, 1, 1) }
+
+      it "sets the date of birth to be 19xx" do
+        partner_form.save!
+        expect(legal_aid_application.reload.partner).to have_attributes(date_of_birth: Date.new("20#{current_year - 1}".to_i, 1, 1))
+      end
+    end
+
     context "with invalid dob elements" do
       let(:params) do
         {

--- a/spec/forms/proceedings/final_hearing_form_spec.rb
+++ b/spec/forms/proceedings/final_hearing_form_spec.rb
@@ -103,6 +103,24 @@ module Proceedings
               date: Time.zone.today,
             )
           end
+
+          context "and the year is greater than the current year" do
+            let(:current_year) { Time.current.strftime("%y").to_i }
+            let(:date_1i) { current_year + 1 }
+
+            it "sets the final hearing date to be 20xx" do
+              expect(final_hearing).to have_attributes(date: Date.new("20#{current_year + 1}".to_i, Time.zone.today.month, Time.zone.today.day))
+            end
+          end
+
+          context "and the year is less than the current year" do
+            let(:current_year) { Time.current.strftime("%y").to_i }
+            let(:date_1i) { current_year - 1 }
+
+            it "sets the final hearing date to be 20xx" do
+              expect(final_hearing).to have_attributes(date: Date.new("20#{current_year - 1}".to_i, Time.zone.today.month, Time.zone.today.day))
+            end
+          end
         end
       end
 


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5646)

This was written a long time ago, when only date of birth was entered

We now have multiple date inputs that require future dates to be entered, e.g. hearing dates in the future, and this handler would reset a future date to be 19xx.

This update only applies a rollback on dates when the requested field is a date of birth entry. For all others it will roll forward


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
