### PR TITLE
AP-5955: Fix employment status form

### DIFF
--- a/app/forms/base_employed_form.rb
+++ b/app/forms/base_employed_form.rb
@@ -9,6 +9,14 @@ class BaseEmployedForm < BaseForm
 
 private
 
+  def initialize(params = {})
+    EMPLOYMENT_TYPES.each do |employment_type|
+      send("#{employment_type}=", params[:model].send(employment_type))
+    end
+
+    super
+  end
+
   def any_checkbox_checked?
     checkbox_hash.values.any?(&:present?)
   end

--- a/app/views/shared/_employment_status.html.erb
+++ b/app/views/shared/_employment_status.html.erb
@@ -11,18 +11,28 @@
                                         caption: { text: t("generic.#{caption_individual}_means_caption"), size: "l" },
                                         hint: { text: t("generic.select_all_that_apply") },
                                         form_group: { class: @form.errors.any? ? "govuk-form-group--error" : "" } do %>
+
       <% if @form.errors[:employed].any? %>
         <p class="govuk-error-message" id="employment-type-error">
           <span class="govuk-visually-hidden">Error: </span><%= @form.errors[:employed].first %></p>
       <% end %>
       <div class="deselect-group govuk-!-margin-bottom-2" data-deselect-ctrl="#<%= individual %>-none-selected-true-field">
         <% BaseEmployedForm::EMPLOYMENT_TYPES.each do |employment_type| %>
-          <%= form.govuk_check_box employment_type, true, "", multiple: false, link_errors: true, label: { text: t(".#{employment_type}") } %>
+          <%= form.govuk_check_box employment_type,
+                                   true,
+                                   "",
+                                   multiple: false,
+                                   link_errors: true,
+                                   label: { text: t(".#{employment_type}") } %>
         <% end %>
       </div>
 
       <%= form.govuk_radio_divider %>
-      <%= form.govuk_check_box :none_selected, true, "", multiple: false, label: { text: t(".not_employed") } %>
+      <%= form.govuk_check_box :none_selected,
+                               true,
+                               "",
+                               multiple: false,
+                               label: { text: t(".not_employed") } %>
     <% end %>
 
     <%= next_action_buttons(show_draft: true, form:) %>

--- a/features/providers/applicant_details.feature
+++ b/features/providers/applicant_details.feature
@@ -191,9 +191,9 @@ Feature: Applicant details
     Then I click 'Save and continue'
     Then I should be on a page showing "What you need to do"
     When I click 'Continue'
-    And I should be on a page showing "What is your client's employment status?"
-    And I select "None of the above"
-    When I click 'Save and continue'
+    Then I should be on a page showing "What is your client's employment status?"
+    When I select "None of the above"
+    When I click "Save and continue"
     Then I should be on a page with title "Does your client use online banking?"
     Then I choose 'Yes'
     Then I click 'Save and continue'

--- a/features/providers/employment_status.feature
+++ b/features/providers/employment_status.feature
@@ -1,0 +1,56 @@
+Feature: Employment status
+
+  @javascript @vcr
+  Scenario: Client employment status page behaves as expected
+    Given I complete the non-passported journey as far as check your answers
+    Then I should be on a page showing 'Check your answers'
+
+    When I click 'Save and continue'
+    Then I should be on a page showing "DWP records show that your client does not get a passporting benefit"
+    Then I choose 'Yes'
+    Then I click 'Save and continue'
+    Then I should be on a page showing "What you need to do"
+
+    When I click 'Continue'
+    Then I should be on a page with title "What is your client's employment status?"
+
+    # Test that no checkbox is prefilled
+    When I click "Save and continue"
+    Then I should see govuk error summary "Select one or more employment types or None of the above if not employed"
+
+    # Test that existing values are represented by checkboxes
+    When I select "Employed"
+    And I click "Save and continue"
+    And I click link "Back"
+    Then I should be on a page with title "What is your client's employment status?"
+    And I should see the following checkboxes checked or unchecked:
+      | checkbox_id | checked |
+      | applicant-employed-true-field | true |
+      | applicant-self-employed-true-field | false |
+      | applicant-armed-forces-true-field | false |
+
+    When I click "Save and continue"
+    Then I should be on a page with title "Does your client use online banking?"
+
+  @javascript @vcr
+  Scenario: Partner employment status page behaves as expected
+    Given I complete the non-passported journey as far as the employment status page for a partner
+    Then I should be on a page with title "What is the partner's employment status?"
+
+    # Test that no checkbox is prefilled
+    When I click "Save and continue"
+    Then I should see govuk error summary "Select one or more employment types or None of the above if not employed"
+
+    # Test that existing values are represented by checkboxes
+    When I select "Employed"
+    And I click "Save and continue"
+    And I click link "Back"
+    Then I should be on a page with title "What is the partner's employment status?"
+    And I should see the following checkboxes checked or unchecked:
+      | checkbox_id | checked |
+      | partner-employed-true-field | true |
+      | partner-self-employed-true-field | false |
+      | partner-armed-forces-true-field | false |
+
+    When I click "Save and continue"
+    Then I should be on a page with title "Upload the partner's bank statements"

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -714,6 +714,34 @@ Given("I complete the journey as far as check client details with a partner") do
   steps %(Then I should be on a page showing 'Check your answers')
 end
 
+Given("I complete the non-passported journey as far as the employment status page for a partner") do
+  applicant = create(:applicant, :with_partner_with_no_contrary_interest)
+  create(
+    :address,
+    address_line_one: "Transport For London",
+    address_line_two: "98 Petty France",
+    city: "London",
+    county: nil,
+    postcode: "SW1H 9EA",
+    lookup_used: true,
+    applicant:,
+  )
+  partner = create(:partner)
+  @legal_aid_application = create(
+    :application,
+    :with_proceedings,
+    :with_non_passported_state_machine,
+    :at_entering_applicant_details,
+    :provider_confirming_applicant_eligibility,
+    applicant:,
+    partner:,
+  )
+
+  login_as @legal_aid_application.provider
+  visit(providers_legal_aid_application_partners_employed_index_path(@legal_aid_application))
+  steps %(Then I should be on a page showing 'employment ')
+end
+
 Given("I complete the journey as far as the employment status page for a partner with no NI number") do
   applicant = create(:applicant, :with_partner)
   create(

--- a/features/step_definitions/generic_steps.rb
+++ b/features/step_definitions/generic_steps.rb
@@ -66,6 +66,12 @@ Then("the following sections should not exist:") do |table|
   end
 end
 
+Then("I should see the following checkboxes checked or unchecked:") do |table|
+  table.hashes.each do |row|
+    expect(page).to have_field(row[:checkbox_id], visible: :all, checked: ActiveModel::Type::Boolean.new.cast(row[:checked]))
+  end
+end
+
 Then("the govuk-summary-card titled {string} should contain:") do |card_title, table|
   element = page.find(class: "govuk-summary-card", text: card_title)
 

--- a/spec/forms/applicants/employed_form_spec.rb
+++ b/spec/forms/applicants/employed_form_spec.rb
@@ -1,19 +1,39 @@
 require "rails_helper"
 
 RSpec.describe Applicants::EmployedForm, type: :form do
-  subject(:described_form) { described_class.new(form_params) }
+  subject(:form) { described_class.new(form_params) }
 
   let(:applicant) { create(:applicant, employed: nil) }
   let(:params) { { employed: true } }
   let(:form_params) { params.merge(model: applicant) }
 
-  describe "validations" do
+  describe "#initialize" do
+    context "when instantiated with model object that does not have existing checkbox values" do
+      let(:params) { {} }
+      let(:applicant) { create(:applicant, employed: nil, self_employed: nil, armed_forces: nil) }
+
+      it "initialises values to nil" do
+        expect(form).to have_attributes(employed: nil, self_employed: nil, armed_forces: nil)
+      end
+    end
+
+    context "when instantiated with model object that has existing checkbox values" do
+      let(:params) { {} }
+      let(:applicant) { create(:applicant, employed: true, self_employed: true, armed_forces: false) }
+
+      it "initialises values to existing model object values" do
+        expect(form).to have_attributes(employed: true, self_employed: true, armed_forces: false)
+      end
+    end
+  end
+
+  describe "#validate" do
     context "when no checkbox is selected" do
       let(:params) { {} }
 
       it "errors" do
-        expect(described_form.save).to be false
-        expect(described_form.errors[:employed]).to eq [I18n.t("activemodel.errors.models.applicant.attributes.base.none_selected")]
+        expect(form).to be_invalid
+        expect(form.errors[:employed]).to eq [I18n.t("activemodel.errors.models.applicant.attributes.base.none_selected")]
       end
     end
 
@@ -21,8 +41,8 @@ RSpec.describe Applicants::EmployedForm, type: :form do
       let(:params) { { employed: "true", none_selected: "true" } }
 
       it "errors" do
-        expect(described_form.save).to be false
-        expect(described_form.errors[:employed]).to eq [I18n.t("activemodel.errors.models.applicant.attributes.base.none_and_another_option_selected")]
+        expect(form).to be_invalid
+        expect(form.errors[:employed]).to eq [I18n.t("activemodel.errors.models.applicant.attributes.base.none_and_another_option_selected")]
       end
     end
   end
@@ -33,7 +53,7 @@ RSpec.describe Applicants::EmployedForm, type: :form do
 
     it "updates record with new value of employed attribute" do
       expect(applicant.employed).to be_nil
-      described_form.save!
+      form.save!
       expect(applicant.employed).to be false
     end
   end

--- a/spec/forms/partners/employed_form_spec.rb
+++ b/spec/forms/partners/employed_form_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Partners::EmployedForm, type: :form do
-  subject(:partner_employed_form) { described_class.new(form_params) }
+  subject(:form) { described_class.new(form_params) }
 
   let(:application) { create(:legal_aid_application, partner:) }
   let(:partner) { create(:partner, employed: nil) }
@@ -9,13 +9,33 @@ RSpec.describe Partners::EmployedForm, type: :form do
   let(:params) { { employed: true } }
   let(:form_params) { params.merge(model: partner) }
 
-  describe "validations" do
+  describe "#initialize" do
+    context "when instantiated with model object that does not have existing checkbox values" do
+      let(:params) { {} }
+      let(:partner) { create(:partner, employed: nil, self_employed: nil, armed_forces: nil) }
+
+      it "initialises values to nil" do
+        expect(form).to have_attributes(employed: nil, self_employed: nil, armed_forces: nil)
+      end
+    end
+
+    context "when instantiated with model object that has existing checkbox values" do
+      let(:params) { {} }
+      let(:partner) { create(:applicant, employed: true, self_employed: true, armed_forces: false) }
+
+      it "initialises values to existing model object values" do
+        expect(form).to have_attributes(employed: true, self_employed: true, armed_forces: false)
+      end
+    end
+  end
+
+  describe "#validate" do
     context "when no checkbox is selected" do
       let(:params) { {} }
 
       it "errors" do
-        expect(partner_employed_form.save).to be false
-        expect(partner_employed_form.errors[:employed]).to eq [I18n.t("activemodel.errors.models.partner.attributes.base.none_selected")]
+        expect(form).to be_invalid
+        expect(form.errors[:employed]).to eq [I18n.t("activemodel.errors.models.partner.attributes.base.none_selected")]
       end
     end
 
@@ -23,8 +43,8 @@ RSpec.describe Partners::EmployedForm, type: :form do
       let(:params) { { employed: "true", none_selected: "true" } }
 
       it "errors" do
-        expect(partner_employed_form.save).to be false
-        expect(partner_employed_form.errors[:employed]).to eq [I18n.t("activemodel.errors.models.partner.attributes.base.none_and_another_option_selected")]
+        expect(form).to be_invalid
+        expect(form.errors[:employed]).to eq [I18n.t("activemodel.errors.models.partner.attributes.base.none_and_another_option_selected")]
       end
     end
   end
@@ -34,7 +54,7 @@ RSpec.describe Partners::EmployedForm, type: :form do
 
     it "updates record with new value of employed attribute" do
       expect(partner.employed).to be_nil
-      partner_employed_form.save!
+      form.save!
       expect(partner.employed).to be false
     end
   end


### PR DESCRIPTION
## What
Fix employment status form to show already checked items

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5955)

So the checkboxes are checked or not when page returned to.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
