### PR TITLE
Chore: Update MOJ frontend package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,10 +28,6 @@ updates:
       day: tuesday
       time: "21:15"
       timezone: Europe/London
-    ignore:
-      - dependency-name: "@ministryofjustice/frontend"
-        versions:
-          - ">= 5.0.0"
     groups:
       moj-frontend:
         patterns:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "postinstall": "rm -rf node_modules/resolve/test/resolver/multirepo node_modules/eslint-plugin-react/node_modules/resolve/test/resolver/multirepo"
   },
   "dependencies": {
-    "@ministryofjustice/frontend": "^4.0.2",
+    "@ministryofjustice/frontend": "^5.1.2",
     "@rails/ujs": "^7.1.501",
     "axios": "^1.8.4",
     "core-js": "^3.41.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1383,10 +1383,10 @@
   dependencies:
     buffer "^6.0.3"
 
-"@ministryofjustice/frontend@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@ministryofjustice/frontend/-/frontend-4.0.2.tgz#6cc8c1e817ba5a264773ed4ffcad37826ed387d3"
-  integrity sha512-UhzWIaIHNBcU1yhtSTAftbv8KaSmGq9+sSb+jTtXtFE/dCkhOAgojBn2glI4O2uWTjqIFPrOmN/N2DRfrx0sLA==
+"@ministryofjustice/frontend@^5.1.2":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@ministryofjustice/frontend/-/frontend-5.1.2.tgz#0eb44cd9f1e2e322dd24792f1e2bd66f8f4b56da"
+  integrity sha512-ZpxmefOMLdm4CQGctz4KLIlbgJGHTjhJXohKAygZoA+/pP+paGmbeGIDkdjW7wRF5etld+ERZ9yqNeoMmm+VAw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
## What

This updates the MOJ frontend package to the latest version and removes the dependabot ignore

I checked the release notes [here](https://github.com/ministryofjustice/moj-frontend/releases/tag/v5.1.0) and found no breaking changes but **a second pair of eyes may be useful**!

We have always imported _all_ JS from the frontend.  We could reduce our JS footprint by only importing the required components but that should probably be a discussion

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
