### PR TITLE
Tidy: Refactor assessment results controllers

### DIFF
--- a/app/controllers/providers/capital_assessment_results_controller.rb
+++ b/app/controllers/providers/capital_assessment_results_controller.rb
@@ -1,24 +1,4 @@
 module Providers
-  class CapitalAssessmentResultsController < ProviderBaseController
-    KNOWN_RESULTS = %w[eligible ineligible contribution_required partially_eligible].freeze
-
-    def show
-      @cfe_result = legal_aid_application.cfe_result
-      handle_unknown
-      @details = ManualReviewDetailer.call(legal_aid_application)
-      @result_partial = ResultsPanelSelector.call(legal_aid_application)
-    end
-
-    def update
-      continue_or_draft
-    end
-
-  private
-
-    def handle_unknown
-      return if KNOWN_RESULTS.include?(@cfe_result.assessment_result)
-
-      raise "Unknown capital_assessment_result: '#{@cfe_result.assessment_result}'"
-    end
+  class CapitalAssessmentResultsController < MeansAssessmentResultsController
   end
 end

--- a/app/controllers/providers/capital_income_assessment_results_controller.rb
+++ b/app/controllers/providers/capital_income_assessment_results_controller.rb
@@ -1,24 +1,4 @@
 module Providers
-  class CapitalIncomeAssessmentResultsController < ProviderBaseController
-    KNOWN_RESULTS = %w[eligible ineligible contribution_required partially_eligible].freeze
-
-    def show
-      @cfe_result = legal_aid_application.cfe_result
-      handle_unknown
-      @details = ManualReviewDetailer.call(legal_aid_application)
-      @result_partial = ResultsPanelSelector.call(legal_aid_application)
-    end
-
-    def update
-      continue_or_draft
-    end
-
-  private
-
-    def handle_unknown
-      return if KNOWN_RESULTS.include?(@cfe_result.assessment_result)
-
-      raise "Unknown capital_income_assessment_result: '#{@cfe_result.assessment_result}'"
-    end
+  class CapitalIncomeAssessmentResultsController < MeansAssessmentResultsController
   end
 end

--- a/app/controllers/providers/means_assessment_results_controller.rb
+++ b/app/controllers/providers/means_assessment_results_controller.rb
@@ -1,0 +1,24 @@
+module Providers
+  class MeansAssessmentResultsController < ProviderBaseController
+    KNOWN_RESULTS = %w[eligible ineligible contribution_required partially_eligible].freeze
+
+    def show
+      @cfe_result = legal_aid_application.cfe_result
+      handle_unknown
+      @details = ManualReviewDetailer.call(legal_aid_application)
+      @result_partial = ResultsPanelSelector.call(legal_aid_application)
+    end
+
+    def update
+      continue_or_draft
+    end
+
+  private
+
+    def handle_unknown
+      return if KNOWN_RESULTS.include?(@cfe_result.assessment_result)
+
+      raise "Unknown result using #{self.class}: '#{@cfe_result.assessment_result}'"
+    end
+  end
+end

--- a/spec/helpers/liquid_capital_items_helper_spec.rb
+++ b/spec/helpers/liquid_capital_items_helper_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe LiquidCapitalItemsHelper do
+  describe "#capital_items_to_display?" do
+    subject(:call) { capital_items_to_display?(legal_aid_application, item) }
+
+    context "with passported application without online accounts item description" do
+      let(:legal_aid_application) { create(:legal_aid_application, :passported) }
+      let(:item) { { description: "foobar" } }
+
+      it { is_expected.to be true }
+    end
+
+    context "with passported application with online account item description" do
+      let(:legal_aid_application) { create(:legal_aid_application, :passported) }
+      let(:item) { { description: "Online current accounts" } }
+
+      it { is_expected.to be false }
+    end
+
+    context "with non-passported application" do
+      let(:legal_aid_application) { create(:legal_aid_application, :non_passported) }
+      let(:item) { { description: "irrelevant" } }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe "#item_description" do
+    subject(:call) { item_description(legal_aid_application, item) }
+
+    context "with passported application" do
+      let(:legal_aid_application) { create(:legal_aid_application, :passported) }
+      let(:item) { { description: "foobar" } }
+
+      it "returns item description" do
+        expect(call).to eql "foobar"
+      end
+    end
+
+    context "with non-passported application and saving account item description" do
+      let(:legal_aid_application) { create(:legal_aid_application, :non_passported) }
+      let(:item) { { description: "Savings accounts" } }
+
+      it { is_expected.to eql "Savings accounts your client cannot access online" }
+    end
+  end
+end

--- a/spec/requests/providers/capital_assessment_results_controller_spec.rb
+++ b/spec/requests/providers/capital_assessment_results_controller_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Providers::CapitalAssessmentResultsController do
         end
 
         context "when capital contribution required" do
-          let(:cfe_result) { create(:cfe_v3_result, :with_capital_contribution_required) }
+          let(:cfe_result) { create(:cfe_v6_result, :with_capital_contribution_required) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -79,7 +79,7 @@ RSpec.describe Providers::CapitalAssessmentResultsController do
         end
 
         context "when capital contribution required" do
-          let(:cfe_result) { create(:cfe_v3_result, :with_capital_contribution_required) }
+          let(:cfe_result) { create(:cfe_v6_result, :with_capital_contribution_required) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -109,7 +109,7 @@ RSpec.describe Providers::CapitalAssessmentResultsController do
         let(:add_policy_disregards?) { true }
 
         context "when eligible" do
-          let(:cfe_result) { create(:cfe_v3_result, :eligible) }
+          let(:cfe_result) { create(:cfe_v6_result, :eligible) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -121,7 +121,7 @@ RSpec.describe Providers::CapitalAssessmentResultsController do
         end
 
         context "when contribution required" do
-          let(:cfe_result) { create(:cfe_v3_result, :with_capital_contribution_required) }
+          let(:cfe_result) { create(:cfe_v6_result, :with_capital_contribution_required) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -139,7 +139,7 @@ RSpec.describe Providers::CapitalAssessmentResultsController do
 
       context "with no policy disregards" do
         context "when eligible" do
-          let(:cfe_result) { create(:cfe_v3_result, :eligible) }
+          let(:cfe_result) { create(:cfe_v6_result, :eligible) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -151,7 +151,7 @@ RSpec.describe Providers::CapitalAssessmentResultsController do
         end
 
         context "when contribution required" do
-          let(:cfe_result) { create(:cfe_v3_result, :with_capital_contribution_required) }
+          let(:cfe_result) { create(:cfe_v6_result, :with_capital_contribution_required) }
 
           it "returns http success" do
             expect(response).to have_http_status(:ok)
@@ -176,7 +176,7 @@ RSpec.describe Providers::CapitalAssessmentResultsController do
       end
 
       context "when eligible" do
-        let(:cfe_result) { create(:cfe_v4_result, :eligible) }
+        let(:cfe_result) { create(:cfe_v6_result, :eligible) }
 
         it "returns http success" do
           expect(response).to have_http_status(:ok)
@@ -191,7 +191,7 @@ RSpec.describe Providers::CapitalAssessmentResultsController do
       end
 
       context "when capital contribution required" do
-        let(:cfe_result) { create(:cfe_v4_result, :with_capital_contribution_required) }
+        let(:cfe_result) { create(:cfe_v6_result, :with_capital_contribution_required) }
         let(:add_policy_disregards?) { false }
 
         it "returns http success" do
@@ -248,11 +248,11 @@ RSpec.describe Providers::CapitalAssessmentResultsController do
     end
 
     context "with unknown result" do
-      let(:cfe_result) { create(:cfe_v3_result, result: {}.to_json) }
+      let(:cfe_result) { create(:cfe_v6_result, result: { result_summary: { overall_result: { result: "foobar" } } }.to_json) }
       let(:before_tasks) { login_provider }
 
       it "raises error" do
-        expect { get_request }.to raise_error(/Unknown capital_assessment_result/)
+        expect { get_request }.to raise_error(/Unknown result using #{described_class}: 'foobar'/)
       end
     end
   end

--- a/spec/requests/providers/capital_income_assessment_results_controller_spec.rb
+++ b/spec/requests/providers/capital_income_assessment_results_controller_spec.rb
@@ -428,13 +428,11 @@ RSpec.describe Providers::CapitalIncomeAssessmentResultsController do
     end
 
     context "with unknown result" do
-      let(:cfe_result) { create(:cfe_v6_result, result: {}.to_json) }
-      let(:before_tasks) do
-        login_provider
-      end
+      let(:cfe_result) { create(:cfe_v6_result, result: { result_summary: { overall_result: { result: "foobar" } } }.to_json) }
+      let(:before_tasks) { login_provider }
 
       it "raises error" do
-        expect { get_request }.to raise_error(/Unknown capital_income_assessment_result/)
+        expect { get_request }.to raise_error(/Unknown result using #{described_class}: 'foobar'/)
       end
     end
 


### PR DESCRIPTION
## What
Refactor assessment result controllers and more

[Came out of story](https://dsdmoj.atlassian.net/browse/AP-5828)

Two controllers that are identical. One for assessment
results for passported one for non-passported.

Can also potentially rename the child controllers, steps
and perhaps look at the views to remove repetition.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
