### PR TITLE
AP-5324: Remove public_law_family feature flag

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -23,8 +23,7 @@ module Admin
                                 allow_welsh_translation
                                 enable_ccms_submission
                                 linked_applications
-                                collect_hmrc_data
-                                public_law_family])
+                                collect_hmrc_data])
     end
 
     def setting

--- a/app/forms/settings/setting_form.rb
+++ b/app/forms/settings/setting_form.rb
@@ -7,8 +7,7 @@ module Settings
                   :allow_welsh_translation,
                   :enable_ccms_submission,
                   :linked_applications,
-                  :collect_hmrc_data,
-                  :public_law_family
+                  :collect_hmrc_data
 
     validates :mock_true_layer_data,
               :manually_review_all_cases,
@@ -16,7 +15,6 @@ module Settings
               :enable_ccms_submission,
               :linked_applications,
               :collect_hmrc_data,
-              :public_law_family,
               presence: true
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,4 +1,6 @@
 class Setting < ApplicationRecord
+  self.ignored_columns += %w[public_law_family]
+
   def self.mock_true_layer_data?
     setting.mock_true_layer_data?
   end
@@ -29,10 +31,6 @@ class Setting < ApplicationRecord
 
   def self.collect_hmrc_data?
     setting.collect_hmrc_data
-  end
-
-  def self.public_law_family?
-    setting.public_law_family
   end
 
   def self.setting

--- a/app/services/legal_framework/proceeding_types/all.rb
+++ b/app/services/legal_framework/proceeding_types/all.rb
@@ -17,11 +17,6 @@ module LegalFramework
           @sca_related = pt_hash["sca_related"]
           @plf = pt_hash["ccms_matter_code"] == "KPBLB"
         end
-
-        # TODO: remove the below when the PLF feature flag is removed
-        def not_plf?
-          @plf == false
-        end
       end
 
       def self.call(legal_aid_application)
@@ -36,10 +31,6 @@ module LegalFramework
       def call
         parsed_body = JSON.parse(request.body)
         result = parsed_body["data"].map { |pt_hash| ProceedingTypeStruct.new(pt_hash) }
-
-        # TODO: remove the below when the PLF feature flag is removed
-        # Filter out PLF applications
-        result.select!(&:not_plf?) unless Setting.public_law_family?
 
         result
       end

--- a/app/services/legal_framework/proceeding_types/all.rb
+++ b/app/services/legal_framework/proceeding_types/all.rb
@@ -30,9 +30,7 @@ module LegalFramework
 
       def call
         parsed_body = JSON.parse(request.body)
-        result = parsed_body["data"].map { |pt_hash| ProceedingTypeStruct.new(pt_hash) }
-
-        result
+        parsed_body["data"].map { |pt_hash| ProceedingTypeStruct.new(pt_hash) }
       end
 
     private

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -66,16 +66,6 @@
           legend: { text: t(".labels.collect_hmrc_data") },
         ) %>
 
-    <%= form.govuk_collection_radio_buttons(
-          :public_law_family,
-          yes_no_options,
-          :value,
-          :label,
-          inline: true,
-          hint: { text: t(".hints.public_law_family") },
-          legend: { text: t(".labels.public_law_family") },
-        ) %>
-
     <%= form.govuk_submit(t("generic.submit")) %>
   <% end %>
 <% end %>

--- a/app/views/providers/start/index.html.erb
+++ b/app/views/providers/start/index.html.erb
@@ -6,7 +6,7 @@
 
     <p class="govuk-body"><%= t(".use_service.list_title") %></p>
 
-    <%= govuk_list Setting.public_law_family? ? t(".use_service.with_plf_list") : t(".use_service.list"), type: :bullet %>
+    <%= govuk_list t(".use_service.list"), type: :bullet %>
 
     <p class="govuk-body"><%= t(".dont_use_service.list_title") %></p>
 

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -81,7 +81,6 @@ en:
           enable_evidence_upload: Enable the new evidence upload feature
           linked_applications: Enable linking and copying cases
           collect_hmrc_data: Collect HMRC data
-          public_law_family: Enable Public Law Family
         hints:
           mock_true_layer_data: Select Yes and TrueLayer data will be replaced by mock data from %{bank_transaction_filename}
           manually_review_all_cases: |
@@ -92,7 +91,6 @@ en:
           enable_evidence_upload: Select Yes to enable the new evidence upload feature for solicitors
           linked_applications: Select Yes to enable the linking and copying cases feature for solicitors
           collect_hmrc_data: Select Yes to enable calls to HMRC for employment data
-          public_law_family: Select Yes to enable Public Law Family feature
 
       update:
         notice: Settings have been updated

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1851,10 +1851,6 @@ en:
             - domestic abuse, except DAPO (domestic abuse protection orders)
             - section 8
             - special children act
-          with_plf_list:
-            - domestic abuse, except DAPO (domestic abuse protection orders)
-            - section 8
-            - special children act
             - public law family
         dont_use_service:
           list_title: "But do not use this service if:"

--- a/features/cassettes/Loop_through_proceeding_questions/No_preselected_emergency_or_substantive_levels_of_service.yml
+++ b/features/cassettes/Loop_through_proceeding_questions/No_preselected_emergency_or_substantive_levels_of_service.yml
@@ -8,14 +8,14 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:10 GMT
+      - Wed, 07 May 2025 15:58:09 GMT
       content-type:
       - application/json;charset=UTF-8
       transfer-encoding:
@@ -37,8 +37,8 @@ http_interactions:
       string: "{\r\n  \"header\" : {\r\n    \"uri\" : \"https://api.os.uk/search/places/v1/postcode?lr=EN&postcode=SW1H9EA\",\r\n
         \   \"query\" : \"postcode=SW1H9EA\",\r\n    \"offset\" : 0,\r\n    \"totalresults\"
         : 5,\r\n    \"format\" : \"JSON\",\r\n    \"dataset\" : \"DPA\",\r\n    \"lr\"
-        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"115\",\r\n    \"lastupdate\"
-        : \"2025-03-13\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
+        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"118\",\r\n    \"lastupdate\"
+        : \"2025-05-06\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
         : [ {\r\n    \"DPA\" : {\r\n      \"UPRN\" : \"100023337883\",\r\n      \"UDPRN\"
         : \"23749699\",\r\n      \"ADDRESS\" : \"84, PETTY FRANCE, LONDON, SW1H 9EA\",\r\n
         \     \"BUILDING_NUMBER\" : \"84\",\r\n      \"THOROUGHFARE_NAME\" : \"PETTY
@@ -133,7 +133,7 @@ http_interactions:
         \     \"BLPU_STATE_DATE\" : \"15/06/2020\",\r\n      \"LANGUAGE\" : \"EN\",\r\n
         \     \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\" : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\"
         : \"1N\"\r\n    }\r\n  } ]\r\n}"
-  recorded_at: Fri, 14 Mar 2025 09:32:10 GMT
+  recorded_at: Wed, 07 May 2025 15:58:09 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
@@ -144,14 +144,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:11 GMT
+      - Wed, 07 May 2025 15:58:10 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -171,440 +171,436 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"93565432497c5ce191eac6fbf69b9a81"
+      - W/"f5d4a442765bb4b1da38aa01d431b319"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - d9778a223ad07bf2be42d9f63ed17dbd
+      - 36000531745c2a0b91622a67055d5262
       x-runtime:
-      - '0.026689'
+      - '0.035256'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
-        for an injunction, order or declaration under the inherent jurisdiction of
-        the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
-        1997 under section 5 - vary or discharge","description":"to be represented
-        on an application to vary or discharge an order under section 5 Protection
-        from Harassment Act 1997 where the parties are associated persons (as defined
-        by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
-        (CAO) - residence","description":"to be represented on an application for
-        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PB003","meaning":"Child assessment order","description":"to
-        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB004","meaning":"Emergency protection
-        order - extend","description":"to be represented on an application for or
-        to extend an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB005","meaning":"Emergency protection
-        order - discharge","description":"to be represented on an application to discharge
-        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB006","meaning":"Secure accommodation
-        order","description":"to be represented on an application for a secure accommodation
-        order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB026","meaning":"Emergency protection
-        order","description":"to be represented on an application for an emergency
-        protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB057","meaning":"Care order","description":"to
-        be represented on an application for a care order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB059","meaning":"Supervision order","description":"to
+      string: '{"success":true,"data":[{"ccms_code":"PBM06","meaning":"Supervision
+        order - vary or discharge","description":"to be represented on an application
+        to vary or discharge a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB059","meaning":"Supervision order","description":"to
         be represented on an application for a supervision order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PBM01","meaning":"Declaration for overseas
         adoption","description":"to be represented on an application for a declaration
         as to an overseas adoption.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM01A","meaning":"Declaration for overseas
-        adoption - appeal","description":"to be represented on an application for
-        a declaration as to an overseas adoption.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM02","meaning":"Adoption - not being held
-        in family proceedings court","description":"to be represented on an application
-        for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM02A","meaning":"Adoption order - appeal","description":"to
-        be represented on an application for an adoption order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM02E","meaning":"Adoption order - enforcement","description":"to
         be represented on an application for an adoption order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36E","meaning":"Care order - joined party
+        - enforcement","description":"to be represented on an application for a care
+        order Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB057","meaning":"Care order","description":"to
+        be represented on an application for a care order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM02A","meaning":"Adoption order - appeal","description":"to
+        be represented on an application for an adoption order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM04","meaning":"Secure accommodation order","description":"to
         be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM22","meaning":"Parental responsibility","description":"to
-        be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM04A","meaning":"Secure accommodation order
-        - appeal","description":"to be represented on an application for a secure
-        accommodation order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM04E","meaning":"Secure accommodation order
-        - enforcement","description":"to be represented on an application for a secure
-        accommodation order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05","meaning":"Contact with a child in
-        care","description":"to be represented on an application for contact with
-        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05A","meaning":"Contact with a child in
-        care - appeal","description":"to be represented on an application for contact
-        with a child in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05E","meaning":"Contact with a child in
-        care - enforcement","description":"to be represented on an application for
-        contact with a child in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06","meaning":"Supervision order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06A","meaning":"Supervision order - appeal
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06E","meaning":"Supervision order - enforcement
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07","meaning":"Care order - discharge","description":"to
-        be represented on an application to discharge a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07A","meaning":"Care order - appeal -
-        discharge","description":"to be represented on an application to discharge
-        a care order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07E","meaning":"Care order - enforcement
-        - discharge","description":"to be represented on an application to discharge
-        a care order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM08","meaning":"Education supervision order","description":"to
-        be represented on an application for an education supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM08A","meaning":"Education supervision
         order - appeal","description":"to be represented on an application for an
         education supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM08E","meaning":"Education supervision
-        order - enforcement","description":"to be represented on an application for
-        an education supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM09","meaning":"Recovery of children order","description":"to
-        be represented on an application for the recovery of a child/children.  Appeals
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM09A","meaning":"Recovery of children order
-        - appeal","description":"to be represented on an application for the recovery
-        of a child/children.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM04E","meaning":"Secure accommodation order
+        - enforcement","description":"to be represented on an application for a secure
+        accommodation order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
+        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM30A","meaning":"Placement order - appeal","description":"to
+        be represented on an application for a placement order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27","meaning":"Emergency protection order","description":"to
+        be represented on an application for or to extend an emergency protection
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM28","meaning":"Emergency protection order
+        - discharge","description":"to be represented on an application to discharge
+        an emergency protection order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM17A","meaning":"Specific issue order - appeal","description":"to
+        be represented on an application for a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB005","meaning":"Emergency protection order
+        - discharge","description":"to be represented on an application to discharge
+        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM23A","meaning":"Care order - appeal","description":"to
+        be represented on an application for a care order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36A","meaning":"Care order - joined party
+        - appeal","description":"to be represented on an application for a care order
+        Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB004","meaning":"Emergency protection order
+        - extend","description":"to be represented on an application for or to extend
+        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM22A","meaning":"Parental responsibility
+        - appeal","description":"to be represented on an application for parental
+        responsibility.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32A","meaning":"Special guardianship order
+        - appeal","description":"to be represented on an application for a Special
+        Guardianship Order . Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM20","meaning":"Prohibited steps order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM02","meaning":"Adoption - not being held
+        in family proceedings court","description":"to be represented on an application
+        for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE007","meaning":"Prohibited steps order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM23","meaning":"Care order","description":"to
+        be represented on an application for a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM09E","meaning":"Recovery of children order
         - enforcement","description":"to be represented on an application for the
         recovery of a child/children.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM10","meaning":"Child assessment order
+        law family (PLF)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J
+        - amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM33A","meaning":"Revocation placement order
+        - appeal","description":"to be represented on an application for revocation
+        of a placement order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM30E","meaning":"Placement order - enforcement","description":"to
+        be represented on an application for a placement order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36","meaning":"Care order - joined party","description":"to
+        be represented on an application for a care order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29A","meaning":"Exclusion requirement
+        - appeal","description":"to be represented on an application to vary/discharge
+        an exclusion requirement.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM06A","meaning":"Supervision order - appeal
         - vary or discharge","description":"to be represented on an application to
-        vary or discharge a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM10A","meaning":"Child assessment order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a child assessment order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11","meaning":"End contact with a child
-        in care","description":"to be represented on an application to terminate contact
-        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11A","meaning":"End contact with a child
-        in care - appeal","description":"to be represented on an application to terminate
-        contact with a child/children in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11E","meaning":"End contact with a child
+        vary or discharge a supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32","meaning":"Special guardianship order","description":"to
+        be represented on an application for a Special Guardianship Order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PB003","meaning":"Child assessment order","description":"to
+        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PB006","meaning":"Secure accommodation order","description":"to
+        be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM11E","meaning":"End contact with a child
         in care - enforcement","description":"to be represented on an application
         to terminate contact with a child/children in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM13","meaning":"Substitute supervision
-        with care","description":"to be represented on an application to substitute
-        a supervision order with care order under section 39 (4) Children Act 1989.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM13A","meaning":"Substitute supervision
-        with care - appeal","description":"to be represented on an application to
-        substitute a supervision order with care order under section 39 (4) Children
-        Act 1989. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM16","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary or discharge","description":"to be represented
+        on an application to vary or discharge a contact order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J
+        - appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM17E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32E","meaning":"Special guardianship order
+        - enforcement","description":"to be represented on an application for a Special
+        Guardianship Order . Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM20E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM35A","meaning":"Special guardianship order
+        - appeal - vary or discharge","description":"To be represented on an application
+        for variation/discharge of a special guardianship order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM16A","meaning":"Prohibited steps order
         - appeal","description":"to be represented on an application for a prohibited
         steps order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM16E","meaning":"Prohibited steps order
+        law family (PLF)"},{"ccms_code":"PBM05A","meaning":"Contact with a child in
+        care - appeal","description":"to be represented on an application for contact
+        with a child in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM10","meaning":"Child assessment order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order - who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM05E","meaning":"Contact with a child in
+        care - enforcement","description":"to be represented on an application for
+        contact with a child in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM30","meaning":"Placement order","description":"to
+        be represented on an application for a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19","meaning":"Child arrangements order
+        (CAO) - residence - vary or discharge","description":"to be represented on
+        an application to vary or discharge a residence order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM24E","meaning":"Supervision order - enforcement","description":"to
+        be represented on an application for a supervision order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
+        - appeal","description":"to be represented on an application for a prohibited
+        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM10A","meaning":"Child assessment order
+        - appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a child assessment order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM45","meaning":"Adoption order - parent
+        or parental responsibility","description":"To represent a parent or person
+        with parental responsibility on an application for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM26E","meaning":"Child assessment order
+        - enforcement","description":"to be represented on an application for a child
+        assessment order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary or discharge","description":"to be represented
+        on an application to vary or discharge a contact order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM35","meaning":"Special guardianship order
+        - vary or discharge","description":"To be represented on an application for
+        variation/discharge of a special guardianship order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM01A","meaning":"Declaration for overseas
+        adoption - appeal","description":"to be represented on an application for
+        a declaration as to an overseas adoption.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM16E","meaning":"Prohibited steps order
         - enforcement","description":"to be represented on an application for a prohibited
         steps order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM17","meaning":"Specific issue order","description":"to
         be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18","meaning":"Child arrangements order
-        (CAO) - contact - vary or discharge","description":"to be represented on an
-        application to vary or discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary or discharge","description":"to be represented
-        on an application to vary or discharge a contact order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary or discharge","description":"to be represented
-        on an application to vary or discharge a contact order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19","meaning":"Child arrangements order
-        (CAO) - residence - vary or discharge","description":"to be represented on
-        an application to vary or discharge a residence order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary or discharge","description":"to be represented
-        on an application to vary or discharge a residence order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary or discharge","description":"to be
-        represented on an application to vary or discharge a residence order. Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20","meaning":"Prohibited steps order
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21","meaning":"Specific issue order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM22A","meaning":"Parental responsibility
-        - appeal","description":"to be represented on an application for parental
-        responsibility.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23","meaning":"Care order","description":"to
-        be represented on an application for a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23A","meaning":"Care order - appeal","description":"to
-        be represented on an application for a care order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23E","meaning":"Care order - enforcement","description":"to
-        be represented on an application for a care order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24","meaning":"Supervision order","description":"to
-        be represented on an application for a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24A","meaning":"Supervision order - appeal","description":"to
-        be represented on an application for a supervision order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24E","meaning":"Supervision order - enforcement","description":"to
-        be represented on an application for a supervision order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26","meaning":"Child assessment order","description":"to
-        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26A","meaning":"Child assessment order
-        - appeal","description":"to be represented on an application for a child assessment
-        order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26E","meaning":"Child assessment order
-        - enforcement","description":"to be represented on an application for a child
-        assessment order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27","meaning":"Emergency protection order","description":"to
-        be represented on an application for or to extend an emergency protection
-        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27A","meaning":"Emergency protection order
-        - appeal","description":"to be represented on an application for or to extend
-        an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27E","meaning":"Emergency protection order
-        - enforcement","description":"to be represented on an application for or to
-        extend an emergency protection order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM28","meaning":"Emergency protection order
-        - discharge","description":"to be represented on an application to discharge
-        an emergency protection order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM28A","meaning":"Emergency protection order
-        - appeal - discharge","description":"to be represented on an application to
-        discharge an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29","meaning":"Exclusion requirement","description":"to
-        be represented on an application to vary/discharge an exclusion requirement.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29A","meaning":"Exclusion requirement
-        - appeal","description":"to be represented on an application to vary/discharge
-        an exclusion requirement.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29E","meaning":"Exclusion requirement
-        - enforcement","description":"to be represented on an application to vary/discharge
-        an exclusion requirement.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30","meaning":"Placement order","description":"to
-        be represented on an application for a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30A","meaning":"Placement order - appeal","description":"to
-        be represented on an application for a placement order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30E","meaning":"Placement order - enforcement","description":"to
-        be represented on an application for a placement order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32","meaning":"Special guardianship order","description":"to
-        be represented on an application for a Special Guardianship Order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32A","meaning":"Special guardianship order
-        - appeal","description":"to be represented on an application for a Special
-        Guardianship Order . Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32E","meaning":"Special guardianship order
-        - enforcement","description":"to be represented on an application for a Special
-        Guardianship Order . Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33","meaning":"Revocation placement order","description":"to
-        be represented on an application for revocation of a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33A","meaning":"Revocation placement order
-        - appeal","description":"to be represented on an application for revocation
-        of a placement order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM33E","meaning":"Revocation placement order
         - enforcement","description":"to be represented on an application for revocation
         of a placement order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35","meaning":"Special guardianship order
-        - vary or discharge","description":"To be represented on an application for
-        variation/discharge of a special guardianship order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35A","meaning":"Special guardianship order
-        - appeal - vary or discharge","description":"To be represented on an application
-        for variation/discharge of a special guardianship order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35E","meaning":"Special guardianship order
-        - enforcement - vary or discharge","description":"To be represented on an
-        application for variation/discharge of a special guardianship order.  Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36","meaning":"Care order - joined party","description":"to
-        be represented on an application for a care order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36A","meaning":"Care order - joined party
-        - appeal","description":"to be represented on an application for a care order
-        Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36E","meaning":"Care order - joined party
-        - enforcement","description":"to be represented on an application for a care
-        order Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37","meaning":"Supervision order - joined
-        party","description":"to be represented on an application for a supervision
-        order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37A","meaning":"Supervision order - joined
+        law family (PLF)"},{"ccms_code":"PBM21A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM22","meaning":"Parental responsibility","description":"to
+        be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27A","meaning":"Emergency protection order
+        - appeal","description":"to be represented on an application for or to extend
+        an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM04A","meaning":"Secure accommodation order
+        - appeal","description":"to be represented on an application for a secure
+        accommodation order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM08E","meaning":"Education supervision
+        order - enforcement","description":"to be represented on an application for
+        an education supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE014","meaning":"Child arrangements order
+        (CAO) - residence","description":"to be represented on an application for
+        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM37A","meaning":"Supervision order - joined
         party - appeal","description":"to be represented on an application for a supervision
         order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37E","meaning":"Supervision order - joined
-        party - enforcement","description":"to be represented on an application for
-        a supervision order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order - who the child(ren) spend time with","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order - who the child(ren) spend time with. Appeals
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order - who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM39","meaning":"Child arrangements order
         (CAO) - residence","description":"to be represented on an application for
         a child arrangements order - where the child(ren) will live.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order - where the child(ren) will live. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order - where the child(ren) will live. Enforcement
+        law family (PLF)"},{"ccms_code":"PBM13","meaning":"Substitute supervision
+        with care","description":"to be represented on an application to substitute
+        a supervision order with care order under section 39 (4) Children Act 1989.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM05","meaning":"Contact with a child in
+        care","description":"to be represented on an application for contact with
+        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24A","meaning":"Supervision order - appeal","description":"to
+        be represented on an application for a supervision order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM08","meaning":"Education supervision order","description":"to
+        be represented on an application for an education supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM07","meaning":"Care order - discharge","description":"to
+        be represented on an application to discharge a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary or discharge","description":"to be represented
+        on an application to vary or discharge a residence order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM23E","meaning":"Care order - enforcement","description":"to
+        be represented on an application for a care order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order - who the child(ren) spend time with","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM09A","meaning":"Recovery of children order
+        - appeal","description":"to be represented on an application for the recovery
+        of a child/children.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM11","meaning":"End contact with a child
+        in care","description":"to be represented on an application to terminate contact
+        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM35E","meaning":"Special guardianship order
+        - enforcement - vary or discharge","description":"To be represented on an
+        application for variation/discharge of a special guardianship order.  Enforcement
         only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB026","meaning":"Emergency protection order","description":"to
+        be represented on an application for an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM26","meaning":"Child assessment order","description":"to
+        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM09","meaning":"Recovery of children order","description":"to
+        be represented on an application for the recovery of a child/children.  Appeals
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM37E","meaning":"Supervision order - joined
+        party - enforcement","description":"to be represented on an application for
+        a supervision order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM40","meaning":"Placement order - parent
         or parental responsibility","description":"To represent a parent or person
         with parental responsibility on an application for a placement order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM40E","meaning":"Placement order - parent
-        or parental responsibility - enforcement","description":"To represent a parent
-        or person with parental responsibility on an application for a placement order.
-        Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM45","meaning":"Adoption order - parent
-        or parental responsibility","description":"To represent a parent or person
-        with parental responsibility on an application for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM11A","meaning":"End contact with a child
+        in care - appeal","description":"to be represented on an application to terminate
+        contact with a child/children in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM45E","meaning":"Adoption order - parent
         or parental responsibility - enforcement","description":"To represent a parent
         or person with parental responsibility on an application for a placement order.
         Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24","meaning":"Supervision order","description":"to
+        be represented on an application for a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18","meaning":"Child arrangements order
+        (CAO) - contact - vary or discharge","description":"to be represented on an
+        application to vary or discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM39A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order - where the child(ren) will live. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM21E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM13A","meaning":"Substitute supervision
+        with care - appeal","description":"to be represented on an application to
+        substitute a supervision order with care order under section 39 (4) Children
+        Act 1989. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary","description":"to be represented on an
+        application to vary or discharge a child arrangements order –where the child(ren)
+        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM07A","meaning":"Care order - appeal - discharge","description":"to
+        be represented on an application to discharge a care order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary or discharge","description":"to be
+        represented on an application to vary or discharge a residence order. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM33","meaning":"Revocation placement order","description":"to
+        be represented on an application for revocation of a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM06E","meaning":"Supervision order - enforcement
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order - who the child(ren) spend time with. Appeals
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM16","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29E","meaning":"Exclusion requirement
+        - enforcement","description":"to be represented on an application to vary/discharge
+        an exclusion requirement.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
+        for an injunction, order or declaration under the inherent jurisdiction of
+        the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM20A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA002","meaning":"Protection from harassment
+        act 1997 under section 5 - vary or discharge","description":"to be represented
+        on an application to vary or discharge an order under section 5 Protection
+        from Harassment Act 1997 where the parties are associated persons (as defined
+        by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM07E","meaning":"Care order - enforcement - discharge","description":"to
+        be represented on an application to discharge a care order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM37","meaning":"Supervision order - joined
+        party","description":"to be represented on an application for a supervision
+        order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM26A","meaning":"Child assessment order
+        - appeal","description":"to be represented on an application for a child assessment
+        order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM39E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order - where the child(ren) will live. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29","meaning":"Exclusion requirement","description":"to
+        be represented on an application to vary/discharge an exclusion requirement.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM28A","meaning":"Emergency protection order
+        - appeal - discharge","description":"to be represented on an application to
+        discharge an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM40E","meaning":"Placement order - parent
+        or parental responsibility - enforcement","description":"To represent a parent
+        or person with parental responsibility on an application for a placement order.
+        Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J
+        and committal","description":"to be represented on an application for committal
+        and for an enforcement order under section 11J Children Act 1989. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM21","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27E","meaning":"Emergency protection order
+        - enforcement","description":"to be represented on an application for or to
+        extend an emergency protection order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:32:11 GMT
+  recorded_at: Wed, 07 May 2025 15:58:10 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
@@ -615,14 +611,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:13 GMT
+      - Wed, 07 May 2025 15:58:12 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -642,440 +638,436 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"93565432497c5ce191eac6fbf69b9a81"
+      - W/"f5d4a442765bb4b1da38aa01d431b319"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 5714b7a7b1ef25e931f22ea935794ad2
+      - e019e35c026bb0cbde09abf73ded246a
       x-runtime:
-      - '0.024894'
+      - '0.028687'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
-        for an injunction, order or declaration under the inherent jurisdiction of
-        the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
-        1997 under section 5 - vary or discharge","description":"to be represented
-        on an application to vary or discharge an order under section 5 Protection
-        from Harassment Act 1997 where the parties are associated persons (as defined
-        by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
-        (CAO) - residence","description":"to be represented on an application for
-        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PB003","meaning":"Child assessment order","description":"to
-        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB004","meaning":"Emergency protection
-        order - extend","description":"to be represented on an application for or
-        to extend an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB005","meaning":"Emergency protection
-        order - discharge","description":"to be represented on an application to discharge
-        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB006","meaning":"Secure accommodation
-        order","description":"to be represented on an application for a secure accommodation
-        order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB026","meaning":"Emergency protection
-        order","description":"to be represented on an application for an emergency
-        protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB057","meaning":"Care order","description":"to
-        be represented on an application for a care order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB059","meaning":"Supervision order","description":"to
+      string: '{"success":true,"data":[{"ccms_code":"PBM06","meaning":"Supervision
+        order - vary or discharge","description":"to be represented on an application
+        to vary or discharge a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB059","meaning":"Supervision order","description":"to
         be represented on an application for a supervision order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PBM01","meaning":"Declaration for overseas
         adoption","description":"to be represented on an application for a declaration
         as to an overseas adoption.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM01A","meaning":"Declaration for overseas
-        adoption - appeal","description":"to be represented on an application for
-        a declaration as to an overseas adoption.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM02","meaning":"Adoption - not being held
-        in family proceedings court","description":"to be represented on an application
-        for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM02A","meaning":"Adoption order - appeal","description":"to
-        be represented on an application for an adoption order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM02E","meaning":"Adoption order - enforcement","description":"to
         be represented on an application for an adoption order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36E","meaning":"Care order - joined party
+        - enforcement","description":"to be represented on an application for a care
+        order Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB057","meaning":"Care order","description":"to
+        be represented on an application for a care order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM02A","meaning":"Adoption order - appeal","description":"to
+        be represented on an application for an adoption order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM04","meaning":"Secure accommodation order","description":"to
         be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM22","meaning":"Parental responsibility","description":"to
-        be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM04A","meaning":"Secure accommodation order
-        - appeal","description":"to be represented on an application for a secure
-        accommodation order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM04E","meaning":"Secure accommodation order
-        - enforcement","description":"to be represented on an application for a secure
-        accommodation order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05","meaning":"Contact with a child in
-        care","description":"to be represented on an application for contact with
-        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05A","meaning":"Contact with a child in
-        care - appeal","description":"to be represented on an application for contact
-        with a child in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05E","meaning":"Contact with a child in
-        care - enforcement","description":"to be represented on an application for
-        contact with a child in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06","meaning":"Supervision order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06A","meaning":"Supervision order - appeal
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06E","meaning":"Supervision order - enforcement
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07","meaning":"Care order - discharge","description":"to
-        be represented on an application to discharge a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07A","meaning":"Care order - appeal -
-        discharge","description":"to be represented on an application to discharge
-        a care order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07E","meaning":"Care order - enforcement
-        - discharge","description":"to be represented on an application to discharge
-        a care order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM08","meaning":"Education supervision order","description":"to
-        be represented on an application for an education supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM08A","meaning":"Education supervision
         order - appeal","description":"to be represented on an application for an
         education supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM08E","meaning":"Education supervision
-        order - enforcement","description":"to be represented on an application for
-        an education supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM09","meaning":"Recovery of children order","description":"to
-        be represented on an application for the recovery of a child/children.  Appeals
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM09A","meaning":"Recovery of children order
-        - appeal","description":"to be represented on an application for the recovery
-        of a child/children.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM04E","meaning":"Secure accommodation order
+        - enforcement","description":"to be represented on an application for a secure
+        accommodation order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
+        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM30A","meaning":"Placement order - appeal","description":"to
+        be represented on an application for a placement order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27","meaning":"Emergency protection order","description":"to
+        be represented on an application for or to extend an emergency protection
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM28","meaning":"Emergency protection order
+        - discharge","description":"to be represented on an application to discharge
+        an emergency protection order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM17A","meaning":"Specific issue order - appeal","description":"to
+        be represented on an application for a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB005","meaning":"Emergency protection order
+        - discharge","description":"to be represented on an application to discharge
+        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM23A","meaning":"Care order - appeal","description":"to
+        be represented on an application for a care order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36A","meaning":"Care order - joined party
+        - appeal","description":"to be represented on an application for a care order
+        Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB004","meaning":"Emergency protection order
+        - extend","description":"to be represented on an application for or to extend
+        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM22A","meaning":"Parental responsibility
+        - appeal","description":"to be represented on an application for parental
+        responsibility.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32A","meaning":"Special guardianship order
+        - appeal","description":"to be represented on an application for a Special
+        Guardianship Order . Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM20","meaning":"Prohibited steps order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM02","meaning":"Adoption - not being held
+        in family proceedings court","description":"to be represented on an application
+        for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE007","meaning":"Prohibited steps order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM23","meaning":"Care order","description":"to
+        be represented on an application for a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM09E","meaning":"Recovery of children order
         - enforcement","description":"to be represented on an application for the
         recovery of a child/children.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM10","meaning":"Child assessment order
+        law family (PLF)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J
+        - amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM33A","meaning":"Revocation placement order
+        - appeal","description":"to be represented on an application for revocation
+        of a placement order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM30E","meaning":"Placement order - enforcement","description":"to
+        be represented on an application for a placement order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36","meaning":"Care order - joined party","description":"to
+        be represented on an application for a care order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29A","meaning":"Exclusion requirement
+        - appeal","description":"to be represented on an application to vary/discharge
+        an exclusion requirement.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM06A","meaning":"Supervision order - appeal
         - vary or discharge","description":"to be represented on an application to
-        vary or discharge a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM10A","meaning":"Child assessment order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a child assessment order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11","meaning":"End contact with a child
-        in care","description":"to be represented on an application to terminate contact
-        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11A","meaning":"End contact with a child
-        in care - appeal","description":"to be represented on an application to terminate
-        contact with a child/children in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11E","meaning":"End contact with a child
+        vary or discharge a supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32","meaning":"Special guardianship order","description":"to
+        be represented on an application for a Special Guardianship Order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PB003","meaning":"Child assessment order","description":"to
+        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PB006","meaning":"Secure accommodation order","description":"to
+        be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM11E","meaning":"End contact with a child
         in care - enforcement","description":"to be represented on an application
         to terminate contact with a child/children in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM13","meaning":"Substitute supervision
-        with care","description":"to be represented on an application to substitute
-        a supervision order with care order under section 39 (4) Children Act 1989.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM13A","meaning":"Substitute supervision
-        with care - appeal","description":"to be represented on an application to
-        substitute a supervision order with care order under section 39 (4) Children
-        Act 1989. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM16","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary or discharge","description":"to be represented
+        on an application to vary or discharge a contact order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J
+        - appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM17E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32E","meaning":"Special guardianship order
+        - enforcement","description":"to be represented on an application for a Special
+        Guardianship Order . Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM20E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM35A","meaning":"Special guardianship order
+        - appeal - vary or discharge","description":"To be represented on an application
+        for variation/discharge of a special guardianship order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM16A","meaning":"Prohibited steps order
         - appeal","description":"to be represented on an application for a prohibited
         steps order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM16E","meaning":"Prohibited steps order
+        law family (PLF)"},{"ccms_code":"PBM05A","meaning":"Contact with a child in
+        care - appeal","description":"to be represented on an application for contact
+        with a child in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM10","meaning":"Child assessment order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order - who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM05E","meaning":"Contact with a child in
+        care - enforcement","description":"to be represented on an application for
+        contact with a child in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM30","meaning":"Placement order","description":"to
+        be represented on an application for a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19","meaning":"Child arrangements order
+        (CAO) - residence - vary or discharge","description":"to be represented on
+        an application to vary or discharge a residence order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM24E","meaning":"Supervision order - enforcement","description":"to
+        be represented on an application for a supervision order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
+        - appeal","description":"to be represented on an application for a prohibited
+        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM10A","meaning":"Child assessment order
+        - appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a child assessment order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM45","meaning":"Adoption order - parent
+        or parental responsibility","description":"To represent a parent or person
+        with parental responsibility on an application for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM26E","meaning":"Child assessment order
+        - enforcement","description":"to be represented on an application for a child
+        assessment order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary or discharge","description":"to be represented
+        on an application to vary or discharge a contact order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM35","meaning":"Special guardianship order
+        - vary or discharge","description":"To be represented on an application for
+        variation/discharge of a special guardianship order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM01A","meaning":"Declaration for overseas
+        adoption - appeal","description":"to be represented on an application for
+        a declaration as to an overseas adoption.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM16E","meaning":"Prohibited steps order
         - enforcement","description":"to be represented on an application for a prohibited
         steps order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM17","meaning":"Specific issue order","description":"to
         be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18","meaning":"Child arrangements order
-        (CAO) - contact - vary or discharge","description":"to be represented on an
-        application to vary or discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary or discharge","description":"to be represented
-        on an application to vary or discharge a contact order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary or discharge","description":"to be represented
-        on an application to vary or discharge a contact order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19","meaning":"Child arrangements order
-        (CAO) - residence - vary or discharge","description":"to be represented on
-        an application to vary or discharge a residence order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary or discharge","description":"to be represented
-        on an application to vary or discharge a residence order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary or discharge","description":"to be
-        represented on an application to vary or discharge a residence order. Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20","meaning":"Prohibited steps order
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21","meaning":"Specific issue order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM22A","meaning":"Parental responsibility
-        - appeal","description":"to be represented on an application for parental
-        responsibility.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23","meaning":"Care order","description":"to
-        be represented on an application for a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23A","meaning":"Care order - appeal","description":"to
-        be represented on an application for a care order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23E","meaning":"Care order - enforcement","description":"to
-        be represented on an application for a care order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24","meaning":"Supervision order","description":"to
-        be represented on an application for a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24A","meaning":"Supervision order - appeal","description":"to
-        be represented on an application for a supervision order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24E","meaning":"Supervision order - enforcement","description":"to
-        be represented on an application for a supervision order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26","meaning":"Child assessment order","description":"to
-        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26A","meaning":"Child assessment order
-        - appeal","description":"to be represented on an application for a child assessment
-        order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26E","meaning":"Child assessment order
-        - enforcement","description":"to be represented on an application for a child
-        assessment order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27","meaning":"Emergency protection order","description":"to
-        be represented on an application for or to extend an emergency protection
-        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27A","meaning":"Emergency protection order
-        - appeal","description":"to be represented on an application for or to extend
-        an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27E","meaning":"Emergency protection order
-        - enforcement","description":"to be represented on an application for or to
-        extend an emergency protection order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM28","meaning":"Emergency protection order
-        - discharge","description":"to be represented on an application to discharge
-        an emergency protection order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM28A","meaning":"Emergency protection order
-        - appeal - discharge","description":"to be represented on an application to
-        discharge an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29","meaning":"Exclusion requirement","description":"to
-        be represented on an application to vary/discharge an exclusion requirement.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29A","meaning":"Exclusion requirement
-        - appeal","description":"to be represented on an application to vary/discharge
-        an exclusion requirement.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29E","meaning":"Exclusion requirement
-        - enforcement","description":"to be represented on an application to vary/discharge
-        an exclusion requirement.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30","meaning":"Placement order","description":"to
-        be represented on an application for a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30A","meaning":"Placement order - appeal","description":"to
-        be represented on an application for a placement order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30E","meaning":"Placement order - enforcement","description":"to
-        be represented on an application for a placement order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32","meaning":"Special guardianship order","description":"to
-        be represented on an application for a Special Guardianship Order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32A","meaning":"Special guardianship order
-        - appeal","description":"to be represented on an application for a Special
-        Guardianship Order . Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32E","meaning":"Special guardianship order
-        - enforcement","description":"to be represented on an application for a Special
-        Guardianship Order . Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33","meaning":"Revocation placement order","description":"to
-        be represented on an application for revocation of a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33A","meaning":"Revocation placement order
-        - appeal","description":"to be represented on an application for revocation
-        of a placement order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM33E","meaning":"Revocation placement order
         - enforcement","description":"to be represented on an application for revocation
         of a placement order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35","meaning":"Special guardianship order
-        - vary or discharge","description":"To be represented on an application for
-        variation/discharge of a special guardianship order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35A","meaning":"Special guardianship order
-        - appeal - vary or discharge","description":"To be represented on an application
-        for variation/discharge of a special guardianship order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35E","meaning":"Special guardianship order
-        - enforcement - vary or discharge","description":"To be represented on an
-        application for variation/discharge of a special guardianship order.  Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36","meaning":"Care order - joined party","description":"to
-        be represented on an application for a care order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36A","meaning":"Care order - joined party
-        - appeal","description":"to be represented on an application for a care order
-        Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36E","meaning":"Care order - joined party
-        - enforcement","description":"to be represented on an application for a care
-        order Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37","meaning":"Supervision order - joined
-        party","description":"to be represented on an application for a supervision
-        order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37A","meaning":"Supervision order - joined
+        law family (PLF)"},{"ccms_code":"PBM21A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM22","meaning":"Parental responsibility","description":"to
+        be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27A","meaning":"Emergency protection order
+        - appeal","description":"to be represented on an application for or to extend
+        an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM04A","meaning":"Secure accommodation order
+        - appeal","description":"to be represented on an application for a secure
+        accommodation order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM08E","meaning":"Education supervision
+        order - enforcement","description":"to be represented on an application for
+        an education supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE014","meaning":"Child arrangements order
+        (CAO) - residence","description":"to be represented on an application for
+        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM37A","meaning":"Supervision order - joined
         party - appeal","description":"to be represented on an application for a supervision
         order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37E","meaning":"Supervision order - joined
-        party - enforcement","description":"to be represented on an application for
-        a supervision order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order - who the child(ren) spend time with","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order - who the child(ren) spend time with. Appeals
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order - who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM39","meaning":"Child arrangements order
         (CAO) - residence","description":"to be represented on an application for
         a child arrangements order - where the child(ren) will live.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order - where the child(ren) will live. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order - where the child(ren) will live. Enforcement
+        law family (PLF)"},{"ccms_code":"PBM13","meaning":"Substitute supervision
+        with care","description":"to be represented on an application to substitute
+        a supervision order with care order under section 39 (4) Children Act 1989.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM05","meaning":"Contact with a child in
+        care","description":"to be represented on an application for contact with
+        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24A","meaning":"Supervision order - appeal","description":"to
+        be represented on an application for a supervision order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM08","meaning":"Education supervision order","description":"to
+        be represented on an application for an education supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM07","meaning":"Care order - discharge","description":"to
+        be represented on an application to discharge a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary or discharge","description":"to be represented
+        on an application to vary or discharge a residence order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM23E","meaning":"Care order - enforcement","description":"to
+        be represented on an application for a care order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order - who the child(ren) spend time with","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM09A","meaning":"Recovery of children order
+        - appeal","description":"to be represented on an application for the recovery
+        of a child/children.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM11","meaning":"End contact with a child
+        in care","description":"to be represented on an application to terminate contact
+        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM35E","meaning":"Special guardianship order
+        - enforcement - vary or discharge","description":"To be represented on an
+        application for variation/discharge of a special guardianship order.  Enforcement
         only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB026","meaning":"Emergency protection order","description":"to
+        be represented on an application for an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM26","meaning":"Child assessment order","description":"to
+        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM09","meaning":"Recovery of children order","description":"to
+        be represented on an application for the recovery of a child/children.  Appeals
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM37E","meaning":"Supervision order - joined
+        party - enforcement","description":"to be represented on an application for
+        a supervision order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM40","meaning":"Placement order - parent
         or parental responsibility","description":"To represent a parent or person
         with parental responsibility on an application for a placement order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM40E","meaning":"Placement order - parent
-        or parental responsibility - enforcement","description":"To represent a parent
-        or person with parental responsibility on an application for a placement order.
-        Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM45","meaning":"Adoption order - parent
-        or parental responsibility","description":"To represent a parent or person
-        with parental responsibility on an application for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM11A","meaning":"End contact with a child
+        in care - appeal","description":"to be represented on an application to terminate
+        contact with a child/children in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM45E","meaning":"Adoption order - parent
         or parental responsibility - enforcement","description":"To represent a parent
         or person with parental responsibility on an application for a placement order.
         Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24","meaning":"Supervision order","description":"to
+        be represented on an application for a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18","meaning":"Child arrangements order
+        (CAO) - contact - vary or discharge","description":"to be represented on an
+        application to vary or discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM39A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order - where the child(ren) will live. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM21E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM13A","meaning":"Substitute supervision
+        with care - appeal","description":"to be represented on an application to
+        substitute a supervision order with care order under section 39 (4) Children
+        Act 1989. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary","description":"to be represented on an
+        application to vary or discharge a child arrangements order –where the child(ren)
+        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM07A","meaning":"Care order - appeal - discharge","description":"to
+        be represented on an application to discharge a care order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary or discharge","description":"to be
+        represented on an application to vary or discharge a residence order. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM33","meaning":"Revocation placement order","description":"to
+        be represented on an application for revocation of a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM06E","meaning":"Supervision order - enforcement
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order - who the child(ren) spend time with. Appeals
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM16","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29E","meaning":"Exclusion requirement
+        - enforcement","description":"to be represented on an application to vary/discharge
+        an exclusion requirement.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
+        for an injunction, order or declaration under the inherent jurisdiction of
+        the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM20A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA002","meaning":"Protection from harassment
+        act 1997 under section 5 - vary or discharge","description":"to be represented
+        on an application to vary or discharge an order under section 5 Protection
+        from Harassment Act 1997 where the parties are associated persons (as defined
+        by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM07E","meaning":"Care order - enforcement - discharge","description":"to
+        be represented on an application to discharge a care order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM37","meaning":"Supervision order - joined
+        party","description":"to be represented on an application for a supervision
+        order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM26A","meaning":"Child assessment order
+        - appeal","description":"to be represented on an application for a child assessment
+        order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM39E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order - where the child(ren) will live. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29","meaning":"Exclusion requirement","description":"to
+        be represented on an application to vary/discharge an exclusion requirement.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM28A","meaning":"Emergency protection order
+        - appeal - discharge","description":"to be represented on an application to
+        discharge an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM40E","meaning":"Placement order - parent
+        or parental responsibility - enforcement","description":"To represent a parent
+        or person with parental responsibility on an application for a placement order.
+        Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J
+        and committal","description":"to be represented on an application for committal
+        and for an enforcement order under section 11J Children Act 1989. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM21","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27E","meaning":"Emergency protection order
+        - enforcement","description":"to be represented on an application for or to
+        extend an emergency protection order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:32:13 GMT
+  recorded_at: Wed, 07 May 2025 15:58:12 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE095
@@ -1086,14 +1078,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:13 GMT
+      - Wed, 07 May 2025 15:58:12 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1117,9 +1109,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 8d79922914e977ddbad5d4a22fd2dac0
+      - b22535fa483629cf36a4ee8423baeb75
       x-runtime:
-      - '0.005794'
+      - '0.012212'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1137,7 +1129,7 @@ http_interactions:
         representation on the return date."}},"service_levels":[{"level":1,"name":"Family
         Help (Higher)","stage":1,"proceeding_default":true},{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":false}]}'
-  recorded_at: Fri, 14 Mar 2025 09:32:13 GMT
+  recorded_at: Wed, 07 May 2025 15:58:12 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
@@ -1148,14 +1140,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:14 GMT
+      - Wed, 07 May 2025 15:58:12 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1175,19 +1167,136 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"d0c75a80989393e2146bed7fc9b259ba"
+      - W/"cc71c3f788f71f224d68d66ae6fdc940"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 20dfce74cec0356ab90a7fe5d61d9150
+      - 8bd68afcbcb64fcc0ff96b5f52c4b045
       x-runtime:
-      - '0.051643'
+      - '0.040445'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
+      string: '{"success":true,"data":[{"ccms_code":"DA004","meaning":"Non-molestation
+        order","description":"to be represented on an application for a non-molestation
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
+        vary or discharge","description":"to be represented on an application to vary
+        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
+        amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
+        appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order - appeal","description":"to
+        be represented on an application for a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
+        (CAO) - residence","description":"to be represented on an application for
+        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary","description":"to be represented on an
+        application to vary or discharge a child arrangements order –where the child(ren)
+        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
         for an injunction, order or declaration under the inherent jurisdiction of
         the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
         abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
@@ -1195,128 +1304,11 @@ http_interactions:
         on an application to vary or discharge an order under section 5 Protection
         from Harassment Act 1997 where the parties are associated persons (as defined
         by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
-        (CAO) - residence","description":"to be represented on an application for
-        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        abuse (DA)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and committal","description":"to
+        be represented on an application for committal and for an enforcement order
+        under section 11J Children Act 1989. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
         8 children (S8)"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:32:13 GMT
+  recorded_at: Wed, 07 May 2025 15:58:12 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/SE095
@@ -1327,14 +1319,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:15 GMT
+      - Wed, 07 May 2025 15:58:13 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1358,9 +1350,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 36135706b72c43af6438e3c8ddeb4d9b
+      - 15f2b261ae88f01c2cd163541bdd266a
       x-runtime:
-      - '0.002488'
+      - '0.002887'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1368,7 +1360,7 @@ http_interactions:
       string: '{"success":true,"client_involvement_type":[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:32:14 GMT
+  recorded_at: Wed, 07 May 2025 15:58:13 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/SE095
@@ -1379,14 +1371,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:15 GMT
+      - Wed, 07 May 2025 15:58:14 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1410,9 +1402,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - a9fef8cda3e69bbf67459d087c1af144
+      - 5c1aa7401742e67b9ed457130e85621b
       x-runtime:
-      - '0.001810'
+      - '0.007507'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1420,7 +1412,7 @@ http_interactions:
       string: '{"success":true,"client_involvement_type":[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:32:15 GMT
+  recorded_at: Wed, 07 May 2025 15:58:14 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -1431,14 +1423,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:17 GMT
+      - Wed, 07 May 2025 15:58:15 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1462,9 +1454,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 95df06ce25b9bbe7b956568acecde637
+      - cf401b77ac4a488715567ccc7a18bfc1
       x-runtime:
-      - '0.004924'
+      - '0.008498'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1474,7 +1466,7 @@ http_interactions:
         order inc. return date","description":"Limited to all steps necessary to apply
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 09:32:16 GMT
+  recorded_at: Wed, 07 May 2025 15:58:15 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -1485,14 +1477,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:18 GMT
+      - Wed, 07 May 2025 15:58:16 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1516,9 +1508,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 698427111d496a83227a6b4bfc7b5da2
+      - 9900edeeb1aef1507c02b995d2a447e5
       x-runtime:
-      - '0.004982'
+      - '0.007117'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1528,7 +1520,7 @@ http_interactions:
         order inc. return date","description":"Limited to all steps necessary to apply
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 09:32:17 GMT
+  recorded_at: Wed, 07 May 2025 15:58:15 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE095
@@ -1539,14 +1531,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:18 GMT
+      - Wed, 07 May 2025 15:58:16 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1570,9 +1562,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 13d276f9502c29f8178bce997f480bae
+      - 0a3986b578dffd8979c3f463063803c0
       x-runtime:
-      - '0.007777'
+      - '0.013499'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1590,7 +1582,7 @@ http_interactions:
         representation on the return date."}},"service_levels":[{"level":1,"name":"Family
         Help (Higher)","stage":1,"proceeding_default":true},{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":false}]}'
-  recorded_at: Fri, 14 Mar 2025 09:32:17 GMT
+  recorded_at: Wed, 07 May 2025 15:58:16 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE095
@@ -1601,14 +1593,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:19 GMT
+      - Wed, 07 May 2025 15:58:16 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1632,9 +1624,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - be7bb7669b7118bbfdb77ece83c1d4ff
+      - d3f3e3434f41a539acacbecc7d00ab8c
       x-runtime:
-      - '0.006872'
+      - '0.014593'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1652,7 +1644,7 @@ http_interactions:
         representation on the return date."}},"service_levels":[{"level":1,"name":"Family
         Help (Higher)","stage":1,"proceeding_default":true},{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":false}]}'
-  recorded_at: Fri, 14 Mar 2025 09:32:18 GMT
+  recorded_at: Wed, 07 May 2025 15:58:16 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -1663,14 +1655,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:19 GMT
+      - Wed, 07 May 2025 15:58:16 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1694,9 +1686,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - cc079feed5f2702f61ce109198e17b2b
+      - df3c83dc8a2de46887d6a39b180e9bd0
       x-runtime:
-      - '0.005375'
+      - '0.008255'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1706,7 +1698,7 @@ http_interactions:
         order inc. return date","description":"Limited to all steps necessary to apply
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 09:32:18 GMT
+  recorded_at: Wed, 07 May 2025 15:58:16 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE095
@@ -1717,14 +1709,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:20 GMT
+      - Wed, 07 May 2025 15:58:17 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1748,9 +1740,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - e0767fbd7f1b45ba4a777caaa09592ce
+      - b1178830a0ffe3429433ae2d7be83687
       x-runtime:
-      - '0.006198'
+      - '0.012590'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1768,7 +1760,7 @@ http_interactions:
         representation on the return date."}},"service_levels":[{"level":1,"name":"Family
         Help (Higher)","stage":1,"proceeding_default":true},{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":false}]}'
-  recorded_at: Fri, 14 Mar 2025 09:32:19 GMT
+  recorded_at: Wed, 07 May 2025 15:58:17 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -1779,14 +1771,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:20 GMT
+      - Wed, 07 May 2025 15:58:17 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1810,9 +1802,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - c41cf7c82f393ea936d50232aa70a363
+      - 26f72e4b9dc95f2bb3fbba4c92e30b89
       x-runtime:
-      - '0.005265'
+      - '0.009475'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1822,7 +1814,7 @@ http_interactions:
         order inc. return date","description":"Limited to all steps necessary to apply
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 09:32:19 GMT
+  recorded_at: Wed, 07 May 2025 15:58:17 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_scopes
@@ -1833,14 +1825,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:20 GMT
+      - Wed, 07 May 2025 15:58:17 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1864,9 +1856,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - e8df259b6a7ab06c84f0a4e76c426ac8
+      - b5485054249388bfe1889d74f2359f34
       x-runtime:
-      - '0.012437'
+      - '0.027631'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1893,7 +1885,7 @@ http_interactions:
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]},{"code":"FM015","meaning":"Section
         37 Report","description":"Limited to a section 37 report only.","additional_params":[]}]}}'
-  recorded_at: Fri, 14 Mar 2025 09:32:19 GMT
+  recorded_at: Wed, 07 May 2025 15:58:17 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_scopes
@@ -1904,14 +1896,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:21 GMT
+      - Wed, 07 May 2025 15:58:18 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1935,9 +1927,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 553fc60efbd0e398649c371ffb8b389e
+      - d8966864a6de140df575f2876d2d114b
       x-runtime:
-      - '0.012838'
+      - '0.027798'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1964,7 +1956,7 @@ http_interactions:
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]},{"code":"FM015","meaning":"Section
         37 Report","description":"Limited to a section 37 report only.","additional_params":[]}]}}'
-  recorded_at: Fri, 14 Mar 2025 09:32:20 GMT
+  recorded_at: Wed, 07 May 2025 15:58:18 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -1975,14 +1967,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:21 GMT
+      - Wed, 07 May 2025 15:58:19 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2006,9 +1998,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - da57f713eff30732bf760ab439e83c46
+      - ee805e962bcac00be8d11d31ee6909ee
       x-runtime:
-      - '0.006382'
+      - '0.009771'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2018,7 +2010,7 @@ http_interactions:
         to Family Help (Higher) and to all steps necessary to negotiate and conclude
         a settlement. To include the issue of proceedings and representation in those
         proceedings save in relation to or at a contested final hearing.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 09:32:20 GMT
+  recorded_at: Wed, 07 May 2025 15:58:19 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -2029,14 +2021,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:22 GMT
+      - Wed, 07 May 2025 15:58:19 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2060,9 +2052,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 7af27975f01e47255ee44be893c9edba
+      - bd7f2a45aef9ebd9bc97a2ce209a8c53
       x-runtime:
-      - '0.004952'
+      - '0.008572'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2072,7 +2064,7 @@ http_interactions:
         to Family Help (Higher) and to all steps necessary to negotiate and conclude
         a settlement. To include the issue of proceedings and representation in those
         proceedings save in relation to or at a contested final hearing.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 09:32:21 GMT
+  recorded_at: Wed, 07 May 2025 15:58:19 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE095
@@ -2083,14 +2075,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:22 GMT
+      - Wed, 07 May 2025 15:58:19 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2114,9 +2106,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 07133c9a32fac8c96c139e9d1a2e6ac5
+      - a916f9ff4368c652f019b94c4c1908ef
       x-runtime:
-      - '0.006222'
+      - '0.014829'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2134,7 +2126,7 @@ http_interactions:
         representation on the return date."}},"service_levels":[{"level":1,"name":"Family
         Help (Higher)","stage":1,"proceeding_default":true},{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":false}]}'
-  recorded_at: Fri, 14 Mar 2025 09:32:21 GMT
+  recorded_at: Wed, 07 May 2025 15:58:19 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE095
@@ -2145,14 +2137,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:23 GMT
+      - Wed, 07 May 2025 15:58:20 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2176,9 +2168,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 2afd4df607bf8118dc63cc9751c5f8c1
+      - e5879883e45ac736c312423cb79341b4
       x-runtime:
-      - '0.006682'
+      - '0.016518'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2196,7 +2188,7 @@ http_interactions:
         representation on the return date."}},"service_levels":[{"level":1,"name":"Family
         Help (Higher)","stage":1,"proceeding_default":true},{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":false}]}'
-  recorded_at: Fri, 14 Mar 2025 09:32:22 GMT
+  recorded_at: Wed, 07 May 2025 15:58:20 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -2207,14 +2199,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:23 GMT
+      - Wed, 07 May 2025 15:58:20 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2238,9 +2230,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - fb9804f2e27961b008ba5c1ab2ee2923
+      - 0ab32c06cfa15272ebd5081f761f0c30
       x-runtime:
-      - '0.004600'
+      - '0.010865'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2250,7 +2242,7 @@ http_interactions:
         to Family Help (Higher) and to all steps necessary to negotiate and conclude
         a settlement. To include the issue of proceedings and representation in those
         proceedings save in relation to or at a contested final hearing.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 09:32:22 GMT
+  recorded_at: Wed, 07 May 2025 15:58:20 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE095
@@ -2261,14 +2253,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:24 GMT
+      - Wed, 07 May 2025 15:58:21 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2292,9 +2284,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - afb06c201fca1e5be5007d46ced9be00
+      - 17a47da64323aff6e510440e2b457230
       x-runtime:
-      - '0.007691'
+      - '0.014321'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2312,7 +2304,7 @@ http_interactions:
         representation on the return date."}},"service_levels":[{"level":1,"name":"Family
         Help (Higher)","stage":1,"proceeding_default":true},{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":false}]}'
-  recorded_at: Fri, 14 Mar 2025 09:32:23 GMT
+  recorded_at: Wed, 07 May 2025 15:58:21 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -2323,14 +2315,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:24 GMT
+      - Wed, 07 May 2025 15:58:21 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2354,9 +2346,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 9722da738c8895cdc62317045b24d4d8
+      - 3f98b0f3867201147133c87578884992
       x-runtime:
-      - '0.005218'
+      - '0.009098'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2366,7 +2358,7 @@ http_interactions:
         to Family Help (Higher) and to all steps necessary to negotiate and conclude
         a settlement. To include the issue of proceedings and representation in those
         proceedings save in relation to or at a contested final hearing.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 09:32:23 GMT
+  recorded_at: Wed, 07 May 2025 15:58:21 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_scopes
@@ -2377,14 +2369,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:25 GMT
+      - Wed, 07 May 2025 15:58:22 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2408,9 +2400,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 8be41ee271bbf7b5d4e3a96ee41f6d2e
+      - bee2f48fc6538414cafcdafd3b08a5af
       x-runtime:
-      - '0.010616'
+      - '0.024010'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2440,7 +2432,7 @@ http_interactions:
         order inc. return date","description":"Limited to all steps necessary to apply
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]}]}}'
-  recorded_at: Fri, 14 Mar 2025 09:32:24 GMT
+  recorded_at: Wed, 07 May 2025 15:58:22 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_scopes
@@ -2451,14 +2443,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:26 GMT
+      - Wed, 07 May 2025 15:58:23 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2482,9 +2474,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 5ef85a3cc58c2474b1d98f227dcd5d92
+      - d7ebfece661a0b4541f5d65a96d17fb6
       x-runtime:
-      - '0.009230'
+      - '0.026175'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2514,5 +2506,5 @@ http_interactions:
         order inc. return date","description":"Limited to all steps necessary to apply
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]}]}}'
-  recorded_at: Fri, 14 Mar 2025 09:32:25 GMT
+  recorded_at: Wed, 07 May 2025 15:58:23 GMT
 recorded_with: VCR 6.3.1

--- a/features/cassettes/Loop_through_proceeding_questions/When_provider_accepts_default_levels_of_service.yml
+++ b/features/cassettes/Loop_through_proceeding_questions/When_provider_accepts_default_levels_of_service.yml
@@ -8,14 +8,14 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:48 GMT
+      - Wed, 07 May 2025 15:57:20 GMT
       content-type:
       - application/json;charset=UTF-8
       transfer-encoding:
@@ -37,8 +37,8 @@ http_interactions:
       string: "{\r\n  \"header\" : {\r\n    \"uri\" : \"https://api.os.uk/search/places/v1/postcode?lr=EN&postcode=SW1H9EA\",\r\n
         \   \"query\" : \"postcode=SW1H9EA\",\r\n    \"offset\" : 0,\r\n    \"totalresults\"
         : 5,\r\n    \"format\" : \"JSON\",\r\n    \"dataset\" : \"DPA\",\r\n    \"lr\"
-        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"115\",\r\n    \"lastupdate\"
-        : \"2025-03-13\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
+        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"118\",\r\n    \"lastupdate\"
+        : \"2025-05-06\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
         : [ {\r\n    \"DPA\" : {\r\n      \"UPRN\" : \"100023337883\",\r\n      \"UDPRN\"
         : \"23749699\",\r\n      \"ADDRESS\" : \"84, PETTY FRANCE, LONDON, SW1H 9EA\",\r\n
         \     \"BUILDING_NUMBER\" : \"84\",\r\n      \"THOROUGHFARE_NAME\" : \"PETTY
@@ -133,7 +133,7 @@ http_interactions:
         \     \"BLPU_STATE_DATE\" : \"15/06/2020\",\r\n      \"LANGUAGE\" : \"EN\",\r\n
         \     \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\" : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\"
         : \"1N\"\r\n    }\r\n  } ]\r\n}"
-  recorded_at: Fri, 14 Mar 2025 09:31:48 GMT
+  recorded_at: Wed, 07 May 2025 15:57:20 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
@@ -144,14 +144,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:49 GMT
+      - Wed, 07 May 2025 15:57:21 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -171,440 +171,436 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"93565432497c5ce191eac6fbf69b9a81"
+      - W/"f5d4a442765bb4b1da38aa01d431b319"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 7d3b520893dabe5b9b49ab505a2ba7b9
+      - ba19624e2a7aa0dad2e55c5cc4bf8884
       x-runtime:
-      - '0.039074'
+      - '0.042938'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
-        for an injunction, order or declaration under the inherent jurisdiction of
-        the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
-        1997 under section 5 - vary or discharge","description":"to be represented
-        on an application to vary or discharge an order under section 5 Protection
-        from Harassment Act 1997 where the parties are associated persons (as defined
-        by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
-        (CAO) - residence","description":"to be represented on an application for
-        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PB003","meaning":"Child assessment order","description":"to
-        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB004","meaning":"Emergency protection
-        order - extend","description":"to be represented on an application for or
-        to extend an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB005","meaning":"Emergency protection
-        order - discharge","description":"to be represented on an application to discharge
-        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB006","meaning":"Secure accommodation
-        order","description":"to be represented on an application for a secure accommodation
-        order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB026","meaning":"Emergency protection
-        order","description":"to be represented on an application for an emergency
-        protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB057","meaning":"Care order","description":"to
-        be represented on an application for a care order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB059","meaning":"Supervision order","description":"to
+      string: '{"success":true,"data":[{"ccms_code":"PBM06","meaning":"Supervision
+        order - vary or discharge","description":"to be represented on an application
+        to vary or discharge a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB059","meaning":"Supervision order","description":"to
         be represented on an application for a supervision order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PBM01","meaning":"Declaration for overseas
         adoption","description":"to be represented on an application for a declaration
         as to an overseas adoption.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM01A","meaning":"Declaration for overseas
-        adoption - appeal","description":"to be represented on an application for
-        a declaration as to an overseas adoption.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM02","meaning":"Adoption - not being held
-        in family proceedings court","description":"to be represented on an application
-        for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM02A","meaning":"Adoption order - appeal","description":"to
-        be represented on an application for an adoption order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM02E","meaning":"Adoption order - enforcement","description":"to
         be represented on an application for an adoption order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36E","meaning":"Care order - joined party
+        - enforcement","description":"to be represented on an application for a care
+        order Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB057","meaning":"Care order","description":"to
+        be represented on an application for a care order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM02A","meaning":"Adoption order - appeal","description":"to
+        be represented on an application for an adoption order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM04","meaning":"Secure accommodation order","description":"to
         be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM22","meaning":"Parental responsibility","description":"to
-        be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM04A","meaning":"Secure accommodation order
-        - appeal","description":"to be represented on an application for a secure
-        accommodation order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM04E","meaning":"Secure accommodation order
-        - enforcement","description":"to be represented on an application for a secure
-        accommodation order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05","meaning":"Contact with a child in
-        care","description":"to be represented on an application for contact with
-        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05A","meaning":"Contact with a child in
-        care - appeal","description":"to be represented on an application for contact
-        with a child in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05E","meaning":"Contact with a child in
-        care - enforcement","description":"to be represented on an application for
-        contact with a child in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06","meaning":"Supervision order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06A","meaning":"Supervision order - appeal
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06E","meaning":"Supervision order - enforcement
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07","meaning":"Care order - discharge","description":"to
-        be represented on an application to discharge a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07A","meaning":"Care order - appeal -
-        discharge","description":"to be represented on an application to discharge
-        a care order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07E","meaning":"Care order - enforcement
-        - discharge","description":"to be represented on an application to discharge
-        a care order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM08","meaning":"Education supervision order","description":"to
-        be represented on an application for an education supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM08A","meaning":"Education supervision
         order - appeal","description":"to be represented on an application for an
         education supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM08E","meaning":"Education supervision
-        order - enforcement","description":"to be represented on an application for
-        an education supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM09","meaning":"Recovery of children order","description":"to
-        be represented on an application for the recovery of a child/children.  Appeals
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM09A","meaning":"Recovery of children order
-        - appeal","description":"to be represented on an application for the recovery
-        of a child/children.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM04E","meaning":"Secure accommodation order
+        - enforcement","description":"to be represented on an application for a secure
+        accommodation order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
+        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM30A","meaning":"Placement order - appeal","description":"to
+        be represented on an application for a placement order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27","meaning":"Emergency protection order","description":"to
+        be represented on an application for or to extend an emergency protection
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM28","meaning":"Emergency protection order
+        - discharge","description":"to be represented on an application to discharge
+        an emergency protection order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM17A","meaning":"Specific issue order - appeal","description":"to
+        be represented on an application for a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB005","meaning":"Emergency protection order
+        - discharge","description":"to be represented on an application to discharge
+        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM23A","meaning":"Care order - appeal","description":"to
+        be represented on an application for a care order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36A","meaning":"Care order - joined party
+        - appeal","description":"to be represented on an application for a care order
+        Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB004","meaning":"Emergency protection order
+        - extend","description":"to be represented on an application for or to extend
+        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM22A","meaning":"Parental responsibility
+        - appeal","description":"to be represented on an application for parental
+        responsibility.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32A","meaning":"Special guardianship order
+        - appeal","description":"to be represented on an application for a Special
+        Guardianship Order . Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM20","meaning":"Prohibited steps order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM02","meaning":"Adoption - not being held
+        in family proceedings court","description":"to be represented on an application
+        for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE007","meaning":"Prohibited steps order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM23","meaning":"Care order","description":"to
+        be represented on an application for a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM09E","meaning":"Recovery of children order
         - enforcement","description":"to be represented on an application for the
         recovery of a child/children.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM10","meaning":"Child assessment order
+        law family (PLF)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J
+        - amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM33A","meaning":"Revocation placement order
+        - appeal","description":"to be represented on an application for revocation
+        of a placement order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM30E","meaning":"Placement order - enforcement","description":"to
+        be represented on an application for a placement order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36","meaning":"Care order - joined party","description":"to
+        be represented on an application for a care order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29A","meaning":"Exclusion requirement
+        - appeal","description":"to be represented on an application to vary/discharge
+        an exclusion requirement.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM06A","meaning":"Supervision order - appeal
         - vary or discharge","description":"to be represented on an application to
-        vary or discharge a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM10A","meaning":"Child assessment order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a child assessment order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11","meaning":"End contact with a child
-        in care","description":"to be represented on an application to terminate contact
-        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11A","meaning":"End contact with a child
-        in care - appeal","description":"to be represented on an application to terminate
-        contact with a child/children in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11E","meaning":"End contact with a child
+        vary or discharge a supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32","meaning":"Special guardianship order","description":"to
+        be represented on an application for a Special Guardianship Order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PB003","meaning":"Child assessment order","description":"to
+        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PB006","meaning":"Secure accommodation order","description":"to
+        be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM11E","meaning":"End contact with a child
         in care - enforcement","description":"to be represented on an application
         to terminate contact with a child/children in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM13","meaning":"Substitute supervision
-        with care","description":"to be represented on an application to substitute
-        a supervision order with care order under section 39 (4) Children Act 1989.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM13A","meaning":"Substitute supervision
-        with care - appeal","description":"to be represented on an application to
-        substitute a supervision order with care order under section 39 (4) Children
-        Act 1989. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM16","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary or discharge","description":"to be represented
+        on an application to vary or discharge a contact order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J
+        - appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM17E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32E","meaning":"Special guardianship order
+        - enforcement","description":"to be represented on an application for a Special
+        Guardianship Order . Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM20E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM35A","meaning":"Special guardianship order
+        - appeal - vary or discharge","description":"To be represented on an application
+        for variation/discharge of a special guardianship order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM16A","meaning":"Prohibited steps order
         - appeal","description":"to be represented on an application for a prohibited
         steps order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM16E","meaning":"Prohibited steps order
+        law family (PLF)"},{"ccms_code":"PBM05A","meaning":"Contact with a child in
+        care - appeal","description":"to be represented on an application for contact
+        with a child in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM10","meaning":"Child assessment order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order - who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM05E","meaning":"Contact with a child in
+        care - enforcement","description":"to be represented on an application for
+        contact with a child in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM30","meaning":"Placement order","description":"to
+        be represented on an application for a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19","meaning":"Child arrangements order
+        (CAO) - residence - vary or discharge","description":"to be represented on
+        an application to vary or discharge a residence order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM24E","meaning":"Supervision order - enforcement","description":"to
+        be represented on an application for a supervision order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
+        - appeal","description":"to be represented on an application for a prohibited
+        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM10A","meaning":"Child assessment order
+        - appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a child assessment order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM45","meaning":"Adoption order - parent
+        or parental responsibility","description":"To represent a parent or person
+        with parental responsibility on an application for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM26E","meaning":"Child assessment order
+        - enforcement","description":"to be represented on an application for a child
+        assessment order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary or discharge","description":"to be represented
+        on an application to vary or discharge a contact order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM35","meaning":"Special guardianship order
+        - vary or discharge","description":"To be represented on an application for
+        variation/discharge of a special guardianship order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM01A","meaning":"Declaration for overseas
+        adoption - appeal","description":"to be represented on an application for
+        a declaration as to an overseas adoption.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM16E","meaning":"Prohibited steps order
         - enforcement","description":"to be represented on an application for a prohibited
         steps order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM17","meaning":"Specific issue order","description":"to
         be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18","meaning":"Child arrangements order
-        (CAO) - contact - vary or discharge","description":"to be represented on an
-        application to vary or discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary or discharge","description":"to be represented
-        on an application to vary or discharge a contact order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary or discharge","description":"to be represented
-        on an application to vary or discharge a contact order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19","meaning":"Child arrangements order
-        (CAO) - residence - vary or discharge","description":"to be represented on
-        an application to vary or discharge a residence order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary or discharge","description":"to be represented
-        on an application to vary or discharge a residence order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary or discharge","description":"to be
-        represented on an application to vary or discharge a residence order. Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20","meaning":"Prohibited steps order
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21","meaning":"Specific issue order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM22A","meaning":"Parental responsibility
-        - appeal","description":"to be represented on an application for parental
-        responsibility.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23","meaning":"Care order","description":"to
-        be represented on an application for a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23A","meaning":"Care order - appeal","description":"to
-        be represented on an application for a care order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23E","meaning":"Care order - enforcement","description":"to
-        be represented on an application for a care order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24","meaning":"Supervision order","description":"to
-        be represented on an application for a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24A","meaning":"Supervision order - appeal","description":"to
-        be represented on an application for a supervision order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24E","meaning":"Supervision order - enforcement","description":"to
-        be represented on an application for a supervision order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26","meaning":"Child assessment order","description":"to
-        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26A","meaning":"Child assessment order
-        - appeal","description":"to be represented on an application for a child assessment
-        order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26E","meaning":"Child assessment order
-        - enforcement","description":"to be represented on an application for a child
-        assessment order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27","meaning":"Emergency protection order","description":"to
-        be represented on an application for or to extend an emergency protection
-        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27A","meaning":"Emergency protection order
-        - appeal","description":"to be represented on an application for or to extend
-        an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27E","meaning":"Emergency protection order
-        - enforcement","description":"to be represented on an application for or to
-        extend an emergency protection order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM28","meaning":"Emergency protection order
-        - discharge","description":"to be represented on an application to discharge
-        an emergency protection order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM28A","meaning":"Emergency protection order
-        - appeal - discharge","description":"to be represented on an application to
-        discharge an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29","meaning":"Exclusion requirement","description":"to
-        be represented on an application to vary/discharge an exclusion requirement.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29A","meaning":"Exclusion requirement
-        - appeal","description":"to be represented on an application to vary/discharge
-        an exclusion requirement.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29E","meaning":"Exclusion requirement
-        - enforcement","description":"to be represented on an application to vary/discharge
-        an exclusion requirement.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30","meaning":"Placement order","description":"to
-        be represented on an application for a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30A","meaning":"Placement order - appeal","description":"to
-        be represented on an application for a placement order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30E","meaning":"Placement order - enforcement","description":"to
-        be represented on an application for a placement order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32","meaning":"Special guardianship order","description":"to
-        be represented on an application for a Special Guardianship Order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32A","meaning":"Special guardianship order
-        - appeal","description":"to be represented on an application for a Special
-        Guardianship Order . Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32E","meaning":"Special guardianship order
-        - enforcement","description":"to be represented on an application for a Special
-        Guardianship Order . Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33","meaning":"Revocation placement order","description":"to
-        be represented on an application for revocation of a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33A","meaning":"Revocation placement order
-        - appeal","description":"to be represented on an application for revocation
-        of a placement order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM33E","meaning":"Revocation placement order
         - enforcement","description":"to be represented on an application for revocation
         of a placement order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35","meaning":"Special guardianship order
-        - vary or discharge","description":"To be represented on an application for
-        variation/discharge of a special guardianship order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35A","meaning":"Special guardianship order
-        - appeal - vary or discharge","description":"To be represented on an application
-        for variation/discharge of a special guardianship order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35E","meaning":"Special guardianship order
-        - enforcement - vary or discharge","description":"To be represented on an
-        application for variation/discharge of a special guardianship order.  Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36","meaning":"Care order - joined party","description":"to
-        be represented on an application for a care order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36A","meaning":"Care order - joined party
-        - appeal","description":"to be represented on an application for a care order
-        Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36E","meaning":"Care order - joined party
-        - enforcement","description":"to be represented on an application for a care
-        order Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37","meaning":"Supervision order - joined
-        party","description":"to be represented on an application for a supervision
-        order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37A","meaning":"Supervision order - joined
+        law family (PLF)"},{"ccms_code":"PBM21A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM22","meaning":"Parental responsibility","description":"to
+        be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27A","meaning":"Emergency protection order
+        - appeal","description":"to be represented on an application for or to extend
+        an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM04A","meaning":"Secure accommodation order
+        - appeal","description":"to be represented on an application for a secure
+        accommodation order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM08E","meaning":"Education supervision
+        order - enforcement","description":"to be represented on an application for
+        an education supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE014","meaning":"Child arrangements order
+        (CAO) - residence","description":"to be represented on an application for
+        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM37A","meaning":"Supervision order - joined
         party - appeal","description":"to be represented on an application for a supervision
         order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37E","meaning":"Supervision order - joined
-        party - enforcement","description":"to be represented on an application for
-        a supervision order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order - who the child(ren) spend time with","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order - who the child(ren) spend time with. Appeals
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order - who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM39","meaning":"Child arrangements order
         (CAO) - residence","description":"to be represented on an application for
         a child arrangements order - where the child(ren) will live.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order - where the child(ren) will live. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order - where the child(ren) will live. Enforcement
+        law family (PLF)"},{"ccms_code":"PBM13","meaning":"Substitute supervision
+        with care","description":"to be represented on an application to substitute
+        a supervision order with care order under section 39 (4) Children Act 1989.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM05","meaning":"Contact with a child in
+        care","description":"to be represented on an application for contact with
+        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24A","meaning":"Supervision order - appeal","description":"to
+        be represented on an application for a supervision order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM08","meaning":"Education supervision order","description":"to
+        be represented on an application for an education supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM07","meaning":"Care order - discharge","description":"to
+        be represented on an application to discharge a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary or discharge","description":"to be represented
+        on an application to vary or discharge a residence order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM23E","meaning":"Care order - enforcement","description":"to
+        be represented on an application for a care order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order - who the child(ren) spend time with","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM09A","meaning":"Recovery of children order
+        - appeal","description":"to be represented on an application for the recovery
+        of a child/children.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM11","meaning":"End contact with a child
+        in care","description":"to be represented on an application to terminate contact
+        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM35E","meaning":"Special guardianship order
+        - enforcement - vary or discharge","description":"To be represented on an
+        application for variation/discharge of a special guardianship order.  Enforcement
         only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB026","meaning":"Emergency protection order","description":"to
+        be represented on an application for an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM26","meaning":"Child assessment order","description":"to
+        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM09","meaning":"Recovery of children order","description":"to
+        be represented on an application for the recovery of a child/children.  Appeals
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM37E","meaning":"Supervision order - joined
+        party - enforcement","description":"to be represented on an application for
+        a supervision order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM40","meaning":"Placement order - parent
         or parental responsibility","description":"To represent a parent or person
         with parental responsibility on an application for a placement order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM40E","meaning":"Placement order - parent
-        or parental responsibility - enforcement","description":"To represent a parent
-        or person with parental responsibility on an application for a placement order.
-        Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM45","meaning":"Adoption order - parent
-        or parental responsibility","description":"To represent a parent or person
-        with parental responsibility on an application for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM11A","meaning":"End contact with a child
+        in care - appeal","description":"to be represented on an application to terminate
+        contact with a child/children in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM45E","meaning":"Adoption order - parent
         or parental responsibility - enforcement","description":"To represent a parent
         or person with parental responsibility on an application for a placement order.
         Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24","meaning":"Supervision order","description":"to
+        be represented on an application for a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18","meaning":"Child arrangements order
+        (CAO) - contact - vary or discharge","description":"to be represented on an
+        application to vary or discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM39A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order - where the child(ren) will live. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM21E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM13A","meaning":"Substitute supervision
+        with care - appeal","description":"to be represented on an application to
+        substitute a supervision order with care order under section 39 (4) Children
+        Act 1989. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary","description":"to be represented on an
+        application to vary or discharge a child arrangements order –where the child(ren)
+        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM07A","meaning":"Care order - appeal - discharge","description":"to
+        be represented on an application to discharge a care order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary or discharge","description":"to be
+        represented on an application to vary or discharge a residence order. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM33","meaning":"Revocation placement order","description":"to
+        be represented on an application for revocation of a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM06E","meaning":"Supervision order - enforcement
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order - who the child(ren) spend time with. Appeals
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM16","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29E","meaning":"Exclusion requirement
+        - enforcement","description":"to be represented on an application to vary/discharge
+        an exclusion requirement.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
+        for an injunction, order or declaration under the inherent jurisdiction of
+        the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM20A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA002","meaning":"Protection from harassment
+        act 1997 under section 5 - vary or discharge","description":"to be represented
+        on an application to vary or discharge an order under section 5 Protection
+        from Harassment Act 1997 where the parties are associated persons (as defined
+        by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM07E","meaning":"Care order - enforcement - discharge","description":"to
+        be represented on an application to discharge a care order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM37","meaning":"Supervision order - joined
+        party","description":"to be represented on an application for a supervision
+        order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM26A","meaning":"Child assessment order
+        - appeal","description":"to be represented on an application for a child assessment
+        order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM39E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order - where the child(ren) will live. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29","meaning":"Exclusion requirement","description":"to
+        be represented on an application to vary/discharge an exclusion requirement.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM28A","meaning":"Emergency protection order
+        - appeal - discharge","description":"to be represented on an application to
+        discharge an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM40E","meaning":"Placement order - parent
+        or parental responsibility - enforcement","description":"To represent a parent
+        or person with parental responsibility on an application for a placement order.
+        Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J
+        and committal","description":"to be represented on an application for committal
+        and for an enforcement order under section 11J Children Act 1989. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM21","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27E","meaning":"Emergency protection order
+        - enforcement","description":"to be represented on an application for or to
+        extend an emergency protection order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:49 GMT
+  recorded_at: Wed, 07 May 2025 15:57:21 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
@@ -615,14 +611,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:51 GMT
+      - Wed, 07 May 2025 15:57:23 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -642,443 +638,439 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"93565432497c5ce191eac6fbf69b9a81"
+      - W/"f5d4a442765bb4b1da38aa01d431b319"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - d5d78ecb452f397b6a4e348b5b556598
+      - 7956cb7ca2b49cffeb1cc8ee0c96099c
       x-runtime:
-      - '0.033372'
+      - '0.038711'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
-        for an injunction, order or declaration under the inherent jurisdiction of
-        the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
-        1997 under section 5 - vary or discharge","description":"to be represented
-        on an application to vary or discharge an order under section 5 Protection
-        from Harassment Act 1997 where the parties are associated persons (as defined
-        by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
-        (CAO) - residence","description":"to be represented on an application for
-        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PB003","meaning":"Child assessment order","description":"to
-        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB004","meaning":"Emergency protection
-        order - extend","description":"to be represented on an application for or
-        to extend an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB005","meaning":"Emergency protection
-        order - discharge","description":"to be represented on an application to discharge
-        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB006","meaning":"Secure accommodation
-        order","description":"to be represented on an application for a secure accommodation
-        order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB026","meaning":"Emergency protection
-        order","description":"to be represented on an application for an emergency
-        protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB057","meaning":"Care order","description":"to
-        be represented on an application for a care order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB059","meaning":"Supervision order","description":"to
+      string: '{"success":true,"data":[{"ccms_code":"PBM06","meaning":"Supervision
+        order - vary or discharge","description":"to be represented on an application
+        to vary or discharge a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB059","meaning":"Supervision order","description":"to
         be represented on an application for a supervision order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PBM01","meaning":"Declaration for overseas
         adoption","description":"to be represented on an application for a declaration
         as to an overseas adoption.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM01A","meaning":"Declaration for overseas
-        adoption - appeal","description":"to be represented on an application for
-        a declaration as to an overseas adoption.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM02","meaning":"Adoption - not being held
-        in family proceedings court","description":"to be represented on an application
-        for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM02A","meaning":"Adoption order - appeal","description":"to
-        be represented on an application for an adoption order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM02E","meaning":"Adoption order - enforcement","description":"to
         be represented on an application for an adoption order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36E","meaning":"Care order - joined party
+        - enforcement","description":"to be represented on an application for a care
+        order Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB057","meaning":"Care order","description":"to
+        be represented on an application for a care order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM02A","meaning":"Adoption order - appeal","description":"to
+        be represented on an application for an adoption order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM04","meaning":"Secure accommodation order","description":"to
         be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM22","meaning":"Parental responsibility","description":"to
-        be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM04A","meaning":"Secure accommodation order
-        - appeal","description":"to be represented on an application for a secure
-        accommodation order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM04E","meaning":"Secure accommodation order
-        - enforcement","description":"to be represented on an application for a secure
-        accommodation order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05","meaning":"Contact with a child in
-        care","description":"to be represented on an application for contact with
-        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05A","meaning":"Contact with a child in
-        care - appeal","description":"to be represented on an application for contact
-        with a child in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05E","meaning":"Contact with a child in
-        care - enforcement","description":"to be represented on an application for
-        contact with a child in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06","meaning":"Supervision order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06A","meaning":"Supervision order - appeal
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06E","meaning":"Supervision order - enforcement
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07","meaning":"Care order - discharge","description":"to
-        be represented on an application to discharge a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07A","meaning":"Care order - appeal -
-        discharge","description":"to be represented on an application to discharge
-        a care order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07E","meaning":"Care order - enforcement
-        - discharge","description":"to be represented on an application to discharge
-        a care order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM08","meaning":"Education supervision order","description":"to
-        be represented on an application for an education supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM08A","meaning":"Education supervision
         order - appeal","description":"to be represented on an application for an
         education supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM08E","meaning":"Education supervision
-        order - enforcement","description":"to be represented on an application for
-        an education supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM09","meaning":"Recovery of children order","description":"to
-        be represented on an application for the recovery of a child/children.  Appeals
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM09A","meaning":"Recovery of children order
-        - appeal","description":"to be represented on an application for the recovery
-        of a child/children.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM04E","meaning":"Secure accommodation order
+        - enforcement","description":"to be represented on an application for a secure
+        accommodation order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
+        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM30A","meaning":"Placement order - appeal","description":"to
+        be represented on an application for a placement order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27","meaning":"Emergency protection order","description":"to
+        be represented on an application for or to extend an emergency protection
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM28","meaning":"Emergency protection order
+        - discharge","description":"to be represented on an application to discharge
+        an emergency protection order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM17A","meaning":"Specific issue order - appeal","description":"to
+        be represented on an application for a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB005","meaning":"Emergency protection order
+        - discharge","description":"to be represented on an application to discharge
+        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM23A","meaning":"Care order - appeal","description":"to
+        be represented on an application for a care order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36A","meaning":"Care order - joined party
+        - appeal","description":"to be represented on an application for a care order
+        Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB004","meaning":"Emergency protection order
+        - extend","description":"to be represented on an application for or to extend
+        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM22A","meaning":"Parental responsibility
+        - appeal","description":"to be represented on an application for parental
+        responsibility.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32A","meaning":"Special guardianship order
+        - appeal","description":"to be represented on an application for a Special
+        Guardianship Order . Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM20","meaning":"Prohibited steps order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM02","meaning":"Adoption - not being held
+        in family proceedings court","description":"to be represented on an application
+        for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE007","meaning":"Prohibited steps order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM23","meaning":"Care order","description":"to
+        be represented on an application for a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM09E","meaning":"Recovery of children order
         - enforcement","description":"to be represented on an application for the
         recovery of a child/children.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM10","meaning":"Child assessment order
+        law family (PLF)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J
+        - amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM33A","meaning":"Revocation placement order
+        - appeal","description":"to be represented on an application for revocation
+        of a placement order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM30E","meaning":"Placement order - enforcement","description":"to
+        be represented on an application for a placement order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36","meaning":"Care order - joined party","description":"to
+        be represented on an application for a care order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29A","meaning":"Exclusion requirement
+        - appeal","description":"to be represented on an application to vary/discharge
+        an exclusion requirement.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM06A","meaning":"Supervision order - appeal
         - vary or discharge","description":"to be represented on an application to
-        vary or discharge a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM10A","meaning":"Child assessment order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a child assessment order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11","meaning":"End contact with a child
-        in care","description":"to be represented on an application to terminate contact
-        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11A","meaning":"End contact with a child
-        in care - appeal","description":"to be represented on an application to terminate
-        contact with a child/children in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11E","meaning":"End contact with a child
+        vary or discharge a supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32","meaning":"Special guardianship order","description":"to
+        be represented on an application for a Special Guardianship Order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PB003","meaning":"Child assessment order","description":"to
+        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PB006","meaning":"Secure accommodation order","description":"to
+        be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM11E","meaning":"End contact with a child
         in care - enforcement","description":"to be represented on an application
         to terminate contact with a child/children in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM13","meaning":"Substitute supervision
-        with care","description":"to be represented on an application to substitute
-        a supervision order with care order under section 39 (4) Children Act 1989.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM13A","meaning":"Substitute supervision
-        with care - appeal","description":"to be represented on an application to
-        substitute a supervision order with care order under section 39 (4) Children
-        Act 1989. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM16","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary or discharge","description":"to be represented
+        on an application to vary or discharge a contact order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J
+        - appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM17E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32E","meaning":"Special guardianship order
+        - enforcement","description":"to be represented on an application for a Special
+        Guardianship Order . Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM20E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM35A","meaning":"Special guardianship order
+        - appeal - vary or discharge","description":"To be represented on an application
+        for variation/discharge of a special guardianship order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM16A","meaning":"Prohibited steps order
         - appeal","description":"to be represented on an application for a prohibited
         steps order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM16E","meaning":"Prohibited steps order
+        law family (PLF)"},{"ccms_code":"PBM05A","meaning":"Contact with a child in
+        care - appeal","description":"to be represented on an application for contact
+        with a child in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM10","meaning":"Child assessment order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order - who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM05E","meaning":"Contact with a child in
+        care - enforcement","description":"to be represented on an application for
+        contact with a child in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM30","meaning":"Placement order","description":"to
+        be represented on an application for a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19","meaning":"Child arrangements order
+        (CAO) - residence - vary or discharge","description":"to be represented on
+        an application to vary or discharge a residence order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM24E","meaning":"Supervision order - enforcement","description":"to
+        be represented on an application for a supervision order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
+        - appeal","description":"to be represented on an application for a prohibited
+        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM10A","meaning":"Child assessment order
+        - appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a child assessment order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM45","meaning":"Adoption order - parent
+        or parental responsibility","description":"To represent a parent or person
+        with parental responsibility on an application for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM26E","meaning":"Child assessment order
+        - enforcement","description":"to be represented on an application for a child
+        assessment order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary or discharge","description":"to be represented
+        on an application to vary or discharge a contact order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM35","meaning":"Special guardianship order
+        - vary or discharge","description":"To be represented on an application for
+        variation/discharge of a special guardianship order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM01A","meaning":"Declaration for overseas
+        adoption - appeal","description":"to be represented on an application for
+        a declaration as to an overseas adoption.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM16E","meaning":"Prohibited steps order
         - enforcement","description":"to be represented on an application for a prohibited
         steps order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM17","meaning":"Specific issue order","description":"to
         be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18","meaning":"Child arrangements order
-        (CAO) - contact - vary or discharge","description":"to be represented on an
-        application to vary or discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary or discharge","description":"to be represented
-        on an application to vary or discharge a contact order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary or discharge","description":"to be represented
-        on an application to vary or discharge a contact order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19","meaning":"Child arrangements order
-        (CAO) - residence - vary or discharge","description":"to be represented on
-        an application to vary or discharge a residence order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary or discharge","description":"to be represented
-        on an application to vary or discharge a residence order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary or discharge","description":"to be
-        represented on an application to vary or discharge a residence order. Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20","meaning":"Prohibited steps order
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21","meaning":"Specific issue order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM22A","meaning":"Parental responsibility
-        - appeal","description":"to be represented on an application for parental
-        responsibility.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23","meaning":"Care order","description":"to
-        be represented on an application for a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23A","meaning":"Care order - appeal","description":"to
-        be represented on an application for a care order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23E","meaning":"Care order - enforcement","description":"to
-        be represented on an application for a care order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24","meaning":"Supervision order","description":"to
-        be represented on an application for a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24A","meaning":"Supervision order - appeal","description":"to
-        be represented on an application for a supervision order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24E","meaning":"Supervision order - enforcement","description":"to
-        be represented on an application for a supervision order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26","meaning":"Child assessment order","description":"to
-        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26A","meaning":"Child assessment order
-        - appeal","description":"to be represented on an application for a child assessment
-        order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26E","meaning":"Child assessment order
-        - enforcement","description":"to be represented on an application for a child
-        assessment order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27","meaning":"Emergency protection order","description":"to
-        be represented on an application for or to extend an emergency protection
-        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27A","meaning":"Emergency protection order
-        - appeal","description":"to be represented on an application for or to extend
-        an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27E","meaning":"Emergency protection order
-        - enforcement","description":"to be represented on an application for or to
-        extend an emergency protection order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM28","meaning":"Emergency protection order
-        - discharge","description":"to be represented on an application to discharge
-        an emergency protection order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM28A","meaning":"Emergency protection order
-        - appeal - discharge","description":"to be represented on an application to
-        discharge an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29","meaning":"Exclusion requirement","description":"to
-        be represented on an application to vary/discharge an exclusion requirement.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29A","meaning":"Exclusion requirement
-        - appeal","description":"to be represented on an application to vary/discharge
-        an exclusion requirement.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29E","meaning":"Exclusion requirement
-        - enforcement","description":"to be represented on an application to vary/discharge
-        an exclusion requirement.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30","meaning":"Placement order","description":"to
-        be represented on an application for a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30A","meaning":"Placement order - appeal","description":"to
-        be represented on an application for a placement order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30E","meaning":"Placement order - enforcement","description":"to
-        be represented on an application for a placement order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32","meaning":"Special guardianship order","description":"to
-        be represented on an application for a Special Guardianship Order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32A","meaning":"Special guardianship order
-        - appeal","description":"to be represented on an application for a Special
-        Guardianship Order . Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32E","meaning":"Special guardianship order
-        - enforcement","description":"to be represented on an application for a Special
-        Guardianship Order . Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33","meaning":"Revocation placement order","description":"to
-        be represented on an application for revocation of a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33A","meaning":"Revocation placement order
-        - appeal","description":"to be represented on an application for revocation
-        of a placement order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM33E","meaning":"Revocation placement order
         - enforcement","description":"to be represented on an application for revocation
         of a placement order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35","meaning":"Special guardianship order
-        - vary or discharge","description":"To be represented on an application for
-        variation/discharge of a special guardianship order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35A","meaning":"Special guardianship order
-        - appeal - vary or discharge","description":"To be represented on an application
-        for variation/discharge of a special guardianship order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35E","meaning":"Special guardianship order
-        - enforcement - vary or discharge","description":"To be represented on an
-        application for variation/discharge of a special guardianship order.  Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36","meaning":"Care order - joined party","description":"to
-        be represented on an application for a care order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36A","meaning":"Care order - joined party
-        - appeal","description":"to be represented on an application for a care order
-        Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36E","meaning":"Care order - joined party
-        - enforcement","description":"to be represented on an application for a care
-        order Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37","meaning":"Supervision order - joined
-        party","description":"to be represented on an application for a supervision
-        order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37A","meaning":"Supervision order - joined
+        law family (PLF)"},{"ccms_code":"PBM21A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM22","meaning":"Parental responsibility","description":"to
+        be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27A","meaning":"Emergency protection order
+        - appeal","description":"to be represented on an application for or to extend
+        an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM04A","meaning":"Secure accommodation order
+        - appeal","description":"to be represented on an application for a secure
+        accommodation order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM08E","meaning":"Education supervision
+        order - enforcement","description":"to be represented on an application for
+        an education supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE014","meaning":"Child arrangements order
+        (CAO) - residence","description":"to be represented on an application for
+        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM37A","meaning":"Supervision order - joined
         party - appeal","description":"to be represented on an application for a supervision
         order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37E","meaning":"Supervision order - joined
-        party - enforcement","description":"to be represented on an application for
-        a supervision order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order - who the child(ren) spend time with","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order - who the child(ren) spend time with. Appeals
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order - who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM39","meaning":"Child arrangements order
         (CAO) - residence","description":"to be represented on an application for
         a child arrangements order - where the child(ren) will live.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order - where the child(ren) will live. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order - where the child(ren) will live. Enforcement
+        law family (PLF)"},{"ccms_code":"PBM13","meaning":"Substitute supervision
+        with care","description":"to be represented on an application to substitute
+        a supervision order with care order under section 39 (4) Children Act 1989.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM05","meaning":"Contact with a child in
+        care","description":"to be represented on an application for contact with
+        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24A","meaning":"Supervision order - appeal","description":"to
+        be represented on an application for a supervision order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM08","meaning":"Education supervision order","description":"to
+        be represented on an application for an education supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM07","meaning":"Care order - discharge","description":"to
+        be represented on an application to discharge a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary or discharge","description":"to be represented
+        on an application to vary or discharge a residence order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM23E","meaning":"Care order - enforcement","description":"to
+        be represented on an application for a care order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order - who the child(ren) spend time with","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM09A","meaning":"Recovery of children order
+        - appeal","description":"to be represented on an application for the recovery
+        of a child/children.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM11","meaning":"End contact with a child
+        in care","description":"to be represented on an application to terminate contact
+        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM35E","meaning":"Special guardianship order
+        - enforcement - vary or discharge","description":"To be represented on an
+        application for variation/discharge of a special guardianship order.  Enforcement
         only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB026","meaning":"Emergency protection order","description":"to
+        be represented on an application for an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM26","meaning":"Child assessment order","description":"to
+        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM09","meaning":"Recovery of children order","description":"to
+        be represented on an application for the recovery of a child/children.  Appeals
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM37E","meaning":"Supervision order - joined
+        party - enforcement","description":"to be represented on an application for
+        a supervision order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM40","meaning":"Placement order - parent
         or parental responsibility","description":"To represent a parent or person
         with parental responsibility on an application for a placement order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM40E","meaning":"Placement order - parent
-        or parental responsibility - enforcement","description":"To represent a parent
-        or person with parental responsibility on an application for a placement order.
-        Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM45","meaning":"Adoption order - parent
-        or parental responsibility","description":"To represent a parent or person
-        with parental responsibility on an application for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM11A","meaning":"End contact with a child
+        in care - appeal","description":"to be represented on an application to terminate
+        contact with a child/children in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM45E","meaning":"Adoption order - parent
         or parental responsibility - enforcement","description":"To represent a parent
         or person with parental responsibility on an application for a placement order.
         Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24","meaning":"Supervision order","description":"to
+        be represented on an application for a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18","meaning":"Child arrangements order
+        (CAO) - contact - vary or discharge","description":"to be represented on an
+        application to vary or discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM39A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order - where the child(ren) will live. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM21E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM13A","meaning":"Substitute supervision
+        with care - appeal","description":"to be represented on an application to
+        substitute a supervision order with care order under section 39 (4) Children
+        Act 1989. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary","description":"to be represented on an
+        application to vary or discharge a child arrangements order –where the child(ren)
+        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM07A","meaning":"Care order - appeal - discharge","description":"to
+        be represented on an application to discharge a care order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary or discharge","description":"to be
+        represented on an application to vary or discharge a residence order. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM33","meaning":"Revocation placement order","description":"to
+        be represented on an application for revocation of a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM06E","meaning":"Supervision order - enforcement
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order - who the child(ren) spend time with. Appeals
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM16","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29E","meaning":"Exclusion requirement
+        - enforcement","description":"to be represented on an application to vary/discharge
+        an exclusion requirement.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
+        for an injunction, order or declaration under the inherent jurisdiction of
+        the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM20A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA002","meaning":"Protection from harassment
+        act 1997 under section 5 - vary or discharge","description":"to be represented
+        on an application to vary or discharge an order under section 5 Protection
+        from Harassment Act 1997 where the parties are associated persons (as defined
+        by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM07E","meaning":"Care order - enforcement - discharge","description":"to
+        be represented on an application to discharge a care order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM37","meaning":"Supervision order - joined
+        party","description":"to be represented on an application for a supervision
+        order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM26A","meaning":"Child assessment order
+        - appeal","description":"to be represented on an application for a child assessment
+        order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM39E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order - where the child(ren) will live. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29","meaning":"Exclusion requirement","description":"to
+        be represented on an application to vary/discharge an exclusion requirement.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM28A","meaning":"Emergency protection order
+        - appeal - discharge","description":"to be represented on an application to
+        discharge an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM40E","meaning":"Placement order - parent
+        or parental responsibility - enforcement","description":"To represent a parent
+        or person with parental responsibility on an application for a placement order.
+        Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J
+        and committal","description":"to be represented on an application for committal
+        and for an enforcement order under section 11J Children Act 1989. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM21","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27E","meaning":"Emergency protection order
+        - enforcement","description":"to be represented on an application for or to
+        extend an emergency protection order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:51 GMT
+  recorded_at: Wed, 07 May 2025 15:57:23 GMT
 - request:
     method: get
-    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE014A
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE016A
     body:
       encoding: US-ASCII
       string: ''
@@ -1086,18 +1078,18 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:51 GMT
+      - Wed, 07 May 2025 15:57:23 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '1122'
+      - '1151'
       connection:
       - keep-alive
       x-frame-options:
@@ -1113,50 +1105,50 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"f45b218af96b2d31f74762ce30efa40e"
+      - W/"46479618f2daf466ea680e3ae7a88861"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - cd946776f9f07183b1d417fd53fc1cce
+      - f311bf38562f78c4e590f99dc3fa59d8
       x-runtime:
-      - '0.009932'
+      - '0.011623'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"ccms_code":"SE014A","meaning":"Child arrangements
-        order (CAO) - residence - appeal","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","name":"cao_residence_appeal","description":"to
-        be represented on an application for a child arrangements order –where the
-        child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_matter":"section
+      string: '{"success":true,"ccms_code":"SE016A","meaning":"Child arrangements
+        order (CAO) - residence - appeal - vary","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","name":"vary_cao_redidence_appeal","description":"to
+        be represented on an application to vary or discharge a child arrangements
+        order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_matter":"section
         8 children (S8)","cost_limitations":{"substantive":{"start_date":"1970-01-01","value":"5000.0"},"delegated_functions":{"start_date":"2021-09-13","value":"2250.0"}},"default_scope_limitations":{"substantive":{"code":"CV079","meaning":"Counsel''s
         Opinion","description":"Limited to obtaining external Counsel''s Opinion or
         the opinion of an external solicitor with higher court advocacy rights on
         the information already available."},"delegated_functions":{"code":"CV118","meaning":"Hearing","description":"Limited
         to all steps up to and including the hearing on [see additional limitation
         notes]"}},"service_levels":[{"level":3,"name":"Full Representation","stage":8,"proceeding_default":true}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:51 GMT
+  recorded_at: Wed, 07 May 2025 15:57:23 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
     body:
       encoding: UTF-8
-      string: '{"current_proceedings":["SE014A"],"allowed_categories":["MAT"],"search_term":""}'
+      string: '{"current_proceedings":["SE016A"],"allowed_categories":["MAT"],"search_term":""}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:52 GMT
+      - Wed, 07 May 2025 15:57:24 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '16225'
+      - '16201'
       connection:
       - keep-alive
       x-frame-options:
@@ -1172,19 +1164,135 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"cb87d3773effb9402773dc1f4d2451b5"
+      - W/"05989f0afa888da76d32d0605f4d5421"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - '09e1737a4283c3521b50b2e2f0b796c8'
+      - c5d54cb0b852add7430fc3d23ede574c
       x-runtime:
-      - '0.035412'
+      - '0.060152'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
+      string: '{"success":true,"data":[{"ccms_code":"DA004","meaning":"Non-molestation
+        order","description":"to be represented on an application for a non-molestation
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
+        vary or discharge","description":"to be represented on an application to vary
+        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
+        amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
+        appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order - appeal","description":"to
+        be represented on an application for a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
+        (CAO) - residence","description":"to be represented on an application for
+        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
         for an injunction, order or declaration under the inherent jurisdiction of
         the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
         abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
@@ -1192,150 +1300,33 @@ http_interactions:
         on an application to vary or discharge an order under section 5 Protection
         from Harassment Act 1997 where the parties are associated persons (as defined
         by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
-        (CAO) - residence","description":"to be represented on an application for
-        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        abuse (DA)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and committal","description":"to
+        be represented on an application for committal and for an enforcement order
+        under section 11J Children Act 1989. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
         8 children (S8)"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:51 GMT
+  recorded_at: Wed, 07 May 2025 15:57:24 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
     body:
       encoding: UTF-8
-      string: '{"current_proceedings":["SE014A"],"allowed_categories":["MAT"],"search_term":""}'
+      string: '{"current_proceedings":["SE016A"],"allowed_categories":["MAT"],"search_term":""}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:53 GMT
+      - Wed, 07 May 2025 15:57:24 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '16225'
+      - '16201'
       connection:
       - keep-alive
       x-frame-options:
@@ -1351,19 +1342,135 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"cb87d3773effb9402773dc1f4d2451b5"
+      - W/"05989f0afa888da76d32d0605f4d5421"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 89c1c5df8e0aafa6c0f9dc8270711e6f
+      - 90fb6a366cdb47982a1b8c880a6cc2cf
       x-runtime:
-      - '0.036373'
+      - '0.050415'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
+      string: '{"success":true,"data":[{"ccms_code":"DA004","meaning":"Non-molestation
+        order","description":"to be represented on an application for a non-molestation
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
+        vary or discharge","description":"to be represented on an application to vary
+        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
+        amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
+        appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order - appeal","description":"to
+        be represented on an application for a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
+        (CAO) - residence","description":"to be represented on an application for
+        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
         for an injunction, order or declaration under the inherent jurisdiction of
         the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
         abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
@@ -1371,150 +1478,33 @@ http_interactions:
         on an application to vary or discharge an order under section 5 Protection
         from Harassment Act 1997 where the parties are associated persons (as defined
         by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
-        (CAO) - residence","description":"to be represented on an application for
-        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        abuse (DA)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and committal","description":"to
+        be represented on an application for committal and for an enforcement order
+        under section 11J Children Act 1989. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
         8 children (S8)"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:52 GMT
+  recorded_at: Wed, 07 May 2025 15:57:24 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
     body:
       encoding: UTF-8
-      string: '{"current_proceedings":["SE014A"],"allowed_categories":["MAT"],"search_term":""}'
+      string: '{"current_proceedings":["SE016A"],"allowed_categories":["MAT"],"search_term":""}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:54 GMT
+      - Wed, 07 May 2025 15:57:26 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '16225'
+      - '16201'
       connection:
       - keep-alive
       x-frame-options:
@@ -1530,19 +1520,135 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"cb87d3773effb9402773dc1f4d2451b5"
+      - W/"05989f0afa888da76d32d0605f4d5421"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 6b764605618fd344125a30988927dde9
+      - 2b6c493ce31f32c5838db9990f7f5c6d
       x-runtime:
-      - '0.045472'
+      - '0.045346'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
+      string: '{"success":true,"data":[{"ccms_code":"DA004","meaning":"Non-molestation
+        order","description":"to be represented on an application for a non-molestation
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
+        vary or discharge","description":"to be represented on an application to vary
+        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
+        amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
+        appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order - appeal","description":"to
+        be represented on an application for a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
+        (CAO) - residence","description":"to be represented on an application for
+        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
         for an injunction, order or declaration under the inherent jurisdiction of
         the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
         abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
@@ -1550,128 +1656,11 @@ http_interactions:
         on an application to vary or discharge an order under section 5 Protection
         from Harassment Act 1997 where the parties are associated persons (as defined
         by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
-        (CAO) - residence","description":"to be represented on an application for
-        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        abuse (DA)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and committal","description":"to
+        be represented on an application for committal and for an enforcement order
+        under section 11J Children Act 1989. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
         8 children (S8)"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:53 GMT
+  recorded_at: Wed, 07 May 2025 15:57:26 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE095
@@ -1682,14 +1671,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:54 GMT
+      - Wed, 07 May 2025 15:57:26 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1713,9 +1702,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - b30c21b0a1dae870a939dfe23a16553e
+      - e2448e7c8eebf6d5d8b0cebbc3b44d1e
       x-runtime:
-      - '0.007351'
+      - '0.012055'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1733,29 +1722,29 @@ http_interactions:
         representation on the return date."}},"service_levels":[{"level":1,"name":"Family
         Help (Higher)","stage":1,"proceeding_default":true},{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":false}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:54 GMT
+  recorded_at: Wed, 07 May 2025 15:57:26 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
     body:
       encoding: UTF-8
-      string: '{"current_proceedings":["SE014A","SE095"],"allowed_categories":["MAT"],"search_term":""}'
+      string: '{"current_proceedings":["SE016A","SE095"],"allowed_categories":["MAT"],"search_term":""}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:55 GMT
+      - Wed, 07 May 2025 15:57:26 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '15823'
+      - '15799'
       connection:
       - keep-alive
       x-frame-options:
@@ -1771,19 +1760,132 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"e2d46cd2e8ac121622596f0192ae1782"
+      - W/"b578a985e9a647f56af14435388ed164"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 6db2784cacb256053ca20f4de72d66f0
+      - 7530f08fc04da18acdca187a452d015c
       x-runtime:
-      - '0.044312'
+      - '0.048396'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
+      string: '{"success":true,"data":[{"ccms_code":"DA004","meaning":"Non-molestation
+        order","description":"to be represented on an application for a non-molestation
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
+        vary or discharge","description":"to be represented on an application to vary
+        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
+        amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
+        appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order - appeal","description":"to
+        be represented on an application for a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
+        (CAO) - residence","description":"to be represented on an application for
+        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
         for an injunction, order or declaration under the inherent jurisdiction of
         the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
         abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
@@ -1791,128 +1893,14 @@ http_interactions:
         on an application to vary or discharge an order under section 5 Protection
         from Harassment Act 1997 where the parties are associated persons (as defined
         by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
-        (CAO) - residence","description":"to be represented on an application for
-        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        abuse (DA)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and committal","description":"to
+        be represented on an application for committal and for an enforcement order
+        under section 11J Children Act 1989. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
         8 children (S8)"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:54 GMT
+  recorded_at: Wed, 07 May 2025 15:57:26 GMT
 - request:
     method: get
-    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/SE014A
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/SE016A
     body:
       encoding: US-ASCII
       string: ''
@@ -1920,14 +1908,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:56 GMT
+      - Wed, 07 May 2025 15:57:27 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1951,9 +1939,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - fabdf14ed3a8560ad65cd27a060a1f1c
+      - dfad9a5591f82b1367654725aa65acd2
       x-runtime:
-      - '0.001837'
+      - '0.002707'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1961,10 +1949,10 @@ http_interactions:
       string: '{"success":true,"client_involvement_type":[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:55 GMT
+  recorded_at: Wed, 07 May 2025 15:57:27 GMT
 - request:
     method: get
-    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/SE014A
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/SE016A
     body:
       encoding: US-ASCII
       string: ''
@@ -1972,14 +1960,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:56 GMT
+      - Wed, 07 May 2025 15:57:28 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2003,9 +1991,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - de4367a801a2a7358261a42b4a2e6421
+      - e55198b179e22e20b180e09bc891a4f0
       x-runtime:
-      - '0.002132'
+      - '0.003058'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2013,25 +2001,25 @@ http_interactions:
       string: '{"success":true,"client_involvement_type":[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:56 GMT
+  recorded_at: Wed, 07 May 2025 15:57:28 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
     body:
       encoding: UTF-8
-      string: '{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":true,"client_involvement_type":"A"}'
+      string: '{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":true,"client_involvement_type":"A"}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:58 GMT
+      - Wed, 07 May 2025 15:57:29 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2051,40 +2039,40 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"c7645a6c1803d661969899b2e1493ef4"
+      - W/"89cd07cc1047be7589fc77034f445480"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 323d6523fae82e54bbc6adea00783d07
+      - ea3c7d25d4bdd82f147f096a23ebd313
       x-runtime:
-      - '0.005000'
+      - '0.019871'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":true,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":true,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
         Representation","stage":8},"default_scope":{"code":"CV118","meaning":"Hearing","description":"Limited
         to all steps up to and including the hearing on [see additional limitation
         notes]","additional_params":[{"name":"hearing_date","type":"date","mandatory":true}]}}'
-  recorded_at: Fri, 14 Mar 2025 09:31:57 GMT
+  recorded_at: Wed, 07 May 2025 15:57:29 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
     body:
       encoding: UTF-8
-      string: '{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":true,"client_involvement_type":"A"}'
+      string: '{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":true,"client_involvement_type":"A"}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:59 GMT
+      - Wed, 07 May 2025 15:57:30 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2104,40 +2092,40 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"c7645a6c1803d661969899b2e1493ef4"
+      - W/"89cd07cc1047be7589fc77034f445480"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 521c3dec709c8905ec7856b93666a661
+      - 23a06eef3564be1dfaffd46cc5b376c5
       x-runtime:
-      - '0.005530'
+      - '0.008480'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":true,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":true,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
         Representation","stage":8},"default_scope":{"code":"CV118","meaning":"Hearing","description":"Limited
         to all steps up to and including the hearing on [see additional limitation
         notes]","additional_params":[{"name":"hearing_date","type":"date","mandatory":true}]}}'
-  recorded_at: Fri, 14 Mar 2025 09:31:58 GMT
+  recorded_at: Wed, 07 May 2025 15:57:30 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
     body:
       encoding: UTF-8
-      string: '{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":false,"client_involvement_type":"A"}'
+      string: '{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":false,"client_involvement_type":"A"}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:59 GMT
+      - Wed, 07 May 2025 15:57:30 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2157,41 +2145,41 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"41641a45afd53756062781ec006ef115"
+      - W/"b7f8b504da8b7435824900062d956080"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 444161c8031d2b8ac32f7174f8b3dd7e
+      - 18173204bfd53dbeff77b4f6091d4ec6
       x-runtime:
-      - '0.004338'
+      - '0.009481'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":false,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":false,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
         Representation","stage":8},"default_scope":{"code":"CV079","meaning":"Counsel''s
         Opinion","description":"Limited to obtaining external Counsel''s Opinion or
         the opinion of an external solicitor with higher court advocacy rights on
         the information already available.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 09:31:58 GMT
+  recorded_at: Wed, 07 May 2025 15:57:30 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
     body:
       encoding: UTF-8
-      string: '{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":false,"client_involvement_type":"A"}'
+      string: '{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":false,"client_involvement_type":"A"}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:00 GMT
+      - Wed, 07 May 2025 15:57:31 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2211,23 +2199,23 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"41641a45afd53756062781ec006ef115"
+      - W/"b7f8b504da8b7435824900062d956080"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 7a54a7d0f47e38e3236342a13b8fb618
+      - 6cce439e8cc797bcaa21fb282b6b9e43
       x-runtime:
-      - '0.004994'
+      - '0.008625'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":false,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":false,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
         Representation","stage":8},"default_scope":{"code":"CV079","meaning":"Counsel''s
         Opinion","description":"Limited to obtaining external Counsel''s Opinion or
         the opinion of an external solicitor with higher court advocacy rights on
         the information already available.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 09:31:59 GMT
+  recorded_at: Wed, 07 May 2025 15:57:31 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/SE095
@@ -2238,14 +2226,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:00 GMT
+      - Wed, 07 May 2025 15:57:31 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2269,9 +2257,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 88ce9e750e6ba39aeb5c326fbf431021
+      - 0e027bc38b36f0c8460570472e35e0f8
       x-runtime:
-      - '0.001895'
+      - '0.002897'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2279,7 +2267,7 @@ http_interactions:
       string: '{"success":true,"client_involvement_type":[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:59 GMT
+  recorded_at: Wed, 07 May 2025 15:57:31 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/SE095
@@ -2290,14 +2278,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:01 GMT
+      - Wed, 07 May 2025 15:57:32 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2321,9 +2309,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 1d18ec3c9a5d7a618e3a4a1e5049cc89
+      - a003c6c26f5159f6db14107836566b67
       x-runtime:
-      - '0.001739'
+      - '0.002611'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2331,7 +2319,7 @@ http_interactions:
       string: '{"success":true,"client_involvement_type":[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:32:00 GMT
+  recorded_at: Wed, 07 May 2025 15:57:32 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -2342,14 +2330,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:02 GMT
+      - Wed, 07 May 2025 15:57:33 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2373,9 +2361,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 6e3493136f4ac974d2d558b7d9df4c0c
+      - '0779f075ea4fd0a3b86965e9335de288'
       x-runtime:
-      - '0.006134'
+      - '0.009289'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2385,7 +2373,7 @@ http_interactions:
         to Family Help (Higher) and to all steps necessary to negotiate and conclude
         a settlement. To include the issue of proceedings and representation in those
         proceedings save in relation to or at a contested final hearing.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 09:32:01 GMT
+  recorded_at: Wed, 07 May 2025 15:57:33 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -2396,14 +2384,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:32:03 GMT
+      - Wed, 07 May 2025 15:57:33 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2427,9 +2415,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - f1f404731db846dccf9b675da9e38291
+      - dee9100f661ead39568d54d83861718c
       x-runtime:
-      - '0.004595'
+      - '0.009038'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2439,5 +2427,5 @@ http_interactions:
         to Family Help (Higher) and to all steps necessary to negotiate and conclude
         a settlement. To include the issue of proceedings and representation in those
         proceedings save in relation to or at a contested final hearing.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 09:32:02 GMT
+  recorded_at: Wed, 07 May 2025 15:57:33 GMT
 recorded_with: VCR 6.3.1

--- a/features/cassettes/Loop_through_proceeding_questions/When_provider_does_not_accept_default_levels_of_service.yml
+++ b/features/cassettes/Loop_through_proceeding_questions/When_provider_does_not_accept_default_levels_of_service.yml
@@ -8,14 +8,14 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:18 GMT
+      - Wed, 07 May 2025 15:59:04 GMT
       content-type:
       - application/json;charset=UTF-8
       transfer-encoding:
@@ -37,8 +37,8 @@ http_interactions:
       string: "{\r\n  \"header\" : {\r\n    \"uri\" : \"https://api.os.uk/search/places/v1/postcode?lr=EN&postcode=SW1H9EA\",\r\n
         \   \"query\" : \"postcode=SW1H9EA\",\r\n    \"offset\" : 0,\r\n    \"totalresults\"
         : 5,\r\n    \"format\" : \"JSON\",\r\n    \"dataset\" : \"DPA\",\r\n    \"lr\"
-        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"115\",\r\n    \"lastupdate\"
-        : \"2025-03-13\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
+        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"118\",\r\n    \"lastupdate\"
+        : \"2025-05-06\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
         : [ {\r\n    \"DPA\" : {\r\n      \"UPRN\" : \"100023337883\",\r\n      \"UDPRN\"
         : \"23749699\",\r\n      \"ADDRESS\" : \"84, PETTY FRANCE, LONDON, SW1H 9EA\",\r\n
         \     \"BUILDING_NUMBER\" : \"84\",\r\n      \"THOROUGHFARE_NAME\" : \"PETTY
@@ -133,7 +133,7 @@ http_interactions:
         \     \"BLPU_STATE_DATE\" : \"15/06/2020\",\r\n      \"LANGUAGE\" : \"EN\",\r\n
         \     \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\" : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\"
         : \"1N\"\r\n    }\r\n  } ]\r\n}"
-  recorded_at: Fri, 14 Mar 2025 09:31:17 GMT
+  recorded_at: Wed, 07 May 2025 15:59:04 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
@@ -144,14 +144,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:19 GMT
+      - Wed, 07 May 2025 15:59:05 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -171,440 +171,436 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"93565432497c5ce191eac6fbf69b9a81"
+      - W/"f5d4a442765bb4b1da38aa01d431b319"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - dbe64b7801ae56ad2c9681c1d839e437
+      - ad8eb485a0d3375135c5fc690ded1071
       x-runtime:
-      - '0.029556'
+      - '0.039751'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
-        for an injunction, order or declaration under the inherent jurisdiction of
-        the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
-        1997 under section 5 - vary or discharge","description":"to be represented
-        on an application to vary or discharge an order under section 5 Protection
-        from Harassment Act 1997 where the parties are associated persons (as defined
-        by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
-        (CAO) - residence","description":"to be represented on an application for
-        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PB003","meaning":"Child assessment order","description":"to
-        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB004","meaning":"Emergency protection
-        order - extend","description":"to be represented on an application for or
-        to extend an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB005","meaning":"Emergency protection
-        order - discharge","description":"to be represented on an application to discharge
-        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB006","meaning":"Secure accommodation
-        order","description":"to be represented on an application for a secure accommodation
-        order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB026","meaning":"Emergency protection
-        order","description":"to be represented on an application for an emergency
-        protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB057","meaning":"Care order","description":"to
-        be represented on an application for a care order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB059","meaning":"Supervision order","description":"to
+      string: '{"success":true,"data":[{"ccms_code":"PBM06","meaning":"Supervision
+        order - vary or discharge","description":"to be represented on an application
+        to vary or discharge a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB059","meaning":"Supervision order","description":"to
         be represented on an application for a supervision order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PBM01","meaning":"Declaration for overseas
         adoption","description":"to be represented on an application for a declaration
         as to an overseas adoption.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM01A","meaning":"Declaration for overseas
-        adoption - appeal","description":"to be represented on an application for
-        a declaration as to an overseas adoption.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM02","meaning":"Adoption - not being held
-        in family proceedings court","description":"to be represented on an application
-        for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM02A","meaning":"Adoption order - appeal","description":"to
-        be represented on an application for an adoption order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM02E","meaning":"Adoption order - enforcement","description":"to
         be represented on an application for an adoption order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36E","meaning":"Care order - joined party
+        - enforcement","description":"to be represented on an application for a care
+        order Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB057","meaning":"Care order","description":"to
+        be represented on an application for a care order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM02A","meaning":"Adoption order - appeal","description":"to
+        be represented on an application for an adoption order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM04","meaning":"Secure accommodation order","description":"to
         be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM22","meaning":"Parental responsibility","description":"to
-        be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM04A","meaning":"Secure accommodation order
-        - appeal","description":"to be represented on an application for a secure
-        accommodation order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM04E","meaning":"Secure accommodation order
-        - enforcement","description":"to be represented on an application for a secure
-        accommodation order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05","meaning":"Contact with a child in
-        care","description":"to be represented on an application for contact with
-        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05A","meaning":"Contact with a child in
-        care - appeal","description":"to be represented on an application for contact
-        with a child in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05E","meaning":"Contact with a child in
-        care - enforcement","description":"to be represented on an application for
-        contact with a child in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06","meaning":"Supervision order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06A","meaning":"Supervision order - appeal
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06E","meaning":"Supervision order - enforcement
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07","meaning":"Care order - discharge","description":"to
-        be represented on an application to discharge a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07A","meaning":"Care order - appeal -
-        discharge","description":"to be represented on an application to discharge
-        a care order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07E","meaning":"Care order - enforcement
-        - discharge","description":"to be represented on an application to discharge
-        a care order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM08","meaning":"Education supervision order","description":"to
-        be represented on an application for an education supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM08A","meaning":"Education supervision
         order - appeal","description":"to be represented on an application for an
         education supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM08E","meaning":"Education supervision
-        order - enforcement","description":"to be represented on an application for
-        an education supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM09","meaning":"Recovery of children order","description":"to
-        be represented on an application for the recovery of a child/children.  Appeals
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM09A","meaning":"Recovery of children order
-        - appeal","description":"to be represented on an application for the recovery
-        of a child/children.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM04E","meaning":"Secure accommodation order
+        - enforcement","description":"to be represented on an application for a secure
+        accommodation order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
+        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM30A","meaning":"Placement order - appeal","description":"to
+        be represented on an application for a placement order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27","meaning":"Emergency protection order","description":"to
+        be represented on an application for or to extend an emergency protection
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM28","meaning":"Emergency protection order
+        - discharge","description":"to be represented on an application to discharge
+        an emergency protection order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM17A","meaning":"Specific issue order - appeal","description":"to
+        be represented on an application for a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB005","meaning":"Emergency protection order
+        - discharge","description":"to be represented on an application to discharge
+        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM23A","meaning":"Care order - appeal","description":"to
+        be represented on an application for a care order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36A","meaning":"Care order - joined party
+        - appeal","description":"to be represented on an application for a care order
+        Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB004","meaning":"Emergency protection order
+        - extend","description":"to be represented on an application for or to extend
+        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM22A","meaning":"Parental responsibility
+        - appeal","description":"to be represented on an application for parental
+        responsibility.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32A","meaning":"Special guardianship order
+        - appeal","description":"to be represented on an application for a Special
+        Guardianship Order . Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM20","meaning":"Prohibited steps order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM02","meaning":"Adoption - not being held
+        in family proceedings court","description":"to be represented on an application
+        for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE007","meaning":"Prohibited steps order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM23","meaning":"Care order","description":"to
+        be represented on an application for a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM09E","meaning":"Recovery of children order
         - enforcement","description":"to be represented on an application for the
         recovery of a child/children.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM10","meaning":"Child assessment order
+        law family (PLF)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J
+        - amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM33A","meaning":"Revocation placement order
+        - appeal","description":"to be represented on an application for revocation
+        of a placement order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM30E","meaning":"Placement order - enforcement","description":"to
+        be represented on an application for a placement order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36","meaning":"Care order - joined party","description":"to
+        be represented on an application for a care order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29A","meaning":"Exclusion requirement
+        - appeal","description":"to be represented on an application to vary/discharge
+        an exclusion requirement.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM06A","meaning":"Supervision order - appeal
         - vary or discharge","description":"to be represented on an application to
-        vary or discharge a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM10A","meaning":"Child assessment order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a child assessment order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11","meaning":"End contact with a child
-        in care","description":"to be represented on an application to terminate contact
-        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11A","meaning":"End contact with a child
-        in care - appeal","description":"to be represented on an application to terminate
-        contact with a child/children in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11E","meaning":"End contact with a child
+        vary or discharge a supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32","meaning":"Special guardianship order","description":"to
+        be represented on an application for a Special Guardianship Order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PB003","meaning":"Child assessment order","description":"to
+        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PB006","meaning":"Secure accommodation order","description":"to
+        be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM11E","meaning":"End contact with a child
         in care - enforcement","description":"to be represented on an application
         to terminate contact with a child/children in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM13","meaning":"Substitute supervision
-        with care","description":"to be represented on an application to substitute
-        a supervision order with care order under section 39 (4) Children Act 1989.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM13A","meaning":"Substitute supervision
-        with care - appeal","description":"to be represented on an application to
-        substitute a supervision order with care order under section 39 (4) Children
-        Act 1989. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM16","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary or discharge","description":"to be represented
+        on an application to vary or discharge a contact order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J
+        - appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM17E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32E","meaning":"Special guardianship order
+        - enforcement","description":"to be represented on an application for a Special
+        Guardianship Order . Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM20E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM35A","meaning":"Special guardianship order
+        - appeal - vary or discharge","description":"To be represented on an application
+        for variation/discharge of a special guardianship order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM16A","meaning":"Prohibited steps order
         - appeal","description":"to be represented on an application for a prohibited
         steps order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM16E","meaning":"Prohibited steps order
+        law family (PLF)"},{"ccms_code":"PBM05A","meaning":"Contact with a child in
+        care - appeal","description":"to be represented on an application for contact
+        with a child in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM10","meaning":"Child assessment order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order - who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM05E","meaning":"Contact with a child in
+        care - enforcement","description":"to be represented on an application for
+        contact with a child in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM30","meaning":"Placement order","description":"to
+        be represented on an application for a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19","meaning":"Child arrangements order
+        (CAO) - residence - vary or discharge","description":"to be represented on
+        an application to vary or discharge a residence order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM24E","meaning":"Supervision order - enforcement","description":"to
+        be represented on an application for a supervision order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
+        - appeal","description":"to be represented on an application for a prohibited
+        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM10A","meaning":"Child assessment order
+        - appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a child assessment order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM45","meaning":"Adoption order - parent
+        or parental responsibility","description":"To represent a parent or person
+        with parental responsibility on an application for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM26E","meaning":"Child assessment order
+        - enforcement","description":"to be represented on an application for a child
+        assessment order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary or discharge","description":"to be represented
+        on an application to vary or discharge a contact order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM35","meaning":"Special guardianship order
+        - vary or discharge","description":"To be represented on an application for
+        variation/discharge of a special guardianship order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM01A","meaning":"Declaration for overseas
+        adoption - appeal","description":"to be represented on an application for
+        a declaration as to an overseas adoption.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM16E","meaning":"Prohibited steps order
         - enforcement","description":"to be represented on an application for a prohibited
         steps order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM17","meaning":"Specific issue order","description":"to
         be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18","meaning":"Child arrangements order
-        (CAO) - contact - vary or discharge","description":"to be represented on an
-        application to vary or discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary or discharge","description":"to be represented
-        on an application to vary or discharge a contact order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary or discharge","description":"to be represented
-        on an application to vary or discharge a contact order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19","meaning":"Child arrangements order
-        (CAO) - residence - vary or discharge","description":"to be represented on
-        an application to vary or discharge a residence order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary or discharge","description":"to be represented
-        on an application to vary or discharge a residence order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary or discharge","description":"to be
-        represented on an application to vary or discharge a residence order. Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20","meaning":"Prohibited steps order
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21","meaning":"Specific issue order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM22A","meaning":"Parental responsibility
-        - appeal","description":"to be represented on an application for parental
-        responsibility.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23","meaning":"Care order","description":"to
-        be represented on an application for a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23A","meaning":"Care order - appeal","description":"to
-        be represented on an application for a care order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23E","meaning":"Care order - enforcement","description":"to
-        be represented on an application for a care order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24","meaning":"Supervision order","description":"to
-        be represented on an application for a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24A","meaning":"Supervision order - appeal","description":"to
-        be represented on an application for a supervision order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24E","meaning":"Supervision order - enforcement","description":"to
-        be represented on an application for a supervision order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26","meaning":"Child assessment order","description":"to
-        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26A","meaning":"Child assessment order
-        - appeal","description":"to be represented on an application for a child assessment
-        order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26E","meaning":"Child assessment order
-        - enforcement","description":"to be represented on an application for a child
-        assessment order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27","meaning":"Emergency protection order","description":"to
-        be represented on an application for or to extend an emergency protection
-        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27A","meaning":"Emergency protection order
-        - appeal","description":"to be represented on an application for or to extend
-        an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27E","meaning":"Emergency protection order
-        - enforcement","description":"to be represented on an application for or to
-        extend an emergency protection order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM28","meaning":"Emergency protection order
-        - discharge","description":"to be represented on an application to discharge
-        an emergency protection order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM28A","meaning":"Emergency protection order
-        - appeal - discharge","description":"to be represented on an application to
-        discharge an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29","meaning":"Exclusion requirement","description":"to
-        be represented on an application to vary/discharge an exclusion requirement.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29A","meaning":"Exclusion requirement
-        - appeal","description":"to be represented on an application to vary/discharge
-        an exclusion requirement.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29E","meaning":"Exclusion requirement
-        - enforcement","description":"to be represented on an application to vary/discharge
-        an exclusion requirement.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30","meaning":"Placement order","description":"to
-        be represented on an application for a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30A","meaning":"Placement order - appeal","description":"to
-        be represented on an application for a placement order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30E","meaning":"Placement order - enforcement","description":"to
-        be represented on an application for a placement order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32","meaning":"Special guardianship order","description":"to
-        be represented on an application for a Special Guardianship Order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32A","meaning":"Special guardianship order
-        - appeal","description":"to be represented on an application for a Special
-        Guardianship Order . Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32E","meaning":"Special guardianship order
-        - enforcement","description":"to be represented on an application for a Special
-        Guardianship Order . Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33","meaning":"Revocation placement order","description":"to
-        be represented on an application for revocation of a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33A","meaning":"Revocation placement order
-        - appeal","description":"to be represented on an application for revocation
-        of a placement order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM33E","meaning":"Revocation placement order
         - enforcement","description":"to be represented on an application for revocation
         of a placement order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35","meaning":"Special guardianship order
-        - vary or discharge","description":"To be represented on an application for
-        variation/discharge of a special guardianship order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35A","meaning":"Special guardianship order
-        - appeal - vary or discharge","description":"To be represented on an application
-        for variation/discharge of a special guardianship order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35E","meaning":"Special guardianship order
-        - enforcement - vary or discharge","description":"To be represented on an
-        application for variation/discharge of a special guardianship order.  Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36","meaning":"Care order - joined party","description":"to
-        be represented on an application for a care order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36A","meaning":"Care order - joined party
-        - appeal","description":"to be represented on an application for a care order
-        Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36E","meaning":"Care order - joined party
-        - enforcement","description":"to be represented on an application for a care
-        order Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37","meaning":"Supervision order - joined
-        party","description":"to be represented on an application for a supervision
-        order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37A","meaning":"Supervision order - joined
+        law family (PLF)"},{"ccms_code":"PBM21A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM22","meaning":"Parental responsibility","description":"to
+        be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27A","meaning":"Emergency protection order
+        - appeal","description":"to be represented on an application for or to extend
+        an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM04A","meaning":"Secure accommodation order
+        - appeal","description":"to be represented on an application for a secure
+        accommodation order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM08E","meaning":"Education supervision
+        order - enforcement","description":"to be represented on an application for
+        an education supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE014","meaning":"Child arrangements order
+        (CAO) - residence","description":"to be represented on an application for
+        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM37A","meaning":"Supervision order - joined
         party - appeal","description":"to be represented on an application for a supervision
         order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37E","meaning":"Supervision order - joined
-        party - enforcement","description":"to be represented on an application for
-        a supervision order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order - who the child(ren) spend time with","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order - who the child(ren) spend time with. Appeals
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order - who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM39","meaning":"Child arrangements order
         (CAO) - residence","description":"to be represented on an application for
         a child arrangements order - where the child(ren) will live.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order - where the child(ren) will live. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order - where the child(ren) will live. Enforcement
+        law family (PLF)"},{"ccms_code":"PBM13","meaning":"Substitute supervision
+        with care","description":"to be represented on an application to substitute
+        a supervision order with care order under section 39 (4) Children Act 1989.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM05","meaning":"Contact with a child in
+        care","description":"to be represented on an application for contact with
+        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24A","meaning":"Supervision order - appeal","description":"to
+        be represented on an application for a supervision order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM08","meaning":"Education supervision order","description":"to
+        be represented on an application for an education supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM07","meaning":"Care order - discharge","description":"to
+        be represented on an application to discharge a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary or discharge","description":"to be represented
+        on an application to vary or discharge a residence order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM23E","meaning":"Care order - enforcement","description":"to
+        be represented on an application for a care order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order - who the child(ren) spend time with","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM09A","meaning":"Recovery of children order
+        - appeal","description":"to be represented on an application for the recovery
+        of a child/children.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM11","meaning":"End contact with a child
+        in care","description":"to be represented on an application to terminate contact
+        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM35E","meaning":"Special guardianship order
+        - enforcement - vary or discharge","description":"To be represented on an
+        application for variation/discharge of a special guardianship order.  Enforcement
         only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB026","meaning":"Emergency protection order","description":"to
+        be represented on an application for an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM26","meaning":"Child assessment order","description":"to
+        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM09","meaning":"Recovery of children order","description":"to
+        be represented on an application for the recovery of a child/children.  Appeals
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM37E","meaning":"Supervision order - joined
+        party - enforcement","description":"to be represented on an application for
+        a supervision order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM40","meaning":"Placement order - parent
         or parental responsibility","description":"To represent a parent or person
         with parental responsibility on an application for a placement order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM40E","meaning":"Placement order - parent
-        or parental responsibility - enforcement","description":"To represent a parent
-        or person with parental responsibility on an application for a placement order.
-        Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM45","meaning":"Adoption order - parent
-        or parental responsibility","description":"To represent a parent or person
-        with parental responsibility on an application for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM11A","meaning":"End contact with a child
+        in care - appeal","description":"to be represented on an application to terminate
+        contact with a child/children in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM45E","meaning":"Adoption order - parent
         or parental responsibility - enforcement","description":"To represent a parent
         or person with parental responsibility on an application for a placement order.
         Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24","meaning":"Supervision order","description":"to
+        be represented on an application for a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18","meaning":"Child arrangements order
+        (CAO) - contact - vary or discharge","description":"to be represented on an
+        application to vary or discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM39A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order - where the child(ren) will live. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM21E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM13A","meaning":"Substitute supervision
+        with care - appeal","description":"to be represented on an application to
+        substitute a supervision order with care order under section 39 (4) Children
+        Act 1989. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary","description":"to be represented on an
+        application to vary or discharge a child arrangements order –where the child(ren)
+        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM07A","meaning":"Care order - appeal - discharge","description":"to
+        be represented on an application to discharge a care order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary or discharge","description":"to be
+        represented on an application to vary or discharge a residence order. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM33","meaning":"Revocation placement order","description":"to
+        be represented on an application for revocation of a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM06E","meaning":"Supervision order - enforcement
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order - who the child(ren) spend time with. Appeals
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM16","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29E","meaning":"Exclusion requirement
+        - enforcement","description":"to be represented on an application to vary/discharge
+        an exclusion requirement.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
+        for an injunction, order or declaration under the inherent jurisdiction of
+        the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM20A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA002","meaning":"Protection from harassment
+        act 1997 under section 5 - vary or discharge","description":"to be represented
+        on an application to vary or discharge an order under section 5 Protection
+        from Harassment Act 1997 where the parties are associated persons (as defined
+        by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM07E","meaning":"Care order - enforcement - discharge","description":"to
+        be represented on an application to discharge a care order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM37","meaning":"Supervision order - joined
+        party","description":"to be represented on an application for a supervision
+        order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM26A","meaning":"Child assessment order
+        - appeal","description":"to be represented on an application for a child assessment
+        order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM39E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order - where the child(ren) will live. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29","meaning":"Exclusion requirement","description":"to
+        be represented on an application to vary/discharge an exclusion requirement.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM28A","meaning":"Emergency protection order
+        - appeal - discharge","description":"to be represented on an application to
+        discharge an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM40E","meaning":"Placement order - parent
+        or parental responsibility - enforcement","description":"To represent a parent
+        or person with parental responsibility on an application for a placement order.
+        Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J
+        and committal","description":"to be represented on an application for committal
+        and for an enforcement order under section 11J Children Act 1989. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM21","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27E","meaning":"Emergency protection order
+        - enforcement","description":"to be represented on an application for or to
+        extend an emergency protection order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:18 GMT
+  recorded_at: Wed, 07 May 2025 15:59:05 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
@@ -615,14 +611,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:21 GMT
+      - Wed, 07 May 2025 15:59:07 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -642,443 +638,439 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"93565432497c5ce191eac6fbf69b9a81"
+      - W/"f5d4a442765bb4b1da38aa01d431b319"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 8d65228ebdcdca7999500812f41c53dc
+      - ab1a1d24dcc167ed5c85e8f68ce02540
       x-runtime:
-      - '0.023164'
+      - '0.033528'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
-        for an injunction, order or declaration under the inherent jurisdiction of
-        the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
-        1997 under section 5 - vary or discharge","description":"to be represented
-        on an application to vary or discharge an order under section 5 Protection
-        from Harassment Act 1997 where the parties are associated persons (as defined
-        by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
-        (CAO) - residence","description":"to be represented on an application for
-        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PB003","meaning":"Child assessment order","description":"to
-        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB004","meaning":"Emergency protection
-        order - extend","description":"to be represented on an application for or
-        to extend an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB005","meaning":"Emergency protection
-        order - discharge","description":"to be represented on an application to discharge
-        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB006","meaning":"Secure accommodation
-        order","description":"to be represented on an application for a secure accommodation
-        order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB026","meaning":"Emergency protection
-        order","description":"to be represented on an application for an emergency
-        protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB057","meaning":"Care order","description":"to
-        be represented on an application for a care order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB059","meaning":"Supervision order","description":"to
+      string: '{"success":true,"data":[{"ccms_code":"PBM06","meaning":"Supervision
+        order - vary or discharge","description":"to be represented on an application
+        to vary or discharge a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB059","meaning":"Supervision order","description":"to
         be represented on an application for a supervision order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PBM01","meaning":"Declaration for overseas
         adoption","description":"to be represented on an application for a declaration
         as to an overseas adoption.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM01A","meaning":"Declaration for overseas
-        adoption - appeal","description":"to be represented on an application for
-        a declaration as to an overseas adoption.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM02","meaning":"Adoption - not being held
-        in family proceedings court","description":"to be represented on an application
-        for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM02A","meaning":"Adoption order - appeal","description":"to
-        be represented on an application for an adoption order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM02E","meaning":"Adoption order - enforcement","description":"to
         be represented on an application for an adoption order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36E","meaning":"Care order - joined party
+        - enforcement","description":"to be represented on an application for a care
+        order Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB057","meaning":"Care order","description":"to
+        be represented on an application for a care order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM02A","meaning":"Adoption order - appeal","description":"to
+        be represented on an application for an adoption order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM04","meaning":"Secure accommodation order","description":"to
         be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM22","meaning":"Parental responsibility","description":"to
-        be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM04A","meaning":"Secure accommodation order
-        - appeal","description":"to be represented on an application for a secure
-        accommodation order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM04E","meaning":"Secure accommodation order
-        - enforcement","description":"to be represented on an application for a secure
-        accommodation order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05","meaning":"Contact with a child in
-        care","description":"to be represented on an application for contact with
-        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05A","meaning":"Contact with a child in
-        care - appeal","description":"to be represented on an application for contact
-        with a child in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05E","meaning":"Contact with a child in
-        care - enforcement","description":"to be represented on an application for
-        contact with a child in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06","meaning":"Supervision order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06A","meaning":"Supervision order - appeal
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06E","meaning":"Supervision order - enforcement
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07","meaning":"Care order - discharge","description":"to
-        be represented on an application to discharge a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07A","meaning":"Care order - appeal -
-        discharge","description":"to be represented on an application to discharge
-        a care order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07E","meaning":"Care order - enforcement
-        - discharge","description":"to be represented on an application to discharge
-        a care order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM08","meaning":"Education supervision order","description":"to
-        be represented on an application for an education supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM08A","meaning":"Education supervision
         order - appeal","description":"to be represented on an application for an
         education supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM08E","meaning":"Education supervision
-        order - enforcement","description":"to be represented on an application for
-        an education supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM09","meaning":"Recovery of children order","description":"to
-        be represented on an application for the recovery of a child/children.  Appeals
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM09A","meaning":"Recovery of children order
-        - appeal","description":"to be represented on an application for the recovery
-        of a child/children.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM04E","meaning":"Secure accommodation order
+        - enforcement","description":"to be represented on an application for a secure
+        accommodation order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
+        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM30A","meaning":"Placement order - appeal","description":"to
+        be represented on an application for a placement order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27","meaning":"Emergency protection order","description":"to
+        be represented on an application for or to extend an emergency protection
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM28","meaning":"Emergency protection order
+        - discharge","description":"to be represented on an application to discharge
+        an emergency protection order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM17A","meaning":"Specific issue order - appeal","description":"to
+        be represented on an application for a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB005","meaning":"Emergency protection order
+        - discharge","description":"to be represented on an application to discharge
+        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM23A","meaning":"Care order - appeal","description":"to
+        be represented on an application for a care order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36A","meaning":"Care order - joined party
+        - appeal","description":"to be represented on an application for a care order
+        Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB004","meaning":"Emergency protection order
+        - extend","description":"to be represented on an application for or to extend
+        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM22A","meaning":"Parental responsibility
+        - appeal","description":"to be represented on an application for parental
+        responsibility.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32A","meaning":"Special guardianship order
+        - appeal","description":"to be represented on an application for a Special
+        Guardianship Order . Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM20","meaning":"Prohibited steps order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM02","meaning":"Adoption - not being held
+        in family proceedings court","description":"to be represented on an application
+        for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE007","meaning":"Prohibited steps order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM23","meaning":"Care order","description":"to
+        be represented on an application for a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM09E","meaning":"Recovery of children order
         - enforcement","description":"to be represented on an application for the
         recovery of a child/children.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM10","meaning":"Child assessment order
+        law family (PLF)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J
+        - amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM33A","meaning":"Revocation placement order
+        - appeal","description":"to be represented on an application for revocation
+        of a placement order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM30E","meaning":"Placement order - enforcement","description":"to
+        be represented on an application for a placement order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36","meaning":"Care order - joined party","description":"to
+        be represented on an application for a care order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29A","meaning":"Exclusion requirement
+        - appeal","description":"to be represented on an application to vary/discharge
+        an exclusion requirement.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM06A","meaning":"Supervision order - appeal
         - vary or discharge","description":"to be represented on an application to
-        vary or discharge a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM10A","meaning":"Child assessment order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a child assessment order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11","meaning":"End contact with a child
-        in care","description":"to be represented on an application to terminate contact
-        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11A","meaning":"End contact with a child
-        in care - appeal","description":"to be represented on an application to terminate
-        contact with a child/children in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11E","meaning":"End contact with a child
+        vary or discharge a supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32","meaning":"Special guardianship order","description":"to
+        be represented on an application for a Special Guardianship Order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PB003","meaning":"Child assessment order","description":"to
+        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PB006","meaning":"Secure accommodation order","description":"to
+        be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM11E","meaning":"End contact with a child
         in care - enforcement","description":"to be represented on an application
         to terminate contact with a child/children in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM13","meaning":"Substitute supervision
-        with care","description":"to be represented on an application to substitute
-        a supervision order with care order under section 39 (4) Children Act 1989.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM13A","meaning":"Substitute supervision
-        with care - appeal","description":"to be represented on an application to
-        substitute a supervision order with care order under section 39 (4) Children
-        Act 1989. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM16","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary or discharge","description":"to be represented
+        on an application to vary or discharge a contact order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J
+        - appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM17E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32E","meaning":"Special guardianship order
+        - enforcement","description":"to be represented on an application for a Special
+        Guardianship Order . Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM20E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM35A","meaning":"Special guardianship order
+        - appeal - vary or discharge","description":"To be represented on an application
+        for variation/discharge of a special guardianship order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM16A","meaning":"Prohibited steps order
         - appeal","description":"to be represented on an application for a prohibited
         steps order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM16E","meaning":"Prohibited steps order
+        law family (PLF)"},{"ccms_code":"PBM05A","meaning":"Contact with a child in
+        care - appeal","description":"to be represented on an application for contact
+        with a child in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM10","meaning":"Child assessment order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order - who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM05E","meaning":"Contact with a child in
+        care - enforcement","description":"to be represented on an application for
+        contact with a child in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM30","meaning":"Placement order","description":"to
+        be represented on an application for a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19","meaning":"Child arrangements order
+        (CAO) - residence - vary or discharge","description":"to be represented on
+        an application to vary or discharge a residence order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM24E","meaning":"Supervision order - enforcement","description":"to
+        be represented on an application for a supervision order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
+        - appeal","description":"to be represented on an application for a prohibited
+        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM10A","meaning":"Child assessment order
+        - appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a child assessment order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM45","meaning":"Adoption order - parent
+        or parental responsibility","description":"To represent a parent or person
+        with parental responsibility on an application for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM26E","meaning":"Child assessment order
+        - enforcement","description":"to be represented on an application for a child
+        assessment order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary or discharge","description":"to be represented
+        on an application to vary or discharge a contact order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM35","meaning":"Special guardianship order
+        - vary or discharge","description":"To be represented on an application for
+        variation/discharge of a special guardianship order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM01A","meaning":"Declaration for overseas
+        adoption - appeal","description":"to be represented on an application for
+        a declaration as to an overseas adoption.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM16E","meaning":"Prohibited steps order
         - enforcement","description":"to be represented on an application for a prohibited
         steps order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM17","meaning":"Specific issue order","description":"to
         be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18","meaning":"Child arrangements order
-        (CAO) - contact - vary or discharge","description":"to be represented on an
-        application to vary or discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary or discharge","description":"to be represented
-        on an application to vary or discharge a contact order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary or discharge","description":"to be represented
-        on an application to vary or discharge a contact order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19","meaning":"Child arrangements order
-        (CAO) - residence - vary or discharge","description":"to be represented on
-        an application to vary or discharge a residence order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary or discharge","description":"to be represented
-        on an application to vary or discharge a residence order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary or discharge","description":"to be
-        represented on an application to vary or discharge a residence order. Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20","meaning":"Prohibited steps order
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21","meaning":"Specific issue order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM22A","meaning":"Parental responsibility
-        - appeal","description":"to be represented on an application for parental
-        responsibility.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23","meaning":"Care order","description":"to
-        be represented on an application for a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23A","meaning":"Care order - appeal","description":"to
-        be represented on an application for a care order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23E","meaning":"Care order - enforcement","description":"to
-        be represented on an application for a care order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24","meaning":"Supervision order","description":"to
-        be represented on an application for a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24A","meaning":"Supervision order - appeal","description":"to
-        be represented on an application for a supervision order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24E","meaning":"Supervision order - enforcement","description":"to
-        be represented on an application for a supervision order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26","meaning":"Child assessment order","description":"to
-        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26A","meaning":"Child assessment order
-        - appeal","description":"to be represented on an application for a child assessment
-        order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26E","meaning":"Child assessment order
-        - enforcement","description":"to be represented on an application for a child
-        assessment order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27","meaning":"Emergency protection order","description":"to
-        be represented on an application for or to extend an emergency protection
-        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27A","meaning":"Emergency protection order
-        - appeal","description":"to be represented on an application for or to extend
-        an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27E","meaning":"Emergency protection order
-        - enforcement","description":"to be represented on an application for or to
-        extend an emergency protection order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM28","meaning":"Emergency protection order
-        - discharge","description":"to be represented on an application to discharge
-        an emergency protection order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM28A","meaning":"Emergency protection order
-        - appeal - discharge","description":"to be represented on an application to
-        discharge an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29","meaning":"Exclusion requirement","description":"to
-        be represented on an application to vary/discharge an exclusion requirement.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29A","meaning":"Exclusion requirement
-        - appeal","description":"to be represented on an application to vary/discharge
-        an exclusion requirement.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29E","meaning":"Exclusion requirement
-        - enforcement","description":"to be represented on an application to vary/discharge
-        an exclusion requirement.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30","meaning":"Placement order","description":"to
-        be represented on an application for a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30A","meaning":"Placement order - appeal","description":"to
-        be represented on an application for a placement order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30E","meaning":"Placement order - enforcement","description":"to
-        be represented on an application for a placement order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32","meaning":"Special guardianship order","description":"to
-        be represented on an application for a Special Guardianship Order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32A","meaning":"Special guardianship order
-        - appeal","description":"to be represented on an application for a Special
-        Guardianship Order . Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32E","meaning":"Special guardianship order
-        - enforcement","description":"to be represented on an application for a Special
-        Guardianship Order . Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33","meaning":"Revocation placement order","description":"to
-        be represented on an application for revocation of a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33A","meaning":"Revocation placement order
-        - appeal","description":"to be represented on an application for revocation
-        of a placement order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM33E","meaning":"Revocation placement order
         - enforcement","description":"to be represented on an application for revocation
         of a placement order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35","meaning":"Special guardianship order
-        - vary or discharge","description":"To be represented on an application for
-        variation/discharge of a special guardianship order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35A","meaning":"Special guardianship order
-        - appeal - vary or discharge","description":"To be represented on an application
-        for variation/discharge of a special guardianship order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35E","meaning":"Special guardianship order
-        - enforcement - vary or discharge","description":"To be represented on an
-        application for variation/discharge of a special guardianship order.  Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36","meaning":"Care order - joined party","description":"to
-        be represented on an application for a care order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36A","meaning":"Care order - joined party
-        - appeal","description":"to be represented on an application for a care order
-        Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36E","meaning":"Care order - joined party
-        - enforcement","description":"to be represented on an application for a care
-        order Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37","meaning":"Supervision order - joined
-        party","description":"to be represented on an application for a supervision
-        order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37A","meaning":"Supervision order - joined
+        law family (PLF)"},{"ccms_code":"PBM21A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM22","meaning":"Parental responsibility","description":"to
+        be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27A","meaning":"Emergency protection order
+        - appeal","description":"to be represented on an application for or to extend
+        an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM04A","meaning":"Secure accommodation order
+        - appeal","description":"to be represented on an application for a secure
+        accommodation order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM08E","meaning":"Education supervision
+        order - enforcement","description":"to be represented on an application for
+        an education supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE014","meaning":"Child arrangements order
+        (CAO) - residence","description":"to be represented on an application for
+        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM37A","meaning":"Supervision order - joined
         party - appeal","description":"to be represented on an application for a supervision
         order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37E","meaning":"Supervision order - joined
-        party - enforcement","description":"to be represented on an application for
-        a supervision order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order - who the child(ren) spend time with","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order - who the child(ren) spend time with. Appeals
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order - who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM39","meaning":"Child arrangements order
         (CAO) - residence","description":"to be represented on an application for
         a child arrangements order - where the child(ren) will live.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order - where the child(ren) will live. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order - where the child(ren) will live. Enforcement
+        law family (PLF)"},{"ccms_code":"PBM13","meaning":"Substitute supervision
+        with care","description":"to be represented on an application to substitute
+        a supervision order with care order under section 39 (4) Children Act 1989.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM05","meaning":"Contact with a child in
+        care","description":"to be represented on an application for contact with
+        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24A","meaning":"Supervision order - appeal","description":"to
+        be represented on an application for a supervision order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM08","meaning":"Education supervision order","description":"to
+        be represented on an application for an education supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM07","meaning":"Care order - discharge","description":"to
+        be represented on an application to discharge a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary or discharge","description":"to be represented
+        on an application to vary or discharge a residence order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM23E","meaning":"Care order - enforcement","description":"to
+        be represented on an application for a care order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order - who the child(ren) spend time with","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM09A","meaning":"Recovery of children order
+        - appeal","description":"to be represented on an application for the recovery
+        of a child/children.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM11","meaning":"End contact with a child
+        in care","description":"to be represented on an application to terminate contact
+        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM35E","meaning":"Special guardianship order
+        - enforcement - vary or discharge","description":"To be represented on an
+        application for variation/discharge of a special guardianship order.  Enforcement
         only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB026","meaning":"Emergency protection order","description":"to
+        be represented on an application for an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM26","meaning":"Child assessment order","description":"to
+        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM09","meaning":"Recovery of children order","description":"to
+        be represented on an application for the recovery of a child/children.  Appeals
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM37E","meaning":"Supervision order - joined
+        party - enforcement","description":"to be represented on an application for
+        a supervision order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM40","meaning":"Placement order - parent
         or parental responsibility","description":"To represent a parent or person
         with parental responsibility on an application for a placement order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM40E","meaning":"Placement order - parent
-        or parental responsibility - enforcement","description":"To represent a parent
-        or person with parental responsibility on an application for a placement order.
-        Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM45","meaning":"Adoption order - parent
-        or parental responsibility","description":"To represent a parent or person
-        with parental responsibility on an application for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM11A","meaning":"End contact with a child
+        in care - appeal","description":"to be represented on an application to terminate
+        contact with a child/children in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM45E","meaning":"Adoption order - parent
         or parental responsibility - enforcement","description":"To represent a parent
         or person with parental responsibility on an application for a placement order.
         Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24","meaning":"Supervision order","description":"to
+        be represented on an application for a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18","meaning":"Child arrangements order
+        (CAO) - contact - vary or discharge","description":"to be represented on an
+        application to vary or discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM39A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order - where the child(ren) will live. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM21E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM13A","meaning":"Substitute supervision
+        with care - appeal","description":"to be represented on an application to
+        substitute a supervision order with care order under section 39 (4) Children
+        Act 1989. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary","description":"to be represented on an
+        application to vary or discharge a child arrangements order –where the child(ren)
+        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM07A","meaning":"Care order - appeal - discharge","description":"to
+        be represented on an application to discharge a care order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary or discharge","description":"to be
+        represented on an application to vary or discharge a residence order. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM33","meaning":"Revocation placement order","description":"to
+        be represented on an application for revocation of a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM06E","meaning":"Supervision order - enforcement
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order - who the child(ren) spend time with. Appeals
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM16","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29E","meaning":"Exclusion requirement
+        - enforcement","description":"to be represented on an application to vary/discharge
+        an exclusion requirement.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
+        for an injunction, order or declaration under the inherent jurisdiction of
+        the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM20A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA002","meaning":"Protection from harassment
+        act 1997 under section 5 - vary or discharge","description":"to be represented
+        on an application to vary or discharge an order under section 5 Protection
+        from Harassment Act 1997 where the parties are associated persons (as defined
+        by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM07E","meaning":"Care order - enforcement - discharge","description":"to
+        be represented on an application to discharge a care order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM37","meaning":"Supervision order - joined
+        party","description":"to be represented on an application for a supervision
+        order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM26A","meaning":"Child assessment order
+        - appeal","description":"to be represented on an application for a child assessment
+        order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM39E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order - where the child(ren) will live. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29","meaning":"Exclusion requirement","description":"to
+        be represented on an application to vary/discharge an exclusion requirement.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM28A","meaning":"Emergency protection order
+        - appeal - discharge","description":"to be represented on an application to
+        discharge an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM40E","meaning":"Placement order - parent
+        or parental responsibility - enforcement","description":"To represent a parent
+        or person with parental responsibility on an application for a placement order.
+        Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J
+        and committal","description":"to be represented on an application for committal
+        and for an enforcement order under section 11J Children Act 1989. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM21","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27E","meaning":"Emergency protection order
+        - enforcement","description":"to be represented on an application for or to
+        extend an emergency protection order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:21 GMT
+  recorded_at: Wed, 07 May 2025 15:59:07 GMT
 - request:
     method: get
-    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE014A
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE016A
     body:
       encoding: US-ASCII
       string: ''
@@ -1086,18 +1078,18 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:21 GMT
+      - Wed, 07 May 2025 15:59:07 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '1122'
+      - '1151'
       connection:
       - keep-alive
       x-frame-options:
@@ -1113,50 +1105,50 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"f45b218af96b2d31f74762ce30efa40e"
+      - W/"46479618f2daf466ea680e3ae7a88861"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - f9132d23743ee676b4d9532e6a397c87
+      - 0e6a501ee206243b6415cd72bfd5589f
       x-runtime:
-      - '0.008025'
+      - '0.014495'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"ccms_code":"SE014A","meaning":"Child arrangements
-        order (CAO) - residence - appeal","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","name":"cao_residence_appeal","description":"to
-        be represented on an application for a child arrangements order –where the
-        child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_matter":"section
+      string: '{"success":true,"ccms_code":"SE016A","meaning":"Child arrangements
+        order (CAO) - residence - appeal - vary","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","name":"vary_cao_redidence_appeal","description":"to
+        be represented on an application to vary or discharge a child arrangements
+        order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_matter":"section
         8 children (S8)","cost_limitations":{"substantive":{"start_date":"1970-01-01","value":"5000.0"},"delegated_functions":{"start_date":"2021-09-13","value":"2250.0"}},"default_scope_limitations":{"substantive":{"code":"CV079","meaning":"Counsel''s
         Opinion","description":"Limited to obtaining external Counsel''s Opinion or
         the opinion of an external solicitor with higher court advocacy rights on
         the information already available."},"delegated_functions":{"code":"CV118","meaning":"Hearing","description":"Limited
         to all steps up to and including the hearing on [see additional limitation
         notes]"}},"service_levels":[{"level":3,"name":"Full Representation","stage":8,"proceeding_default":true}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:21 GMT
+  recorded_at: Wed, 07 May 2025 15:59:07 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
     body:
       encoding: UTF-8
-      string: '{"current_proceedings":["SE014A"],"allowed_categories":["MAT"],"search_term":""}'
+      string: '{"current_proceedings":["SE016A"],"allowed_categories":["MAT"],"search_term":""}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:22 GMT
+      - Wed, 07 May 2025 15:59:07 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '16225'
+      - '16201'
       connection:
       - keep-alive
       x-frame-options:
@@ -1172,19 +1164,135 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"cb87d3773effb9402773dc1f4d2451b5"
+      - W/"05989f0afa888da76d32d0605f4d5421"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 8c33cfa22d1148534a6a7b740a565d37
+      - e82151ee0b6efe7d6278a36a1586e33f
       x-runtime:
-      - '0.042197'
+      - '0.055218'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
+      string: '{"success":true,"data":[{"ccms_code":"DA004","meaning":"Non-molestation
+        order","description":"to be represented on an application for a non-molestation
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
+        vary or discharge","description":"to be represented on an application to vary
+        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
+        amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
+        appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order - appeal","description":"to
+        be represented on an application for a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
+        (CAO) - residence","description":"to be represented on an application for
+        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
         for an injunction, order or declaration under the inherent jurisdiction of
         the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
         abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
@@ -1192,150 +1300,33 @@ http_interactions:
         on an application to vary or discharge an order under section 5 Protection
         from Harassment Act 1997 where the parties are associated persons (as defined
         by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
-        (CAO) - residence","description":"to be represented on an application for
-        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        abuse (DA)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and committal","description":"to
+        be represented on an application for committal and for an enforcement order
+        under section 11J Children Act 1989. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
         8 children (S8)"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:21 GMT
+  recorded_at: Wed, 07 May 2025 15:59:07 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
     body:
       encoding: UTF-8
-      string: '{"current_proceedings":["SE014A"],"allowed_categories":["MAT"],"search_term":""}'
+      string: '{"current_proceedings":["SE016A"],"allowed_categories":["MAT"],"search_term":""}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:23 GMT
+      - Wed, 07 May 2025 15:59:08 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '16225'
+      - '16201'
       connection:
       - keep-alive
       x-frame-options:
@@ -1351,19 +1342,135 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"cb87d3773effb9402773dc1f4d2451b5"
+      - W/"05989f0afa888da76d32d0605f4d5421"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 554ed2196bc7e2d2dffa47de96e7d622
+      - 4bbda1568b5b0b45de62bb5fd8d7f89a
       x-runtime:
-      - '0.036212'
+      - '0.046685'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
+      string: '{"success":true,"data":[{"ccms_code":"DA004","meaning":"Non-molestation
+        order","description":"to be represented on an application for a non-molestation
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
+        vary or discharge","description":"to be represented on an application to vary
+        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
+        amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
+        appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order - appeal","description":"to
+        be represented on an application for a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
+        (CAO) - residence","description":"to be represented on an application for
+        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
         for an injunction, order or declaration under the inherent jurisdiction of
         the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
         abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
@@ -1371,150 +1478,33 @@ http_interactions:
         on an application to vary or discharge an order under section 5 Protection
         from Harassment Act 1997 where the parties are associated persons (as defined
         by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
-        (CAO) - residence","description":"to be represented on an application for
-        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        abuse (DA)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and committal","description":"to
+        be represented on an application for committal and for an enforcement order
+        under section 11J Children Act 1989. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
         8 children (S8)"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:22 GMT
+  recorded_at: Wed, 07 May 2025 15:59:08 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
     body:
       encoding: UTF-8
-      string: '{"current_proceedings":["SE014A"],"allowed_categories":["MAT"],"search_term":""}'
+      string: '{"current_proceedings":["SE016A"],"allowed_categories":["MAT"],"search_term":""}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:24 GMT
+      - Wed, 07 May 2025 15:59:09 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '16225'
+      - '16201'
       connection:
       - keep-alive
       x-frame-options:
@@ -1530,19 +1520,135 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"cb87d3773effb9402773dc1f4d2451b5"
+      - W/"05989f0afa888da76d32d0605f4d5421"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - a3945fc3acca64a21310c811fa5b6f8b
+      - df5fe712b64208c0b7b41344c3fcae22
       x-runtime:
-      - '0.037331'
+      - '0.046918'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
+      string: '{"success":true,"data":[{"ccms_code":"DA004","meaning":"Non-molestation
+        order","description":"to be represented on an application for a non-molestation
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
+        vary or discharge","description":"to be represented on an application to vary
+        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
+        amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
+        appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order - appeal","description":"to
+        be represented on an application for a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
+        (CAO) - residence","description":"to be represented on an application for
+        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
         for an injunction, order or declaration under the inherent jurisdiction of
         the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
         abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
@@ -1550,128 +1656,11 @@ http_interactions:
         on an application to vary or discharge an order under section 5 Protection
         from Harassment Act 1997 where the parties are associated persons (as defined
         by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
-        (CAO) - residence","description":"to be represented on an application for
-        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        abuse (DA)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and committal","description":"to
+        be represented on an application for committal and for an enforcement order
+        under section 11J Children Act 1989. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
         8 children (S8)"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:24 GMT
+  recorded_at: Wed, 07 May 2025 15:59:09 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE095
@@ -1682,14 +1671,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:24 GMT
+      - Wed, 07 May 2025 15:59:10 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1713,9 +1702,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - abf5ba581b46dca80fb1c5f90a817c09
+      - 6e5fa14212a896b0b2189f01409e8220
       x-runtime:
-      - '0.008482'
+      - '0.011304'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1733,29 +1722,29 @@ http_interactions:
         representation on the return date."}},"service_levels":[{"level":1,"name":"Family
         Help (Higher)","stage":1,"proceeding_default":true},{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":false}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:24 GMT
+  recorded_at: Wed, 07 May 2025 15:59:10 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
     body:
       encoding: UTF-8
-      string: '{"current_proceedings":["SE014A","SE095"],"allowed_categories":["MAT"],"search_term":""}'
+      string: '{"current_proceedings":["SE016A","SE095"],"allowed_categories":["MAT"],"search_term":""}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:25 GMT
+      - Wed, 07 May 2025 15:59:10 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '15823'
+      - '15799'
       connection:
       - keep-alive
       x-frame-options:
@@ -1771,19 +1760,132 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"e2d46cd2e8ac121622596f0192ae1782"
+      - W/"b578a985e9a647f56af14435388ed164"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 80e803d9ed42332111613e1e75b2497e
+      - 85fb0d519f3a16d1e0c21937a6fa68d4
       x-runtime:
-      - '0.049275'
+      - '0.043335'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
+      string: '{"success":true,"data":[{"ccms_code":"DA004","meaning":"Non-molestation
+        order","description":"to be represented on an application for a non-molestation
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
+        vary or discharge","description":"to be represented on an application to vary
+        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
+        amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
+        appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order - appeal","description":"to
+        be represented on an application for a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
+        (CAO) - residence","description":"to be represented on an application for
+        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
         for an injunction, order or declaration under the inherent jurisdiction of
         the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
         abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
@@ -1791,128 +1893,14 @@ http_interactions:
         on an application to vary or discharge an order under section 5 Protection
         from Harassment Act 1997 where the parties are associated persons (as defined
         by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
-        (CAO) - residence","description":"to be represented on an application for
-        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        abuse (DA)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and committal","description":"to
+        be represented on an application for committal and for an enforcement order
+        under section 11J Children Act 1989. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
         8 children (S8)"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:24 GMT
+  recorded_at: Wed, 07 May 2025 15:59:10 GMT
 - request:
     method: get
-    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/SE014A
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/SE016A
     body:
       encoding: US-ASCII
       string: ''
@@ -1920,14 +1908,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:26 GMT
+      - Wed, 07 May 2025 15:59:11 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1951,9 +1939,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 83231462efead61373685791a51b4c23
+      - bd7534419488e907497683e25c83c6f5
       x-runtime:
-      - '0.001942'
+      - '0.002650'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1961,10 +1949,10 @@ http_interactions:
       string: '{"success":true,"client_involvement_type":[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:25 GMT
+  recorded_at: Wed, 07 May 2025 15:59:11 GMT
 - request:
     method: get
-    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/SE014A
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/SE016A
     body:
       encoding: US-ASCII
       string: ''
@@ -1972,14 +1960,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:27 GMT
+      - Wed, 07 May 2025 15:59:11 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2003,9 +1991,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 253a139d7064aa419fe326ffcf607b1d
+      - 45b4ada976067bce612045418d97fee9
       x-runtime:
-      - '0.001806'
+      - '0.002466'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2013,25 +2001,25 @@ http_interactions:
       string: '{"success":true,"client_involvement_type":[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:26 GMT
+  recorded_at: Wed, 07 May 2025 15:59:11 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
     body:
       encoding: UTF-8
-      string: '{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":true,"client_involvement_type":"A"}'
+      string: '{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":true,"client_involvement_type":"A"}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:29 GMT
+      - Wed, 07 May 2025 15:59:13 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2051,40 +2039,40 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"c7645a6c1803d661969899b2e1493ef4"
+      - W/"89cd07cc1047be7589fc77034f445480"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - d14eaf6630535b6eb95bcdaf885a68c9
+      - 380978c28e35dcf83f2385f190279607
       x-runtime:
-      - '0.004485'
+      - '0.008351'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":true,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":true,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
         Representation","stage":8},"default_scope":{"code":"CV118","meaning":"Hearing","description":"Limited
         to all steps up to and including the hearing on [see additional limitation
         notes]","additional_params":[{"name":"hearing_date","type":"date","mandatory":true}]}}'
-  recorded_at: Fri, 14 Mar 2025 09:31:28 GMT
+  recorded_at: Wed, 07 May 2025 15:59:13 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
     body:
       encoding: UTF-8
-      string: '{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":true,"client_involvement_type":"A"}'
+      string: '{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":true,"client_involvement_type":"A"}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:29 GMT
+      - Wed, 07 May 2025 15:59:14 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2104,25 +2092,25 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"c7645a6c1803d661969899b2e1493ef4"
+      - W/"89cd07cc1047be7589fc77034f445480"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 76a7b10fd75b5cf6f210cdebd0841dbd
+      - 37580ba5f6d4c4059410fd52741e790a
       x-runtime:
-      - '0.005605'
+      - '0.009446'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":true,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":true,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
         Representation","stage":8},"default_scope":{"code":"CV118","meaning":"Hearing","description":"Limited
         to all steps up to and including the hearing on [see additional limitation
         notes]","additional_params":[{"name":"hearing_date","type":"date","mandatory":true}]}}'
-  recorded_at: Fri, 14 Mar 2025 09:31:29 GMT
+  recorded_at: Wed, 07 May 2025 15:59:14 GMT
 - request:
     method: get
-    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE014A
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE016A
     body:
       encoding: US-ASCII
       string: ''
@@ -2130,18 +2118,18 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:30 GMT
+      - Wed, 07 May 2025 15:59:14 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '1122'
+      - '1151'
       connection:
       - keep-alive
       x-frame-options:
@@ -2157,31 +2145,31 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"f45b218af96b2d31f74762ce30efa40e"
+      - W/"46479618f2daf466ea680e3ae7a88861"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 68b33519860d7493f5b3a82d5a8305a4
+      - 55fe4e45aef6aaa96f348d8b97661d31
       x-runtime:
-      - '0.007489'
+      - '0.013566'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"ccms_code":"SE014A","meaning":"Child arrangements
-        order (CAO) - residence - appeal","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","name":"cao_residence_appeal","description":"to
-        be represented on an application for a child arrangements order –where the
-        child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_matter":"section
+      string: '{"success":true,"ccms_code":"SE016A","meaning":"Child arrangements
+        order (CAO) - residence - appeal - vary","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","name":"vary_cao_redidence_appeal","description":"to
+        be represented on an application to vary or discharge a child arrangements
+        order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_matter":"section
         8 children (S8)","cost_limitations":{"substantive":{"start_date":"1970-01-01","value":"5000.0"},"delegated_functions":{"start_date":"2021-09-13","value":"2250.0"}},"default_scope_limitations":{"substantive":{"code":"CV079","meaning":"Counsel''s
         Opinion","description":"Limited to obtaining external Counsel''s Opinion or
         the opinion of an external solicitor with higher court advocacy rights on
         the information already available."},"delegated_functions":{"code":"CV118","meaning":"Hearing","description":"Limited
         to all steps up to and including the hearing on [see additional limitation
         notes]"}},"service_levels":[{"level":3,"name":"Full Representation","stage":8,"proceeding_default":true}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:29 GMT
+  recorded_at: Wed, 07 May 2025 15:59:14 GMT
 - request:
     method: get
-    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE014A
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE016A
     body:
       encoding: US-ASCII
       string: ''
@@ -2189,18 +2177,18 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:30 GMT
+      - Wed, 07 May 2025 15:59:15 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '1122'
+      - '1151'
       connection:
       - keep-alive
       x-frame-options:
@@ -2216,46 +2204,46 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"f45b218af96b2d31f74762ce30efa40e"
+      - W/"46479618f2daf466ea680e3ae7a88861"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 606a1644a0098624b745cc50e449f945
+      - d44c4bebbe21c5c3595bb0c3557f98b2
       x-runtime:
-      - '0.007158'
+      - '0.014544'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"ccms_code":"SE014A","meaning":"Child arrangements
-        order (CAO) - residence - appeal","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","name":"cao_residence_appeal","description":"to
-        be represented on an application for a child arrangements order –where the
-        child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_matter":"section
+      string: '{"success":true,"ccms_code":"SE016A","meaning":"Child arrangements
+        order (CAO) - residence - appeal - vary","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","name":"vary_cao_redidence_appeal","description":"to
+        be represented on an application to vary or discharge a child arrangements
+        order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_matter":"section
         8 children (S8)","cost_limitations":{"substantive":{"start_date":"1970-01-01","value":"5000.0"},"delegated_functions":{"start_date":"2021-09-13","value":"2250.0"}},"default_scope_limitations":{"substantive":{"code":"CV079","meaning":"Counsel''s
         Opinion","description":"Limited to obtaining external Counsel''s Opinion or
         the opinion of an external solicitor with higher court advocacy rights on
         the information already available."},"delegated_functions":{"code":"CV118","meaning":"Hearing","description":"Limited
         to all steps up to and including the hearing on [see additional limitation
         notes]"}},"service_levels":[{"level":3,"name":"Full Representation","stage":8,"proceeding_default":true}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:30 GMT
+  recorded_at: Wed, 07 May 2025 15:59:15 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
     body:
       encoding: UTF-8
-      string: '{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":true,"client_involvement_type":"A"}'
+      string: '{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":true,"client_involvement_type":"A"}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:31 GMT
+      - Wed, 07 May 2025 15:59:15 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2275,40 +2263,40 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"c7645a6c1803d661969899b2e1493ef4"
+      - W/"89cd07cc1047be7589fc77034f445480"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 2fdf0e4c1b7c891cd8e6c81e790c4d42
+      - 89548a02f7dba93d15e8d567be958644
       x-runtime:
-      - '0.005357'
+      - '0.016731'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":true,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":true,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
         Representation","stage":8},"default_scope":{"code":"CV118","meaning":"Hearing","description":"Limited
         to all steps up to and including the hearing on [see additional limitation
         notes]","additional_params":[{"name":"hearing_date","type":"date","mandatory":true}]}}'
-  recorded_at: Fri, 14 Mar 2025 09:31:30 GMT
+  recorded_at: Wed, 07 May 2025 15:59:15 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_scopes
     body:
       encoding: UTF-8
-      string: '{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":true,"client_involvement_type":"A","level_of_service_code":3}'
+      string: '{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":true,"client_involvement_type":"A","level_of_service_code":3}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:31 GMT
+      - Wed, 07 May 2025 15:59:15 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2328,18 +2316,18 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"78e9efeb3d71c29eeaec950dc315f157"
+      - W/"928282521c66ee81aeb99a76ef3b909b"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - aa5c7fb747f10e4c1c0739b4e5160af4
+      - 93525d7ba56dd70340072fcfa97af1e5
       x-runtime:
-      - '0.034995'
+      - '0.064502'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":true,"client_involvement_type":"A","level_of_service_code":3},"level_of_service":{"level":3,"name":"Full
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":true,"client_involvement_type":"A","level_of_service_code":3},"level_of_service":{"level":3,"name":"Full
         Representation","stage":8,"scope_limitations":[{"code":"APL65","meaning":"Appeal
         family court-C opinion (App)","description":"Limited to representation as
         an appellant on an appeal in the family court LIMITED to obtaining Counsel’s
@@ -2425,25 +2413,25 @@ http_interactions:
         from DJ-limited steps (resp)","description":"Limited to representation as
         respondent on an appeal to the Judge against a decision of the District Judge
         or Master, limited to","additional_params":[{"name":"limitation_note","type":"text","mandatory":true}]}]}}'
-  recorded_at: Fri, 14 Mar 2025 09:31:30 GMT
+  recorded_at: Wed, 07 May 2025 15:59:15 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_scopes
     body:
       encoding: UTF-8
-      string: '{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":true,"client_involvement_type":"A","level_of_service_code":3}'
+      string: '{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":true,"client_involvement_type":"A","level_of_service_code":3}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:32 GMT
+      - Wed, 07 May 2025 15:59:16 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2463,18 +2451,18 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"78e9efeb3d71c29eeaec950dc315f157"
+      - W/"928282521c66ee81aeb99a76ef3b909b"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - fd30e7f1d02b43b648cb4ef1f1223b83
+      - 2a4f830b85be23dece4fd9bd4ac69f77
       x-runtime:
-      - '0.030335'
+      - '0.059469'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":true,"client_involvement_type":"A","level_of_service_code":3},"level_of_service":{"level":3,"name":"Full
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":true,"client_involvement_type":"A","level_of_service_code":3},"level_of_service":{"level":3,"name":"Full
         Representation","stage":8,"scope_limitations":[{"code":"APL65","meaning":"Appeal
         family court-C opinion (App)","description":"Limited to representation as
         an appellant on an appeal in the family court LIMITED to obtaining Counsel’s
@@ -2560,25 +2548,25 @@ http_interactions:
         from DJ-limited steps (resp)","description":"Limited to representation as
         respondent on an appeal to the Judge against a decision of the District Judge
         or Master, limited to","additional_params":[{"name":"limitation_note","type":"text","mandatory":true}]}]}}'
-  recorded_at: Fri, 14 Mar 2025 09:31:31 GMT
+  recorded_at: Wed, 07 May 2025 15:59:16 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
     body:
       encoding: UTF-8
-      string: '{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":false,"client_involvement_type":"A"}'
+      string: '{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":false,"client_involvement_type":"A"}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:32 GMT
+      - Wed, 07 May 2025 15:59:16 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2598,41 +2586,41 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"41641a45afd53756062781ec006ef115"
+      - W/"b7f8b504da8b7435824900062d956080"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - d5085b43d146af69dcc7df7ee715e1bd
+      - 6e9d3f9ffb88ff2c2396bace30209d9c
       x-runtime:
-      - '0.004867'
+      - '0.007453'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":false,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":false,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
         Representation","stage":8},"default_scope":{"code":"CV079","meaning":"Counsel''s
         Opinion","description":"Limited to obtaining external Counsel''s Opinion or
         the opinion of an external solicitor with higher court advocacy rights on
         the information already available.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 09:31:31 GMT
+  recorded_at: Wed, 07 May 2025 15:59:16 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
     body:
       encoding: UTF-8
-      string: '{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":false,"client_involvement_type":"A"}'
+      string: '{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":false,"client_involvement_type":"A"}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:33 GMT
+      - Wed, 07 May 2025 15:59:17 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2652,26 +2640,26 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"41641a45afd53756062781ec006ef115"
+      - W/"b7f8b504da8b7435824900062d956080"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - f56e3028ff685ca0e621da389f0d8734
+      - 5a354a6ef4fe6703e28f9212adbee86f
       x-runtime:
-      - '0.006570'
+      - '0.008452'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":false,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":false,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
         Representation","stage":8},"default_scope":{"code":"CV079","meaning":"Counsel''s
         Opinion","description":"Limited to obtaining external Counsel''s Opinion or
         the opinion of an external solicitor with higher court advocacy rights on
         the information already available.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 09:31:32 GMT
+  recorded_at: Wed, 07 May 2025 15:59:17 GMT
 - request:
     method: get
-    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE014A
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE016A
     body:
       encoding: US-ASCII
       string: ''
@@ -2679,18 +2667,18 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:33 GMT
+      - Wed, 07 May 2025 15:59:17 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '1122'
+      - '1151'
       connection:
       - keep-alive
       x-frame-options:
@@ -2706,31 +2694,31 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"f45b218af96b2d31f74762ce30efa40e"
+      - W/"46479618f2daf466ea680e3ae7a88861"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - '09ad19b75c3396682609c883cb05650f'
+      - 848a5f33506c177e0cdb7fcd46bab115
       x-runtime:
-      - '0.006047'
+      - '0.014723'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"ccms_code":"SE014A","meaning":"Child arrangements
-        order (CAO) - residence - appeal","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","name":"cao_residence_appeal","description":"to
-        be represented on an application for a child arrangements order –where the
-        child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_matter":"section
+      string: '{"success":true,"ccms_code":"SE016A","meaning":"Child arrangements
+        order (CAO) - residence - appeal - vary","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","name":"vary_cao_redidence_appeal","description":"to
+        be represented on an application to vary or discharge a child arrangements
+        order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_matter":"section
         8 children (S8)","cost_limitations":{"substantive":{"start_date":"1970-01-01","value":"5000.0"},"delegated_functions":{"start_date":"2021-09-13","value":"2250.0"}},"default_scope_limitations":{"substantive":{"code":"CV079","meaning":"Counsel''s
         Opinion","description":"Limited to obtaining external Counsel''s Opinion or
         the opinion of an external solicitor with higher court advocacy rights on
         the information already available."},"delegated_functions":{"code":"CV118","meaning":"Hearing","description":"Limited
         to all steps up to and including the hearing on [see additional limitation
         notes]"}},"service_levels":[{"level":3,"name":"Full Representation","stage":8,"proceeding_default":true}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:33 GMT
+  recorded_at: Wed, 07 May 2025 15:59:17 GMT
 - request:
     method: get
-    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE014A
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE016A
     body:
       encoding: US-ASCII
       string: ''
@@ -2738,18 +2726,18 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:34 GMT
+      - Wed, 07 May 2025 15:59:18 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '1122'
+      - '1151'
       connection:
       - keep-alive
       x-frame-options:
@@ -2765,46 +2753,46 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"f45b218af96b2d31f74762ce30efa40e"
+      - W/"46479618f2daf466ea680e3ae7a88861"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 5ba1506e516eb3d8e1d6770cce1efb97
+      - 55381829dead72f32b1db2ccac7bb0fe
       x-runtime:
-      - '0.005734'
+      - '0.012305'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"ccms_code":"SE014A","meaning":"Child arrangements
-        order (CAO) - residence - appeal","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","name":"cao_residence_appeal","description":"to
-        be represented on an application for a child arrangements order –where the
-        child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_matter":"section
+      string: '{"success":true,"ccms_code":"SE016A","meaning":"Child arrangements
+        order (CAO) - residence - appeal - vary","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","name":"vary_cao_redidence_appeal","description":"to
+        be represented on an application to vary or discharge a child arrangements
+        order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_matter":"section
         8 children (S8)","cost_limitations":{"substantive":{"start_date":"1970-01-01","value":"5000.0"},"delegated_functions":{"start_date":"2021-09-13","value":"2250.0"}},"default_scope_limitations":{"substantive":{"code":"CV079","meaning":"Counsel''s
         Opinion","description":"Limited to obtaining external Counsel''s Opinion or
         the opinion of an external solicitor with higher court advocacy rights on
         the information already available."},"delegated_functions":{"code":"CV118","meaning":"Hearing","description":"Limited
         to all steps up to and including the hearing on [see additional limitation
         notes]"}},"service_levels":[{"level":3,"name":"Full Representation","stage":8,"proceeding_default":true}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:33 GMT
+  recorded_at: Wed, 07 May 2025 15:59:18 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
     body:
       encoding: UTF-8
-      string: '{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":false,"client_involvement_type":"A"}'
+      string: '{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":false,"client_involvement_type":"A"}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:34 GMT
+      - Wed, 07 May 2025 15:59:18 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2824,41 +2812,41 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"41641a45afd53756062781ec006ef115"
+      - W/"b7f8b504da8b7435824900062d956080"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - f6484c6893a379bd897194f85186eb1c
+      - 7f026c5306522baa992d793e9562356c
       x-runtime:
-      - '0.005125'
+      - '0.010887'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":false,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":false,"client_involvement_type":"A"},"default_level_of_service":{"level":3,"name":"Full
         Representation","stage":8},"default_scope":{"code":"CV079","meaning":"Counsel''s
         Opinion","description":"Limited to obtaining external Counsel''s Opinion or
         the opinion of an external solicitor with higher court advocacy rights on
         the information already available.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 09:31:33 GMT
+  recorded_at: Wed, 07 May 2025 15:59:18 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_scopes
     body:
       encoding: UTF-8
-      string: '{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":false,"client_involvement_type":"A","level_of_service_code":3}'
+      string: '{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":false,"client_involvement_type":"A","level_of_service_code":3}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:35 GMT
+      - Wed, 07 May 2025 15:59:19 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2878,18 +2866,18 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"89915366107ba72569eb9a46caa1672a"
+      - W/"e995068200fc351b22d95bf23dfea434"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - f7561da9ec081629beee2fb2f938c03a
+      - 68008ad3b76a6914d6fca58480889146
       x-runtime:
-      - '0.030837'
+      - '0.059690'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":false,"client_involvement_type":"A","level_of_service_code":3},"level_of_service":{"level":3,"name":"Full
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":false,"client_involvement_type":"A","level_of_service_code":3},"level_of_service":{"level":3,"name":"Full
         Representation","stage":8,"scope_limitations":[{"code":"APL65","meaning":"Appeal
         family court-C opinion (App)","description":"Limited to representation as
         an appellant on an appeal in the family court LIMITED to obtaining Counsel’s
@@ -2975,25 +2963,25 @@ http_interactions:
         from DJ-limited steps (resp)","description":"Limited to representation as
         respondent on an appeal to the Judge against a decision of the District Judge
         or Master, limited to","additional_params":[{"name":"limitation_note","type":"text","mandatory":true}]}]}}'
-  recorded_at: Fri, 14 Mar 2025 09:31:34 GMT
+  recorded_at: Wed, 07 May 2025 15:59:19 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_scopes
     body:
       encoding: UTF-8
-      string: '{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":false,"client_involvement_type":"A","level_of_service_code":3}'
+      string: '{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":false,"client_involvement_type":"A","level_of_service_code":3}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:35 GMT
+      - Wed, 07 May 2025 15:59:20 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -3013,18 +3001,18 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"89915366107ba72569eb9a46caa1672a"
+      - W/"e995068200fc351b22d95bf23dfea434"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - a79ccfb2ba9d976ee99e45a7388e7d4f
+      - e6a8b0d7585ddbd82144a6b3edfa26de
       x-runtime:
-      - '0.029578'
+      - '0.065294'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE014A","delegated_functions_used":false,"client_involvement_type":"A","level_of_service_code":3},"level_of_service":{"level":3,"name":"Full
+      string: '{"success":true,"requested_params":{"proceeding_type_ccms_code":"SE016A","delegated_functions_used":false,"client_involvement_type":"A","level_of_service_code":3},"level_of_service":{"level":3,"name":"Full
         Representation","stage":8,"scope_limitations":[{"code":"APL65","meaning":"Appeal
         family court-C opinion (App)","description":"Limited to representation as
         an appellant on an appeal in the family court LIMITED to obtaining Counsel’s
@@ -3110,7 +3098,7 @@ http_interactions:
         from DJ-limited steps (resp)","description":"Limited to representation as
         respondent on an appeal to the Judge against a decision of the District Judge
         or Master, limited to","additional_params":[{"name":"limitation_note","type":"text","mandatory":true}]}]}}'
-  recorded_at: Fri, 14 Mar 2025 09:31:35 GMT
+  recorded_at: Wed, 07 May 2025 15:59:20 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/SE095
@@ -3121,14 +3109,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:36 GMT
+      - Wed, 07 May 2025 15:59:20 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -3152,9 +3140,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - e1b3a0b89eee3aebce65860291c6fa89
+      - b8d151a35526fbeb96580896393f558e
       x-runtime:
-      - '0.001811'
+      - '0.003527'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -3162,7 +3150,7 @@ http_interactions:
       string: '{"success":true,"client_involvement_type":[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:35 GMT
+  recorded_at: Wed, 07 May 2025 15:59:20 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/SE095
@@ -3173,14 +3161,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:36 GMT
+      - Wed, 07 May 2025 15:59:20 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -3204,9 +3192,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - c2f983a9f8ef20f723a934f9ebaa8c63
+      - 40da17a45d57ab68a9829ff59963a90c
       x-runtime:
-      - '0.001885'
+      - '0.002432'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -3214,7 +3202,7 @@ http_interactions:
       string: '{"success":true,"client_involvement_type":[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:36 GMT
+  recorded_at: Wed, 07 May 2025 15:59:20 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -3225,14 +3213,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:37 GMT
+      - Wed, 07 May 2025 15:59:21 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -3256,9 +3244,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 3f648466c13f2d26578baa2bee998f5c
+      - f1db69ee1d4ca9c2455bb591a45d4a82
       x-runtime:
-      - '0.004455'
+      - '0.009885'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -3268,7 +3256,7 @@ http_interactions:
         to Family Help (Higher) and to all steps necessary to negotiate and conclude
         a settlement. To include the issue of proceedings and representation in those
         proceedings save in relation to or at a contested final hearing.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 09:31:37 GMT
+  recorded_at: Wed, 07 May 2025 15:59:21 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -3279,14 +3267,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:38 GMT
+      - Wed, 07 May 2025 15:59:22 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -3310,9 +3298,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 64a5f025d473496a9974125cb644d8ef
+      - '09700d11f8c26ed3a3710e3e72be213b'
       x-runtime:
-      - '0.004517'
+      - '0.009346'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -3322,7 +3310,7 @@ http_interactions:
         to Family Help (Higher) and to all steps necessary to negotiate and conclude
         a settlement. To include the issue of proceedings and representation in those
         proceedings save in relation to or at a contested final hearing.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 09:31:38 GMT
+  recorded_at: Wed, 07 May 2025 15:59:22 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE095
@@ -3333,14 +3321,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:39 GMT
+      - Wed, 07 May 2025 15:59:23 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -3364,9 +3352,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 872bd2c869ca98a1ca29941fc9c90c59
+      - 86aad2aa40cb135ce1c305b59c4c56a2
       x-runtime:
-      - '0.013143'
+      - '0.013930'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -3384,7 +3372,7 @@ http_interactions:
         representation on the return date."}},"service_levels":[{"level":1,"name":"Family
         Help (Higher)","stage":1,"proceeding_default":true},{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":false}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:38 GMT
+  recorded_at: Wed, 07 May 2025 15:59:23 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE095
@@ -3395,14 +3383,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:39 GMT
+      - Wed, 07 May 2025 15:59:23 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -3426,9 +3414,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 1989e047de5bcabc6db0609f0f0e0b3c
+      - 34e45141d4424d16ca2552c025b7e794
       x-runtime:
-      - '0.006790'
+      - '0.012158'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -3446,7 +3434,7 @@ http_interactions:
         representation on the return date."}},"service_levels":[{"level":1,"name":"Family
         Help (Higher)","stage":1,"proceeding_default":true},{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":false}]}'
-  recorded_at: Fri, 14 Mar 2025 09:31:39 GMT
+  recorded_at: Wed, 07 May 2025 15:59:23 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -3457,14 +3445,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:39 GMT
+      - Wed, 07 May 2025 15:59:24 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -3488,9 +3476,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 5b58ce90cb9e84db2c4c2cdaea35d687
+      - 759ebf0d3165b0cbfb4c001e6968dc3d
       x-runtime:
-      - '0.004654'
+      - '0.007848'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -3500,7 +3488,7 @@ http_interactions:
         to Family Help (Higher) and to all steps necessary to negotiate and conclude
         a settlement. To include the issue of proceedings and representation in those
         proceedings save in relation to or at a contested final hearing.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 09:31:39 GMT
+  recorded_at: Wed, 07 May 2025 15:59:24 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_scopes
@@ -3511,14 +3499,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:40 GMT
+      - Wed, 07 May 2025 15:59:24 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -3542,9 +3530,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 45012f4e746e96d0fd0c8fd9c8053047
+      - 17588192206e826bb6a6a3070df27002
       x-runtime:
-      - '0.012098'
+      - '0.022292'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -3575,7 +3563,7 @@ http_interactions:
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]},{"code":"FM015","meaning":"Section
         37 Report","description":"Limited to a section 37 report only.","additional_params":[]}]}}'
-  recorded_at: Fri, 14 Mar 2025 09:31:39 GMT
+  recorded_at: Wed, 07 May 2025 15:59:24 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_scopes
@@ -3586,14 +3574,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 09:31:41 GMT
+      - Wed, 07 May 2025 15:59:25 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -3617,9 +3605,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - d2785eee9c81d118ac569aed3e812ced
+      - 266581c8bcdae250161c764a7f2a57cd
       x-runtime:
-      - '0.011996'
+      - '0.024920'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -3650,5 +3638,5 @@ http_interactions:
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]},{"code":"FM015","meaning":"Section
         37 Report","description":"Limited to a section 37 report only.","additional_params":[]}]}}'
-  recorded_at: Fri, 14 Mar 2025 09:31:40 GMT
+  recorded_at: Wed, 07 May 2025 15:59:25 GMT
 recorded_with: VCR 6.3.1

--- a/features/cassettes/Scope_limitations_not_being_set/When_a_provider_creates_an_application_with_multiple_proceedings_and_uses_the_back_button_scope_limitations_should_not_be_removed.yml
+++ b/features/cassettes/Scope_limitations_not_being_set/When_a_provider_creates_an_application_with_multiple_proceedings_and_uses_the_back_button_scope_limitations_should_not_be_removed.yml
@@ -8,14 +8,14 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:10:46 GMT
+      - Wed, 07 May 2025 14:20:03 GMT
       content-type:
       - application/json;charset=UTF-8
       transfer-encoding:
@@ -37,8 +37,8 @@ http_interactions:
       string: "{\r\n  \"header\" : {\r\n    \"uri\" : \"https://api.os.uk/search/places/v1/postcode?lr=EN&postcode=SW1H9EA\",\r\n
         \   \"query\" : \"postcode=SW1H9EA\",\r\n    \"offset\" : 0,\r\n    \"totalresults\"
         : 5,\r\n    \"format\" : \"JSON\",\r\n    \"dataset\" : \"DPA\",\r\n    \"lr\"
-        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"115\",\r\n    \"lastupdate\"
-        : \"2025-03-13\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
+        : \"EN\",\r\n    \"maxresults\" : 100,\r\n    \"epoch\" : \"118\",\r\n    \"lastupdate\"
+        : \"2025-05-06\",\r\n    \"output_srs\" : \"EPSG:27700\"\r\n  },\r\n  \"results\"
         : [ {\r\n    \"DPA\" : {\r\n      \"UPRN\" : \"100023337883\",\r\n      \"UDPRN\"
         : \"23749699\",\r\n      \"ADDRESS\" : \"84, PETTY FRANCE, LONDON, SW1H 9EA\",\r\n
         \     \"BUILDING_NUMBER\" : \"84\",\r\n      \"THOROUGHFARE_NAME\" : \"PETTY
@@ -133,7 +133,7 @@ http_interactions:
         \     \"BLPU_STATE_DATE\" : \"15/06/2020\",\r\n      \"LANGUAGE\" : \"EN\",\r\n
         \     \"MATCH\" : 1.0,\r\n      \"MATCH_DESCRIPTION\" : \"EXACT\",\r\n      \"DELIVERY_POINT_SUFFIX\"
         : \"1N\"\r\n    }\r\n  } ]\r\n}"
-  recorded_at: Fri, 14 Mar 2025 12:10:45 GMT
+  recorded_at: Wed, 07 May 2025 14:20:03 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
@@ -144,14 +144,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:10:47 GMT
+      - Wed, 07 May 2025 14:20:05 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -171,440 +171,436 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"93565432497c5ce191eac6fbf69b9a81"
+      - W/"f5d4a442765bb4b1da38aa01d431b319"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 3662de5837d7367b582d2aa5a443485e
+      - e678a3ddca022284afba105e5a50ac10
       x-runtime:
-      - '0.047539'
+      - '0.083818'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
-        for an injunction, order or declaration under the inherent jurisdiction of
-        the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
-        1997 under section 5 - vary or discharge","description":"to be represented
-        on an application to vary or discharge an order under section 5 Protection
-        from Harassment Act 1997 where the parties are associated persons (as defined
-        by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
-        (CAO) - residence","description":"to be represented on an application for
-        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PB003","meaning":"Child assessment order","description":"to
-        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB004","meaning":"Emergency protection
-        order - extend","description":"to be represented on an application for or
-        to extend an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB005","meaning":"Emergency protection
-        order - discharge","description":"to be represented on an application to discharge
-        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB006","meaning":"Secure accommodation
-        order","description":"to be represented on an application for a secure accommodation
-        order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB026","meaning":"Emergency protection
-        order","description":"to be represented on an application for an emergency
-        protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB057","meaning":"Care order","description":"to
-        be represented on an application for a care order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB059","meaning":"Supervision order","description":"to
+      string: '{"success":true,"data":[{"ccms_code":"PBM06","meaning":"Supervision
+        order - vary or discharge","description":"to be represented on an application
+        to vary or discharge a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB059","meaning":"Supervision order","description":"to
         be represented on an application for a supervision order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PBM01","meaning":"Declaration for overseas
         adoption","description":"to be represented on an application for a declaration
         as to an overseas adoption.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM01A","meaning":"Declaration for overseas
-        adoption - appeal","description":"to be represented on an application for
-        a declaration as to an overseas adoption.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM02","meaning":"Adoption - not being held
-        in family proceedings court","description":"to be represented on an application
-        for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM02A","meaning":"Adoption order - appeal","description":"to
-        be represented on an application for an adoption order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM02E","meaning":"Adoption order - enforcement","description":"to
         be represented on an application for an adoption order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36E","meaning":"Care order - joined party
+        - enforcement","description":"to be represented on an application for a care
+        order Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB057","meaning":"Care order","description":"to
+        be represented on an application for a care order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM02A","meaning":"Adoption order - appeal","description":"to
+        be represented on an application for an adoption order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM04","meaning":"Secure accommodation order","description":"to
         be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM22","meaning":"Parental responsibility","description":"to
-        be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM04A","meaning":"Secure accommodation order
-        - appeal","description":"to be represented on an application for a secure
-        accommodation order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM04E","meaning":"Secure accommodation order
-        - enforcement","description":"to be represented on an application for a secure
-        accommodation order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05","meaning":"Contact with a child in
-        care","description":"to be represented on an application for contact with
-        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05A","meaning":"Contact with a child in
-        care - appeal","description":"to be represented on an application for contact
-        with a child in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05E","meaning":"Contact with a child in
-        care - enforcement","description":"to be represented on an application for
-        contact with a child in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06","meaning":"Supervision order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06A","meaning":"Supervision order - appeal
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06E","meaning":"Supervision order - enforcement
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07","meaning":"Care order - discharge","description":"to
-        be represented on an application to discharge a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07A","meaning":"Care order - appeal -
-        discharge","description":"to be represented on an application to discharge
-        a care order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07E","meaning":"Care order - enforcement
-        - discharge","description":"to be represented on an application to discharge
-        a care order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM08","meaning":"Education supervision order","description":"to
-        be represented on an application for an education supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM08A","meaning":"Education supervision
         order - appeal","description":"to be represented on an application for an
         education supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM08E","meaning":"Education supervision
-        order - enforcement","description":"to be represented on an application for
-        an education supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM09","meaning":"Recovery of children order","description":"to
-        be represented on an application for the recovery of a child/children.  Appeals
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM09A","meaning":"Recovery of children order
-        - appeal","description":"to be represented on an application for the recovery
-        of a child/children.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM04E","meaning":"Secure accommodation order
+        - enforcement","description":"to be represented on an application for a secure
+        accommodation order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
+        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM30A","meaning":"Placement order - appeal","description":"to
+        be represented on an application for a placement order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27","meaning":"Emergency protection order","description":"to
+        be represented on an application for or to extend an emergency protection
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM28","meaning":"Emergency protection order
+        - discharge","description":"to be represented on an application to discharge
+        an emergency protection order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM17A","meaning":"Specific issue order - appeal","description":"to
+        be represented on an application for a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB005","meaning":"Emergency protection order
+        - discharge","description":"to be represented on an application to discharge
+        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM23A","meaning":"Care order - appeal","description":"to
+        be represented on an application for a care order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36A","meaning":"Care order - joined party
+        - appeal","description":"to be represented on an application for a care order
+        Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB004","meaning":"Emergency protection order
+        - extend","description":"to be represented on an application for or to extend
+        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM22A","meaning":"Parental responsibility
+        - appeal","description":"to be represented on an application for parental
+        responsibility.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32A","meaning":"Special guardianship order
+        - appeal","description":"to be represented on an application for a Special
+        Guardianship Order . Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM20","meaning":"Prohibited steps order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM02","meaning":"Adoption - not being held
+        in family proceedings court","description":"to be represented on an application
+        for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE007","meaning":"Prohibited steps order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM23","meaning":"Care order","description":"to
+        be represented on an application for a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM09E","meaning":"Recovery of children order
         - enforcement","description":"to be represented on an application for the
         recovery of a child/children.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM10","meaning":"Child assessment order
+        law family (PLF)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J
+        - amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM33A","meaning":"Revocation placement order
+        - appeal","description":"to be represented on an application for revocation
+        of a placement order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM30E","meaning":"Placement order - enforcement","description":"to
+        be represented on an application for a placement order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36","meaning":"Care order - joined party","description":"to
+        be represented on an application for a care order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29A","meaning":"Exclusion requirement
+        - appeal","description":"to be represented on an application to vary/discharge
+        an exclusion requirement.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM06A","meaning":"Supervision order - appeal
         - vary or discharge","description":"to be represented on an application to
-        vary or discharge a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM10A","meaning":"Child assessment order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a child assessment order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11","meaning":"End contact with a child
-        in care","description":"to be represented on an application to terminate contact
-        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11A","meaning":"End contact with a child
-        in care - appeal","description":"to be represented on an application to terminate
-        contact with a child/children in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11E","meaning":"End contact with a child
+        vary or discharge a supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32","meaning":"Special guardianship order","description":"to
+        be represented on an application for a Special Guardianship Order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PB003","meaning":"Child assessment order","description":"to
+        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PB006","meaning":"Secure accommodation order","description":"to
+        be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM11E","meaning":"End contact with a child
         in care - enforcement","description":"to be represented on an application
         to terminate contact with a child/children in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM13","meaning":"Substitute supervision
-        with care","description":"to be represented on an application to substitute
-        a supervision order with care order under section 39 (4) Children Act 1989.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM13A","meaning":"Substitute supervision
-        with care - appeal","description":"to be represented on an application to
-        substitute a supervision order with care order under section 39 (4) Children
-        Act 1989. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM16","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary or discharge","description":"to be represented
+        on an application to vary or discharge a contact order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J
+        - appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM17E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32E","meaning":"Special guardianship order
+        - enforcement","description":"to be represented on an application for a Special
+        Guardianship Order . Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM20E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM35A","meaning":"Special guardianship order
+        - appeal - vary or discharge","description":"To be represented on an application
+        for variation/discharge of a special guardianship order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM16A","meaning":"Prohibited steps order
         - appeal","description":"to be represented on an application for a prohibited
         steps order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM16E","meaning":"Prohibited steps order
+        law family (PLF)"},{"ccms_code":"PBM05A","meaning":"Contact with a child in
+        care - appeal","description":"to be represented on an application for contact
+        with a child in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM10","meaning":"Child assessment order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order - who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM05E","meaning":"Contact with a child in
+        care - enforcement","description":"to be represented on an application for
+        contact with a child in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM30","meaning":"Placement order","description":"to
+        be represented on an application for a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19","meaning":"Child arrangements order
+        (CAO) - residence - vary or discharge","description":"to be represented on
+        an application to vary or discharge a residence order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM24E","meaning":"Supervision order - enforcement","description":"to
+        be represented on an application for a supervision order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
+        - appeal","description":"to be represented on an application for a prohibited
+        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM10A","meaning":"Child assessment order
+        - appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a child assessment order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM45","meaning":"Adoption order - parent
+        or parental responsibility","description":"To represent a parent or person
+        with parental responsibility on an application for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM26E","meaning":"Child assessment order
+        - enforcement","description":"to be represented on an application for a child
+        assessment order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary or discharge","description":"to be represented
+        on an application to vary or discharge a contact order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM35","meaning":"Special guardianship order
+        - vary or discharge","description":"To be represented on an application for
+        variation/discharge of a special guardianship order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM01A","meaning":"Declaration for overseas
+        adoption - appeal","description":"to be represented on an application for
+        a declaration as to an overseas adoption.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM16E","meaning":"Prohibited steps order
         - enforcement","description":"to be represented on an application for a prohibited
         steps order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM17","meaning":"Specific issue order","description":"to
         be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18","meaning":"Child arrangements order
-        (CAO) - contact - vary or discharge","description":"to be represented on an
-        application to vary or discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary or discharge","description":"to be represented
-        on an application to vary or discharge a contact order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary or discharge","description":"to be represented
-        on an application to vary or discharge a contact order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19","meaning":"Child arrangements order
-        (CAO) - residence - vary or discharge","description":"to be represented on
-        an application to vary or discharge a residence order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary or discharge","description":"to be represented
-        on an application to vary or discharge a residence order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary or discharge","description":"to be
-        represented on an application to vary or discharge a residence order. Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20","meaning":"Prohibited steps order
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21","meaning":"Specific issue order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM22A","meaning":"Parental responsibility
-        - appeal","description":"to be represented on an application for parental
-        responsibility.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23","meaning":"Care order","description":"to
-        be represented on an application for a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23A","meaning":"Care order - appeal","description":"to
-        be represented on an application for a care order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23E","meaning":"Care order - enforcement","description":"to
-        be represented on an application for a care order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24","meaning":"Supervision order","description":"to
-        be represented on an application for a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24A","meaning":"Supervision order - appeal","description":"to
-        be represented on an application for a supervision order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24E","meaning":"Supervision order - enforcement","description":"to
-        be represented on an application for a supervision order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26","meaning":"Child assessment order","description":"to
-        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26A","meaning":"Child assessment order
-        - appeal","description":"to be represented on an application for a child assessment
-        order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26E","meaning":"Child assessment order
-        - enforcement","description":"to be represented on an application for a child
-        assessment order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27","meaning":"Emergency protection order","description":"to
-        be represented on an application for or to extend an emergency protection
-        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27A","meaning":"Emergency protection order
-        - appeal","description":"to be represented on an application for or to extend
-        an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27E","meaning":"Emergency protection order
-        - enforcement","description":"to be represented on an application for or to
-        extend an emergency protection order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM28","meaning":"Emergency protection order
-        - discharge","description":"to be represented on an application to discharge
-        an emergency protection order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM28A","meaning":"Emergency protection order
-        - appeal - discharge","description":"to be represented on an application to
-        discharge an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29","meaning":"Exclusion requirement","description":"to
-        be represented on an application to vary/discharge an exclusion requirement.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29A","meaning":"Exclusion requirement
-        - appeal","description":"to be represented on an application to vary/discharge
-        an exclusion requirement.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29E","meaning":"Exclusion requirement
-        - enforcement","description":"to be represented on an application to vary/discharge
-        an exclusion requirement.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30","meaning":"Placement order","description":"to
-        be represented on an application for a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30A","meaning":"Placement order - appeal","description":"to
-        be represented on an application for a placement order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30E","meaning":"Placement order - enforcement","description":"to
-        be represented on an application for a placement order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32","meaning":"Special guardianship order","description":"to
-        be represented on an application for a Special Guardianship Order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32A","meaning":"Special guardianship order
-        - appeal","description":"to be represented on an application for a Special
-        Guardianship Order . Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32E","meaning":"Special guardianship order
-        - enforcement","description":"to be represented on an application for a Special
-        Guardianship Order . Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33","meaning":"Revocation placement order","description":"to
-        be represented on an application for revocation of a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33A","meaning":"Revocation placement order
-        - appeal","description":"to be represented on an application for revocation
-        of a placement order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM33E","meaning":"Revocation placement order
         - enforcement","description":"to be represented on an application for revocation
         of a placement order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35","meaning":"Special guardianship order
-        - vary or discharge","description":"To be represented on an application for
-        variation/discharge of a special guardianship order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35A","meaning":"Special guardianship order
-        - appeal - vary or discharge","description":"To be represented on an application
-        for variation/discharge of a special guardianship order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35E","meaning":"Special guardianship order
-        - enforcement - vary or discharge","description":"To be represented on an
-        application for variation/discharge of a special guardianship order.  Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36","meaning":"Care order - joined party","description":"to
-        be represented on an application for a care order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36A","meaning":"Care order - joined party
-        - appeal","description":"to be represented on an application for a care order
-        Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36E","meaning":"Care order - joined party
-        - enforcement","description":"to be represented on an application for a care
-        order Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37","meaning":"Supervision order - joined
-        party","description":"to be represented on an application for a supervision
-        order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37A","meaning":"Supervision order - joined
+        law family (PLF)"},{"ccms_code":"PBM21A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM22","meaning":"Parental responsibility","description":"to
+        be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27A","meaning":"Emergency protection order
+        - appeal","description":"to be represented on an application for or to extend
+        an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM04A","meaning":"Secure accommodation order
+        - appeal","description":"to be represented on an application for a secure
+        accommodation order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM08E","meaning":"Education supervision
+        order - enforcement","description":"to be represented on an application for
+        an education supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE014","meaning":"Child arrangements order
+        (CAO) - residence","description":"to be represented on an application for
+        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM37A","meaning":"Supervision order - joined
         party - appeal","description":"to be represented on an application for a supervision
         order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37E","meaning":"Supervision order - joined
-        party - enforcement","description":"to be represented on an application for
-        a supervision order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order - who the child(ren) spend time with","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order - who the child(ren) spend time with. Appeals
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order - who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM39","meaning":"Child arrangements order
         (CAO) - residence","description":"to be represented on an application for
         a child arrangements order - where the child(ren) will live.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order - where the child(ren) will live. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order - where the child(ren) will live. Enforcement
+        law family (PLF)"},{"ccms_code":"PBM13","meaning":"Substitute supervision
+        with care","description":"to be represented on an application to substitute
+        a supervision order with care order under section 39 (4) Children Act 1989.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM05","meaning":"Contact with a child in
+        care","description":"to be represented on an application for contact with
+        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24A","meaning":"Supervision order - appeal","description":"to
+        be represented on an application for a supervision order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM08","meaning":"Education supervision order","description":"to
+        be represented on an application for an education supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM07","meaning":"Care order - discharge","description":"to
+        be represented on an application to discharge a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary or discharge","description":"to be represented
+        on an application to vary or discharge a residence order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM23E","meaning":"Care order - enforcement","description":"to
+        be represented on an application for a care order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order - who the child(ren) spend time with","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM09A","meaning":"Recovery of children order
+        - appeal","description":"to be represented on an application for the recovery
+        of a child/children.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM11","meaning":"End contact with a child
+        in care","description":"to be represented on an application to terminate contact
+        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM35E","meaning":"Special guardianship order
+        - enforcement - vary or discharge","description":"To be represented on an
+        application for variation/discharge of a special guardianship order.  Enforcement
         only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB026","meaning":"Emergency protection order","description":"to
+        be represented on an application for an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM26","meaning":"Child assessment order","description":"to
+        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM09","meaning":"Recovery of children order","description":"to
+        be represented on an application for the recovery of a child/children.  Appeals
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM37E","meaning":"Supervision order - joined
+        party - enforcement","description":"to be represented on an application for
+        a supervision order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM40","meaning":"Placement order - parent
         or parental responsibility","description":"To represent a parent or person
         with parental responsibility on an application for a placement order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM40E","meaning":"Placement order - parent
-        or parental responsibility - enforcement","description":"To represent a parent
-        or person with parental responsibility on an application for a placement order.
-        Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM45","meaning":"Adoption order - parent
-        or parental responsibility","description":"To represent a parent or person
-        with parental responsibility on an application for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM11A","meaning":"End contact with a child
+        in care - appeal","description":"to be represented on an application to terminate
+        contact with a child/children in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM45E","meaning":"Adoption order - parent
         or parental responsibility - enforcement","description":"To represent a parent
         or person with parental responsibility on an application for a placement order.
         Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24","meaning":"Supervision order","description":"to
+        be represented on an application for a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18","meaning":"Child arrangements order
+        (CAO) - contact - vary or discharge","description":"to be represented on an
+        application to vary or discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM39A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order - where the child(ren) will live. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM21E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM13A","meaning":"Substitute supervision
+        with care - appeal","description":"to be represented on an application to
+        substitute a supervision order with care order under section 39 (4) Children
+        Act 1989. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary","description":"to be represented on an
+        application to vary or discharge a child arrangements order –where the child(ren)
+        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM07A","meaning":"Care order - appeal - discharge","description":"to
+        be represented on an application to discharge a care order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary or discharge","description":"to be
+        represented on an application to vary or discharge a residence order. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM33","meaning":"Revocation placement order","description":"to
+        be represented on an application for revocation of a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM06E","meaning":"Supervision order - enforcement
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order - who the child(ren) spend time with. Appeals
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM16","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29E","meaning":"Exclusion requirement
+        - enforcement","description":"to be represented on an application to vary/discharge
+        an exclusion requirement.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
+        for an injunction, order or declaration under the inherent jurisdiction of
+        the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM20A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA002","meaning":"Protection from harassment
+        act 1997 under section 5 - vary or discharge","description":"to be represented
+        on an application to vary or discharge an order under section 5 Protection
+        from Harassment Act 1997 where the parties are associated persons (as defined
+        by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM07E","meaning":"Care order - enforcement - discharge","description":"to
+        be represented on an application to discharge a care order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM37","meaning":"Supervision order - joined
+        party","description":"to be represented on an application for a supervision
+        order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM26A","meaning":"Child assessment order
+        - appeal","description":"to be represented on an application for a child assessment
+        order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM39E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order - where the child(ren) will live. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29","meaning":"Exclusion requirement","description":"to
+        be represented on an application to vary/discharge an exclusion requirement.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM28A","meaning":"Emergency protection order
+        - appeal - discharge","description":"to be represented on an application to
+        discharge an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM40E","meaning":"Placement order - parent
+        or parental responsibility - enforcement","description":"To represent a parent
+        or person with parental responsibility on an application for a placement order.
+        Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J
+        and committal","description":"to be represented on an application for committal
+        and for an enforcement order under section 11J Children Act 1989. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM21","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27E","meaning":"Emergency protection order
+        - enforcement","description":"to be represented on an application for or to
+        extend an emergency protection order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"}]}'
-  recorded_at: Fri, 14 Mar 2025 12:10:46 GMT
+  recorded_at: Wed, 07 May 2025 14:20:05 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
@@ -615,14 +611,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:10:48 GMT
+      - Wed, 07 May 2025 14:20:06 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -642,440 +638,436 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"93565432497c5ce191eac6fbf69b9a81"
+      - W/"f5d4a442765bb4b1da38aa01d431b319"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 8d3fdcf04a9e098487ea684bcca79a9a
+      - 6b7a936c25e952559e5f86986d54331a
       x-runtime:
-      - '0.026615'
+      - '0.041023'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
-        for an injunction, order or declaration under the inherent jurisdiction of
-        the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
-        1997 under section 5 - vary or discharge","description":"to be represented
-        on an application to vary or discharge an order under section 5 Protection
-        from Harassment Act 1997 where the parties are associated persons (as defined
-        by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014","meaning":"Child arrangements order
-        (CAO) - residence","description":"to be represented on an application for
-        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"PB003","meaning":"Child assessment order","description":"to
-        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB004","meaning":"Emergency protection
-        order - extend","description":"to be represented on an application for or
-        to extend an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB005","meaning":"Emergency protection
-        order - discharge","description":"to be represented on an application to discharge
-        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB006","meaning":"Secure accommodation
-        order","description":"to be represented on an application for a secure accommodation
-        order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB026","meaning":"Emergency protection
-        order","description":"to be represented on an application for an emergency
-        protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB057","meaning":"Care order","description":"to
-        be represented on an application for a care order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
-        children act (SCA)"},{"ccms_code":"PB059","meaning":"Supervision order","description":"to
+      string: '{"success":true,"data":[{"ccms_code":"PBM06","meaning":"Supervision
+        order - vary or discharge","description":"to be represented on an application
+        to vary or discharge a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB059","meaning":"Supervision order","description":"to
         be represented on an application for a supervision order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
         children act (SCA)"},{"ccms_code":"PBM01","meaning":"Declaration for overseas
         adoption","description":"to be represented on an application for a declaration
         as to an overseas adoption.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM01A","meaning":"Declaration for overseas
-        adoption - appeal","description":"to be represented on an application for
-        a declaration as to an overseas adoption.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM02","meaning":"Adoption - not being held
-        in family proceedings court","description":"to be represented on an application
-        for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM02A","meaning":"Adoption order - appeal","description":"to
-        be represented on an application for an adoption order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM02E","meaning":"Adoption order - enforcement","description":"to
         be represented on an application for an adoption order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36E","meaning":"Care order - joined party
+        - enforcement","description":"to be represented on an application for a care
+        order Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB057","meaning":"Care order","description":"to
+        be represented on an application for a care order","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM02A","meaning":"Adoption order - appeal","description":"to
+        be represented on an application for an adoption order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM04","meaning":"Secure accommodation order","description":"to
         be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM22","meaning":"Parental responsibility","description":"to
-        be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM04A","meaning":"Secure accommodation order
-        - appeal","description":"to be represented on an application for a secure
-        accommodation order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM04E","meaning":"Secure accommodation order
-        - enforcement","description":"to be represented on an application for a secure
-        accommodation order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05","meaning":"Contact with a child in
-        care","description":"to be represented on an application for contact with
-        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05A","meaning":"Contact with a child in
-        care - appeal","description":"to be represented on an application for contact
-        with a child in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM05E","meaning":"Contact with a child in
-        care - enforcement","description":"to be represented on an application for
-        contact with a child in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06","meaning":"Supervision order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06A","meaning":"Supervision order - appeal
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM06E","meaning":"Supervision order - enforcement
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07","meaning":"Care order - discharge","description":"to
-        be represented on an application to discharge a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07A","meaning":"Care order - appeal -
-        discharge","description":"to be represented on an application to discharge
-        a care order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM07E","meaning":"Care order - enforcement
-        - discharge","description":"to be represented on an application to discharge
-        a care order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM08","meaning":"Education supervision order","description":"to
-        be represented on an application for an education supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM08A","meaning":"Education supervision
         order - appeal","description":"to be represented on an application for an
         education supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM08E","meaning":"Education supervision
-        order - enforcement","description":"to be represented on an application for
-        an education supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM09","meaning":"Recovery of children order","description":"to
-        be represented on an application for the recovery of a child/children.  Appeals
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM09A","meaning":"Recovery of children order
-        - appeal","description":"to be represented on an application for the recovery
-        of a child/children.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM04E","meaning":"Secure accommodation order
+        - enforcement","description":"to be represented on an application for a secure
+        accommodation order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
+        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM30A","meaning":"Placement order - appeal","description":"to
+        be represented on an application for a placement order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27","meaning":"Emergency protection order","description":"to
+        be represented on an application for or to extend an emergency protection
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM28","meaning":"Emergency protection order
+        - discharge","description":"to be represented on an application to discharge
+        an emergency protection order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM17A","meaning":"Specific issue order - appeal","description":"to
+        be represented on an application for a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB005","meaning":"Emergency protection order
+        - discharge","description":"to be represented on an application to discharge
+        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM23A","meaning":"Care order - appeal","description":"to
+        be represented on an application for a care order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36A","meaning":"Care order - joined party
+        - appeal","description":"to be represented on an application for a care order
+        Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB004","meaning":"Emergency protection order
+        - extend","description":"to be represented on an application for or to extend
+        an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM22A","meaning":"Parental responsibility
+        - appeal","description":"to be represented on an application for parental
+        responsibility.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32A","meaning":"Special guardianship order
+        - appeal","description":"to be represented on an application for a Special
+        Guardianship Order . Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM20","meaning":"Prohibited steps order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM02","meaning":"Adoption - not being held
+        in family proceedings court","description":"to be represented on an application
+        for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE007","meaning":"Prohibited steps order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM23","meaning":"Care order","description":"to
+        be represented on an application for a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM09E","meaning":"Recovery of children order
         - enforcement","description":"to be represented on an application for the
         recovery of a child/children.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM10","meaning":"Child assessment order
+        law family (PLF)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J
+        - amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM33A","meaning":"Revocation placement order
+        - appeal","description":"to be represented on an application for revocation
+        of a placement order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM30E","meaning":"Placement order - enforcement","description":"to
+        be represented on an application for a placement order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM36","meaning":"Care order - joined party","description":"to
+        be represented on an application for a care order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29A","meaning":"Exclusion requirement
+        - appeal","description":"to be represented on an application to vary/discharge
+        an exclusion requirement.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM06A","meaning":"Supervision order - appeal
         - vary or discharge","description":"to be represented on an application to
-        vary or discharge a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM10A","meaning":"Child assessment order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a child assessment order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11","meaning":"End contact with a child
-        in care","description":"to be represented on an application to terminate contact
-        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11A","meaning":"End contact with a child
-        in care - appeal","description":"to be represented on an application to terminate
-        contact with a child/children in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM11E","meaning":"End contact with a child
+        vary or discharge a supervision order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32","meaning":"Special guardianship order","description":"to
+        be represented on an application for a Special Guardianship Order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PB003","meaning":"Child assessment order","description":"to
+        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PB006","meaning":"Secure accommodation order","description":"to
+        be represented on an application for a secure accommodation order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM11E","meaning":"End contact with a child
         in care - enforcement","description":"to be represented on an application
         to terminate contact with a child/children in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM13","meaning":"Substitute supervision
-        with care","description":"to be represented on an application to substitute
-        a supervision order with care order under section 39 (4) Children Act 1989.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM13A","meaning":"Substitute supervision
-        with care - appeal","description":"to be represented on an application to
-        substitute a supervision order with care order under section 39 (4) Children
-        Act 1989. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM16","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary or discharge","description":"to be represented
+        on an application to vary or discharge a contact order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J
+        - appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM17E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM32E","meaning":"Special guardianship order
+        - enforcement","description":"to be represented on an application for a Special
+        Guardianship Order . Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM20E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM35A","meaning":"Special guardianship order
+        - appeal - vary or discharge","description":"To be represented on an application
+        for variation/discharge of a special guardianship order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM16A","meaning":"Prohibited steps order
         - appeal","description":"to be represented on an application for a prohibited
         steps order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM16E","meaning":"Prohibited steps order
+        law family (PLF)"},{"ccms_code":"PBM05A","meaning":"Contact with a child in
+        care - appeal","description":"to be represented on an application for contact
+        with a child in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM10","meaning":"Child assessment order
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order - who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM05E","meaning":"Contact with a child in
+        care - enforcement","description":"to be represented on an application for
+        contact with a child in care.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM30","meaning":"Placement order","description":"to
+        be represented on an application for a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19","meaning":"Child arrangements order
+        (CAO) - residence - vary or discharge","description":"to be represented on
+        an application to vary or discharge a residence order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM24E","meaning":"Supervision order - enforcement","description":"to
+        be represented on an application for a supervision order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
+        - appeal","description":"to be represented on an application for a prohibited
+        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM10A","meaning":"Child assessment order
+        - appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a child assessment order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM45","meaning":"Adoption order - parent
+        or parental responsibility","description":"To represent a parent or person
+        with parental responsibility on an application for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM26E","meaning":"Child assessment order
+        - enforcement","description":"to be represented on an application for a child
+        assessment order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary or discharge","description":"to be represented
+        on an application to vary or discharge a contact order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM35","meaning":"Special guardianship order
+        - vary or discharge","description":"To be represented on an application for
+        variation/discharge of a special guardianship order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM01A","meaning":"Declaration for overseas
+        adoption - appeal","description":"to be represented on an application for
+        a declaration as to an overseas adoption.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM16E","meaning":"Prohibited steps order
         - enforcement","description":"to be represented on an application for a prohibited
         steps order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM17","meaning":"Specific issue order","description":"to
         be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM17E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18","meaning":"Child arrangements order
-        (CAO) - contact - vary or discharge","description":"to be represented on an
-        application to vary or discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary or discharge","description":"to be represented
-        on an application to vary or discharge a contact order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM18E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary or discharge","description":"to be represented
-        on an application to vary or discharge a contact order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19","meaning":"Child arrangements order
-        (CAO) - residence - vary or discharge","description":"to be represented on
-        an application to vary or discharge a residence order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary or discharge","description":"to be represented
-        on an application to vary or discharge a residence order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM19E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary or discharge","description":"to be
-        represented on an application to vary or discharge a residence order. Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20","meaning":"Prohibited steps order
-        - vary or discharge","description":"to be represented on an application to
-        vary or discharge a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM20E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21","meaning":"Specific issue order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM21E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM22A","meaning":"Parental responsibility
-        - appeal","description":"to be represented on an application for parental
-        responsibility.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23","meaning":"Care order","description":"to
-        be represented on an application for a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23A","meaning":"Care order - appeal","description":"to
-        be represented on an application for a care order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM23E","meaning":"Care order - enforcement","description":"to
-        be represented on an application for a care order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24","meaning":"Supervision order","description":"to
-        be represented on an application for a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24A","meaning":"Supervision order - appeal","description":"to
-        be represented on an application for a supervision order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM24E","meaning":"Supervision order - enforcement","description":"to
-        be represented on an application for a supervision order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26","meaning":"Child assessment order","description":"to
-        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26A","meaning":"Child assessment order
-        - appeal","description":"to be represented on an application for a child assessment
-        order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM26E","meaning":"Child assessment order
-        - enforcement","description":"to be represented on an application for a child
-        assessment order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27","meaning":"Emergency protection order","description":"to
-        be represented on an application for or to extend an emergency protection
-        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27A","meaning":"Emergency protection order
-        - appeal","description":"to be represented on an application for or to extend
-        an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM27E","meaning":"Emergency protection order
-        - enforcement","description":"to be represented on an application for or to
-        extend an emergency protection order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM28","meaning":"Emergency protection order
-        - discharge","description":"to be represented on an application to discharge
-        an emergency protection order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM28A","meaning":"Emergency protection order
-        - appeal - discharge","description":"to be represented on an application to
-        discharge an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29","meaning":"Exclusion requirement","description":"to
-        be represented on an application to vary/discharge an exclusion requirement.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29A","meaning":"Exclusion requirement
-        - appeal","description":"to be represented on an application to vary/discharge
-        an exclusion requirement.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM29E","meaning":"Exclusion requirement
-        - enforcement","description":"to be represented on an application to vary/discharge
-        an exclusion requirement.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30","meaning":"Placement order","description":"to
-        be represented on an application for a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30A","meaning":"Placement order - appeal","description":"to
-        be represented on an application for a placement order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM30E","meaning":"Placement order - enforcement","description":"to
-        be represented on an application for a placement order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32","meaning":"Special guardianship order","description":"to
-        be represented on an application for a Special Guardianship Order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32A","meaning":"Special guardianship order
-        - appeal","description":"to be represented on an application for a Special
-        Guardianship Order . Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM32E","meaning":"Special guardianship order
-        - enforcement","description":"to be represented on an application for a Special
-        Guardianship Order . Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33","meaning":"Revocation placement order","description":"to
-        be represented on an application for revocation of a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM33A","meaning":"Revocation placement order
-        - appeal","description":"to be represented on an application for revocation
-        of a placement order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM33E","meaning":"Revocation placement order
         - enforcement","description":"to be represented on an application for revocation
         of a placement order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35","meaning":"Special guardianship order
-        - vary or discharge","description":"To be represented on an application for
-        variation/discharge of a special guardianship order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35A","meaning":"Special guardianship order
-        - appeal - vary or discharge","description":"To be represented on an application
-        for variation/discharge of a special guardianship order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM35E","meaning":"Special guardianship order
-        - enforcement - vary or discharge","description":"To be represented on an
-        application for variation/discharge of a special guardianship order.  Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36","meaning":"Care order - joined party","description":"to
-        be represented on an application for a care order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36A","meaning":"Care order - joined party
-        - appeal","description":"to be represented on an application for a care order
-        Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM36E","meaning":"Care order - joined party
-        - enforcement","description":"to be represented on an application for a care
-        order Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37","meaning":"Supervision order - joined
-        party","description":"to be represented on an application for a supervision
-        order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37A","meaning":"Supervision order - joined
+        law family (PLF)"},{"ccms_code":"PBM21A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM22","meaning":"Parental responsibility","description":"to
+        be represented on an application for parental responsibility.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27A","meaning":"Emergency protection order
+        - appeal","description":"to be represented on an application for or to extend
+        an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM04A","meaning":"Secure accommodation order
+        - appeal","description":"to be represented on an application for a secure
+        accommodation order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM08E","meaning":"Education supervision
+        order - enforcement","description":"to be represented on an application for
+        an education supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE014","meaning":"Child arrangements order
+        (CAO) - residence","description":"to be represented on an application for
+        a child arrangements order –where the child(ren) will live","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM37A","meaning":"Supervision order - joined
         party - appeal","description":"to be represented on an application for a supervision
         order  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM37E","meaning":"Supervision order - joined
-        party - enforcement","description":"to be represented on an application for
-        a supervision order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order - who the child(ren) spend time with","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order - who the child(ren) spend time with. Appeals
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM38E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order - who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM39","meaning":"Child arrangements order
         (CAO) - residence","description":"to be represented on an application for
         a child arrangements order - where the child(ren) will live.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order - where the child(ren) will live. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM39E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order - where the child(ren) will live. Enforcement
+        law family (PLF)"},{"ccms_code":"PBM13","meaning":"Substitute supervision
+        with care","description":"to be represented on an application to substitute
+        a supervision order with care order under section 39 (4) Children Act 1989.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM05","meaning":"Contact with a child in
+        care","description":"to be represented on an application for contact with
+        a child in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24A","meaning":"Supervision order - appeal","description":"to
+        be represented on an application for a supervision order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM08","meaning":"Education supervision order","description":"to
+        be represented on an application for an education supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM07","meaning":"Care order - discharge","description":"to
+        be represented on an application to discharge a care order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary or discharge","description":"to be represented
+        on an application to vary or discharge a residence order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM23E","meaning":"Care order - enforcement","description":"to
+        be represented on an application for a care order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order - who the child(ren) spend time with","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM09A","meaning":"Recovery of children order
+        - appeal","description":"to be represented on an application for the recovery
+        of a child/children.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM11","meaning":"End contact with a child
+        in care","description":"to be represented on an application to terminate contact
+        with a child/children in care.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM35E","meaning":"Special guardianship order
+        - enforcement - vary or discharge","description":"To be represented on an
+        application for variation/discharge of a special guardianship order.  Enforcement
         only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PB026","meaning":"Emergency protection order","description":"to
+        be represented on an application for an emergency protection order.","full_s8_only":false,"sca_core":true,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLW","ccms_matter":"special
+        children act (SCA)"},{"ccms_code":"PBM26","meaning":"Child assessment order","description":"to
+        be represented on an application for a child assessment order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM09","meaning":"Recovery of children order","description":"to
+        be represented on an application for the recovery of a child/children.  Appeals
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM37E","meaning":"Supervision order - joined
+        party - enforcement","description":"to be represented on an application for
+        a supervision order  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM40","meaning":"Placement order - parent
         or parental responsibility","description":"To represent a parent or person
         with parental responsibility on an application for a placement order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM40E","meaning":"Placement order - parent
-        or parental responsibility - enforcement","description":"To represent a parent
-        or person with parental responsibility on an application for a placement order.
-        Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
-        law family (PLF)"},{"ccms_code":"PBM45","meaning":"Adoption order - parent
-        or parental responsibility","description":"To represent a parent or person
-        with parental responsibility on an application for an adoption order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM11A","meaning":"End contact with a child
+        in care - appeal","description":"to be represented on an application to terminate
+        contact with a child/children in care.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"},{"ccms_code":"PBM45E","meaning":"Adoption order - parent
         or parental responsibility - enforcement","description":"To represent a parent
         or person with parental responsibility on an application for a placement order.
         Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM24","meaning":"Supervision order","description":"to
+        be represented on an application for a supervision order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM18","meaning":"Child arrangements order
+        (CAO) - contact - vary or discharge","description":"to be represented on an
+        application to vary or discharge a contact order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM39A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order - where the child(ren) will live. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM21E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM13A","meaning":"Substitute supervision
+        with care - appeal","description":"to be represented on an application to
+        substitute a supervision order with care order under section 39 (4) Children
+        Act 1989. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary","description":"to be represented on an
+        application to vary or discharge a child arrangements order –where the child(ren)
+        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM07A","meaning":"Care order - appeal - discharge","description":"to
+        be represented on an application to discharge a care order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM19E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary or discharge","description":"to be
+        represented on an application to vary or discharge a residence order. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM33","meaning":"Revocation placement order","description":"to
+        be represented on an application for revocation of a placement order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM06E","meaning":"Supervision order - enforcement
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a supervision order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM38A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order - who the child(ren) spend time with. Appeals
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM16","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29E","meaning":"Exclusion requirement
+        - enforcement","description":"to be represented on an application to vary/discharge
+        an exclusion requirement.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
+        for an injunction, order or declaration under the inherent jurisdiction of
+        the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM20A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"DA002","meaning":"Protection from harassment
+        act 1997 under section 5 - vary or discharge","description":"to be represented
+        on an application to vary or discharge an order under section 5 Protection
+        from Harassment Act 1997 where the parties are associated persons (as defined
+        by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"PBM07E","meaning":"Care order - enforcement - discharge","description":"to
+        be represented on an application to discharge a care order.  Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM37","meaning":"Supervision order - joined
+        party","description":"to be represented on an application for a supervision
+        order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM26A","meaning":"Child assessment order
+        - appeal","description":"to be represented on an application for a child assessment
+        order.  Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM39E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order - where the child(ren) will live. Enforcement
+        only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM29","meaning":"Exclusion requirement","description":"to
+        be represented on an application to vary/discharge an exclusion requirement.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM28A","meaning":"Emergency protection order
+        - appeal - discharge","description":"to be represented on an application to
+        discharge an emergency protection order. Appeals only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM40E","meaning":"Placement order - parent
+        or parental responsibility - enforcement","description":"To represent a parent
+        or person with parental responsibility on an application for a placement order.
+        Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":true,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J
+        and committal","description":"to be represented on an application for committal
+        and for an enforcement order under section 11J Children Act 1989. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"PBM21","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
+        law family (PLF)"},{"ccms_code":"PBM27E","meaning":"Emergency protection order
+        - enforcement","description":"to be represented on an application for or to
+        extend an emergency protection order. Enforcement only.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KPBLB","ccms_matter":"public
         law family (PLF)"}]}'
-  recorded_at: Fri, 14 Mar 2025 12:10:47 GMT
+  recorded_at: Wed, 07 May 2025 14:20:06 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE014
@@ -1086,14 +1078,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:10:49 GMT
+      - Wed, 07 May 2025 14:20:06 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1117,9 +1109,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 889210625bba386026f6864f3fc92ee8
+      - ae8d503b18c6e177220aa1fd596dbc3d
       x-runtime:
-      - '0.007459'
+      - '0.026122'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -1138,7 +1130,7 @@ http_interactions:
         representation on the return date."}},"service_levels":[{"level":1,"name":"Family
         Help (Higher)","stage":1,"proceeding_default":true},{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":false}]}'
-  recorded_at: Fri, 14 Mar 2025 12:10:48 GMT
+  recorded_at: Wed, 07 May 2025 14:20:06 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
@@ -1149,14 +1141,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:10:49 GMT
+      - Wed, 07 May 2025 14:20:07 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1176,19 +1168,136 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"a4884d98005d7bc6032facc11f462313"
+      - W/"87fd15f42e21dd78e379b020bdda1156"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 40e33399e43df243e47dec20f86a45d6
+      - 92ff806f8b00f5e4d3f74a1f4112759b
       x-runtime:
-      - '0.035823'
+      - '0.049906'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
+      string: '{"success":true,"data":[{"ccms_code":"DA004","meaning":"Non-molestation
+        order","description":"to be represented on an application for a non-molestation
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
+        vary or discharge","description":"to be represented on an application to vary
+        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
+        amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
+        appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order - appeal","description":"to
+        be represented on an application for a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary","description":"to be represented on an
+        application to vary or discharge a child arrangements order –where the child(ren)
+        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
         for an injunction, order or declaration under the inherent jurisdiction of
         the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
         abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
@@ -1196,128 +1305,11 @@ http_interactions:
         on an application to vary or discharge an order under section 5 Protection
         from Harassment Act 1997 where the parties are associated persons (as defined
         by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        abuse (DA)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and committal","description":"to
+        be represented on an application for committal and for an enforcement order
+        under section 11J Children Act 1989. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
         8 children (S8)"}]}'
-  recorded_at: Fri, 14 Mar 2025 12:10:48 GMT
+  recorded_at: Wed, 07 May 2025 14:20:07 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
@@ -1328,14 +1320,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:10:50 GMT
+      - Wed, 07 May 2025 14:20:08 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1355,19 +1347,136 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"a4884d98005d7bc6032facc11f462313"
+      - W/"87fd15f42e21dd78e379b020bdda1156"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - fc1fa8efc6dbbeb97e58d6abd0c27da4
+      - 62fd08ee4eae1ae1f929390b8cbfb249
       x-runtime:
-      - '0.034602'
+      - '0.041839'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
+      string: '{"success":true,"data":[{"ccms_code":"DA004","meaning":"Non-molestation
+        order","description":"to be represented on an application for a non-molestation
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
+        vary or discharge","description":"to be represented on an application to vary
+        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
+        amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
+        appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order - appeal","description":"to
+        be represented on an application for a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary","description":"to be represented on an
+        application to vary or discharge a child arrangements order –where the child(ren)
+        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
         for an injunction, order or declaration under the inherent jurisdiction of
         the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
         abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
@@ -1375,128 +1484,11 @@ http_interactions:
         on an application to vary or discharge an order under section 5 Protection
         from Harassment Act 1997 where the parties are associated persons (as defined
         by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        abuse (DA)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and committal","description":"to
+        be represented on an application for committal and for an enforcement order
+        under section 11J Children Act 1989. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
         8 children (S8)"}]}'
-  recorded_at: Fri, 14 Mar 2025 12:10:49 GMT
+  recorded_at: Wed, 07 May 2025 14:20:08 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
@@ -1507,14 +1499,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:10:52 GMT
+      - Wed, 07 May 2025 14:20:09 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -1534,19 +1526,136 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"a4884d98005d7bc6032facc11f462313"
+      - W/"87fd15f42e21dd78e379b020bdda1156"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 517bbf974704a0eb2c18590baeb3ff2b
+      - e051689f0c6bd7e1078af9c28ad297a6
       x-runtime:
-      - '0.041064'
+      - '0.051263'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
+      string: '{"success":true,"data":[{"ccms_code":"DA004","meaning":"Non-molestation
+        order","description":"to be represented on an application for a non-molestation
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
+        vary or discharge","description":"to be represented on an application to vary
+        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
+        amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
+        appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order - appeal","description":"to
+        be represented on an application for a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
+        - enforcement","description":"to be represented on an application for a prohibited
+        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary","description":"to be represented on an
+        application to vary or discharge a child arrangements order –where the child(ren)
+        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
         for an injunction, order or declaration under the inherent jurisdiction of
         the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
         abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
@@ -1554,131 +1663,14 @@ http_interactions:
         on an application to vary or discharge an order under section 5 Protection
         from Harassment Act 1997 where the parties are associated persons (as defined
         by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order
-        - appeal","description":"to be represented on an application for a prohibited
-        steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        abuse (DA)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and committal","description":"to
+        be represented on an application for committal and for an enforcement order
+        under section 11J Children Act 1989. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
         8 children (S8)"}]}'
-  recorded_at: Fri, 14 Mar 2025 12:10:51 GMT
+  recorded_at: Wed, 07 May 2025 14:20:09 GMT
 - request:
     method: get
-    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE003
+    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE003A
     body:
       encoding: US-ASCII
       string: ''
@@ -1686,18 +1678,18 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:10:52 GMT
+      - Wed, 07 May 2025 14:20:09 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '1273'
+      - '1079'
       connection:
       - keep-alive
       x-frame-options:
@@ -1713,52 +1705,49 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"a8e301f6c68a975b72f8a70c56accb66"
+      - W/"ba9560387b672121cea7f794cdd78627"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - e836b62e11b0ec2fc17231cb645fbc75
+      - 9f9719c54900e907b103f4c0dfb23333
       x-runtime:
-      - '0.006304'
+      - '0.020681'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"ccms_code":"SE003","meaning":"Prohibited steps order","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","name":"prohibited_steps_order_s8","description":"to
-        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_matter":"section
-        8 children (S8)","cost_limitations":{"substantive":{"start_date":"1970-01-01","value":"25000.0"},"delegated_functions":{"start_date":"2021-09-13","value":"2250.0"}},"default_scope_limitations":{"substantive":{"code":"FM059","meaning":"FHH
-        Children","description":"Limited to Family Help (Higher) and to all steps
-        necessary to negotiate and conclude a settlement. To include the issue of
-        proceedings and representation in those proceedings save in relation to or
-        at a contested final hearing."},"delegated_functions":{"code":"CV117","meaning":"Interim
-        order inc. return date","description":"Limited to all steps necessary to apply
-        for an interim order; where application is made without notice to include
-        representation on the return date."}},"service_levels":[{"level":1,"name":"Family
-        Help (Higher)","stage":1,"proceeding_default":true},{"level":3,"name":"Full
-        Representation","stage":8,"proceeding_default":false}]}'
-  recorded_at: Fri, 14 Mar 2025 12:10:51 GMT
+      string: '{"success":true,"ccms_code":"SE003A","meaning":"Prohibited steps order
+        - appeal","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","name":"prohibited_steps_order_appeal_s8","description":"to
+        be represented on an application for a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"ccms_category_law":"Family","ccms_matter":"section
+        8 children (S8)","cost_limitations":{"substantive":{"start_date":"1970-01-01","value":"5000.0"},"delegated_functions":{"start_date":"2021-09-13","value":"2250.0"}},"default_scope_limitations":{"substantive":{"code":"CV079","meaning":"Counsel''s
+        Opinion","description":"Limited to obtaining external Counsel''s Opinion or
+        the opinion of an external solicitor with higher court advocacy rights on
+        the information already available."},"delegated_functions":{"code":"CV118","meaning":"Hearing","description":"Limited
+        to all steps up to and including the hearing on [see additional limitation
+        notes]"}},"service_levels":[{"level":3,"name":"Full Representation","stage":8,"proceeding_default":true}]}'
+  recorded_at: Wed, 07 May 2025 14:20:09 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
     body:
       encoding: UTF-8
-      string: '{"current_proceedings":["SE014","SE003"],"allowed_categories":["MAT"],"search_term":""}'
+      string: '{"current_proceedings":["SE014","SE003A"],"allowed_categories":["MAT"],"search_term":""}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:10:53 GMT
+      - Wed, 07 May 2025 14:20:10 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '15896'
+      - '15872'
       connection:
       - keep-alive
       x-frame-options:
@@ -1774,19 +1763,134 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"637a81edb26725e4212bf343f42858c4"
+      - W/"2c0ee6cf98b7260dea00b7dba53864a4"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 25847238b0a71041ec5da109ccd32f3e
+      - 1f9e2639ac5f597286bf61083feae2ee
       x-runtime:
-      - '0.037055'
+      - '0.048927'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
+      string: '{"success":true,"data":[{"ccms_code":"DA004","meaning":"Non-molestation
+        order","description":"to be represented on an application for a non-molestation
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
+        vary or discharge","description":"to be represented on an application to vary
+        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
+        amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
+        appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order - enforcement","description":"to
+        be represented on an application for a prohibited steps order.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary","description":"to be represented on an
+        application to vary or discharge a child arrangements order –where the child(ren)
+        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
         for an injunction, order or declaration under the inherent jurisdiction of
         the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
         abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
@@ -1794,147 +1898,33 @@ http_interactions:
         on an application to vary or discharge an order under section 5 Protection
         from Harassment Act 1997 where the parties are associated persons (as defined
         by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order - appeal","description":"to
-        be represented on an application for a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        abuse (DA)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and committal","description":"to
+        be represented on an application for committal and for an enforcement order
+        under section 11J Children Act 1989. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
         8 children (S8)"}]}'
-  recorded_at: Fri, 14 Mar 2025 12:10:52 GMT
+  recorded_at: Wed, 07 May 2025 14:20:10 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
     body:
       encoding: UTF-8
-      string: '{"current_proceedings":["SE014","SE003"],"allowed_categories":["MAT"],"search_term":""}'
+      string: '{"current_proceedings":["SE014","SE003A"],"allowed_categories":["MAT"],"search_term":""}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:10:54 GMT
+      - Wed, 07 May 2025 14:20:11 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '15896'
+      - '15872'
       connection:
       - keep-alive
       x-frame-options:
@@ -1950,19 +1940,134 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"637a81edb26725e4212bf343f42858c4"
+      - W/"2c0ee6cf98b7260dea00b7dba53864a4"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - c0a3d6f2c4fc4330c0a13f1d0edc814d
+      - 4bdc759178eedd6d3e871fecfb292f35
       x-runtime:
-      - '0.037653'
+      - '0.044813'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
+      string: '{"success":true,"data":[{"ccms_code":"DA004","meaning":"Non-molestation
+        order","description":"to be represented on an application for a non-molestation
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
+        vary or discharge","description":"to be represented on an application to vary
+        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
+        amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
+        appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order - enforcement","description":"to
+        be represented on an application for a prohibited steps order.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary","description":"to be represented on an
+        application to vary or discharge a child arrangements order –where the child(ren)
+        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
         for an injunction, order or declaration under the inherent jurisdiction of
         the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
         abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
@@ -1970,147 +2075,33 @@ http_interactions:
         on an application to vary or discharge an order under section 5 Protection
         from Harassment Act 1997 where the parties are associated persons (as defined
         by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order - appeal","description":"to
-        be represented on an application for a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        abuse (DA)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and committal","description":"to
+        be represented on an application for committal and for an enforcement order
+        under section 11J Children Act 1989. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
         8 children (S8)"}]}'
-  recorded_at: Fri, 14 Mar 2025 12:10:53 GMT
+  recorded_at: Wed, 07 May 2025 14:20:11 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
     body:
       encoding: UTF-8
-      string: '{"current_proceedings":["SE014","SE003"],"allowed_categories":["MAT"],"search_term":""}'
+      string: '{"current_proceedings":["SE014","SE003A"],"allowed_categories":["MAT"],"search_term":""}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:10:56 GMT
+      - Wed, 07 May 2025 14:20:12 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '15896'
+      - '15872'
       connection:
       - keep-alive
       x-frame-options:
@@ -2126,19 +2117,134 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"637a81edb26725e4212bf343f42858c4"
+      - W/"2c0ee6cf98b7260dea00b7dba53864a4"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 5f0f1f9e50fd7aa17df90d2e37259c98
+      - 1a40dc6c325b02adab6e695e8b738d6b
       x-runtime:
-      - '0.035468'
+      - '0.058050'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
+      string: '{"success":true,"data":[{"ccms_code":"DA004","meaning":"Non-molestation
+        order","description":"to be represented on an application for a non-molestation
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
+        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
+        vary or discharge","description":"to be represented on an application to vary
+        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
+        amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
+        appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order - enforcement","description":"to
+        be represented on an application for a prohibited steps order.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary","description":"to be represented on an
+        application to vary or discharge a child arrangements order –where the child(ren)
+        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
         for an injunction, order or declaration under the inherent jurisdiction of
         the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
         abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
@@ -2146,125 +2252,11 @@ http_interactions:
         on an application to vary or discharge an order under section 5 Protection
         from Harassment Act 1997 where the parties are associated persons (as defined
         by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order - appeal","description":"to
-        be represented on an application for a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004","meaning":"Specific issue order","description":"to
-        be represented on an application for a specific issue order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        abuse (DA)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and committal","description":"to
+        be represented on an application for committal and for an enforcement order
+        under section 11J Children Act 1989. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
         8 children (S8)"}]}'
-  recorded_at: Fri, 14 Mar 2025 12:10:55 GMT
+  recorded_at: Wed, 07 May 2025 14:20:12 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE004
@@ -2275,14 +2267,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:10:56 GMT
+      - Wed, 07 May 2025 14:20:13 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2306,9 +2298,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 20a0bde5e0e831489599bd7ddedcc1d9
+      - d080c6e7d162e344a19671c397d64bb1
       x-runtime:
-      - '0.006426'
+      - '0.015285'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2325,29 +2317,29 @@ http_interactions:
         representation on the return date."}},"service_levels":[{"level":1,"name":"Family
         Help (Higher)","stage":1,"proceeding_default":true},{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":false}]}'
-  recorded_at: Fri, 14 Mar 2025 12:10:55 GMT
+  recorded_at: Wed, 07 May 2025 14:20:13 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
     body:
       encoding: UTF-8
-      string: '{"current_proceedings":["SE014","SE003","SE004"],"allowed_categories":["MAT"],"search_term":""}'
+      string: '{"current_proceedings":["SE014","SE003A","SE004"],"allowed_categories":["MAT"],"search_term":""}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:10:58 GMT
+      - Wed, 07 May 2025 14:20:13 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '15547'
+      - '15523'
       connection:
       - keep-alive
       x-frame-options:
@@ -2363,19 +2355,132 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"9b091a2e46c24aa91ba986477c80a8e5"
+      - W/"f2467d03713a435c646711d0c9941813"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - c07382e446fc8b6aacf285f19b894354
+      - f090017b1a1fb2c12b72304b7584ae69
       x-runtime:
-      - '0.080710'
+      - '0.049022'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
+      string: '{"success":true,"data":[{"ccms_code":"DA004","meaning":"Non-molestation
+        order","description":"to be represented on an application for a non-molestation
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007","meaning":"Prohibited steps order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
+        amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
+        appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order - enforcement","description":"to
+        be represented on an application for a prohibited steps order.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary","description":"to be represented on an
+        application to vary or discharge a child arrangements order –where the child(ren)
+        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
         for an injunction, order or declaration under the inherent jurisdiction of
         the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
         abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
@@ -2383,123 +2488,11 @@ http_interactions:
         on an application to vary or discharge an order under section 5 Protection
         from Harassment Act 1997 where the parties are associated persons (as defined
         by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order - appeal","description":"to
-        be represented on an application for a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        abuse (DA)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and committal","description":"to
+        be represented on an application for committal and for an enforcement order
+        under section 11J Children Act 1989. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
         8 children (S8)"}]}'
-  recorded_at: Fri, 14 Mar 2025 12:10:57 GMT
+  recorded_at: Wed, 07 May 2025 14:20:13 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/SE014
@@ -2510,14 +2503,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:10:59 GMT
+      - Wed, 07 May 2025 14:20:14 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2541,9 +2534,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - ab8e29b248f39850677f98bc3d3a706f
+      - 24e243d6f82f94857fb6f235e86aa2b0
       x-runtime:
-      - '0.001708'
+      - '0.002967'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2551,7 +2544,7 @@ http_interactions:
       string: '{"success":true,"client_involvement_type":[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]}'
-  recorded_at: Fri, 14 Mar 2025 12:10:58 GMT
+  recorded_at: Wed, 07 May 2025 14:20:14 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/SE014
@@ -2562,14 +2555,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:10:59 GMT
+      - Wed, 07 May 2025 14:20:15 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2593,9 +2586,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 6d1f32fefae811a38d8fdf03ecb28ba9
+      - a0fb1debddc113535dd642ecf0150dfb
       x-runtime:
-      - '0.002137'
+      - '0.003995'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2603,7 +2596,7 @@ http_interactions:
       string: '{"success":true,"client_involvement_type":[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]}'
-  recorded_at: Fri, 14 Mar 2025 12:10:58 GMT
+  recorded_at: Wed, 07 May 2025 14:20:15 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -2614,14 +2607,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:11:01 GMT
+      - Wed, 07 May 2025 14:20:16 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2645,9 +2638,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 43cbdbed179c67be30c1243683ef04eb
+      - 827134cf10ed6d395787909b9fc142cf
       x-runtime:
-      - '0.007396'
+      - '0.015329'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2657,7 +2650,7 @@ http_interactions:
         order inc. return date","description":"Limited to all steps necessary to apply
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 12:11:00 GMT
+  recorded_at: Wed, 07 May 2025 14:20:16 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -2668,14 +2661,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:11:01 GMT
+      - Wed, 07 May 2025 14:20:17 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2699,9 +2692,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - b7ad85d5671c9ee888f1e967e96a4be1
+      - 772754fdde42a69d96afa06350eae767
       x-runtime:
-      - '0.005175'
+      - '0.014296'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2711,7 +2704,7 @@ http_interactions:
         order inc. return date","description":"Limited to all steps necessary to apply
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 12:11:00 GMT
+  recorded_at: Wed, 07 May 2025 14:20:17 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE014
@@ -2722,14 +2715,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:11:02 GMT
+      - Wed, 07 May 2025 14:20:17 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2753,9 +2746,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - b59641d89405f3abffe25ef9b990820d
+      - 9471d430f51318ea66302b922b69f567
       x-runtime:
-      - '0.006807'
+      - '0.013530'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2774,7 +2767,7 @@ http_interactions:
         representation on the return date."}},"service_levels":[{"level":1,"name":"Family
         Help (Higher)","stage":1,"proceeding_default":true},{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":false}]}'
-  recorded_at: Fri, 14 Mar 2025 12:11:01 GMT
+  recorded_at: Wed, 07 May 2025 14:20:17 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE014
@@ -2785,14 +2778,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:11:02 GMT
+      - Wed, 07 May 2025 14:20:18 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2816,9 +2809,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 44af72746e2dcd8039c7de20defcc97c
+      - f2befeaf505074145915432185760957
       x-runtime:
-      - '0.005576'
+      - '0.012331'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2837,7 +2830,7 @@ http_interactions:
         representation on the return date."}},"service_levels":[{"level":1,"name":"Family
         Help (Higher)","stage":1,"proceeding_default":true},{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":false}]}'
-  recorded_at: Fri, 14 Mar 2025 12:11:01 GMT
+  recorded_at: Wed, 07 May 2025 14:20:18 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -2848,14 +2841,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:11:03 GMT
+      - Wed, 07 May 2025 14:20:18 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2879,9 +2872,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - c64911edc81b9da9145d96edbc6d05b7
+      - cc6ef5c0e7aac0e100d1e18932539a0a
       x-runtime:
-      - '0.004775'
+      - '0.014788'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2891,7 +2884,7 @@ http_interactions:
         order inc. return date","description":"Limited to all steps necessary to apply
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 12:11:01 GMT
+  recorded_at: Wed, 07 May 2025 14:20:18 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_scopes
@@ -2902,14 +2895,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:11:03 GMT
+      - Wed, 07 May 2025 14:20:18 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -2933,9 +2926,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 275ef648f270e1e46dfef1e6f8a3ddba
+      - 79db21e3ed147ba4fe8a4809853b09a0
       x-runtime:
-      - '0.011928'
+      - '0.050065'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -2962,7 +2955,7 @@ http_interactions:
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]},{"code":"FM015","meaning":"Section
         37 Report","description":"Limited to a section 37 report only.","additional_params":[]}]}}'
-  recorded_at: Fri, 14 Mar 2025 12:11:02 GMT
+  recorded_at: Wed, 07 May 2025 14:20:18 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/SE014
@@ -2973,14 +2966,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:11:04 GMT
+      - Wed, 07 May 2025 14:20:19 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -3004,9 +2997,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 8fa818a957b6b702fb5347b5a5073d74
+      - 7e33aa6d01ed2a430b80a5d0fe312e39
       x-runtime:
-      - '0.006299'
+      - '0.017227'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -3025,7 +3018,7 @@ http_interactions:
         representation on the return date."}},"service_levels":[{"level":1,"name":"Family
         Help (Higher)","stage":1,"proceeding_default":true},{"level":3,"name":"Full
         Representation","stage":8,"proceeding_default":false}]}'
-  recorded_at: Fri, 14 Mar 2025 12:11:03 GMT
+  recorded_at: Wed, 07 May 2025 14:20:18 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_type_defaults
@@ -3036,14 +3029,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:11:04 GMT
+      - Wed, 07 May 2025 14:20:19 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -3067,9 +3060,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - bceae13b883c94d01a99cd476005dbc8
+      - 17df3f48d9b0c413d1e93e7ceb33dade
       x-runtime:
-      - '0.004441'
+      - '0.011257'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -3079,7 +3072,7 @@ http_interactions:
         order inc. return date","description":"Limited to all steps necessary to apply
         for an interim order; where application is made without notice to include
         representation on the return date.","additional_params":[]}}'
-  recorded_at: Fri, 14 Mar 2025 12:11:03 GMT
+  recorded_at: Wed, 07 May 2025 14:20:19 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/SE014
@@ -3090,14 +3083,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:11:06 GMT
+      - Wed, 07 May 2025 14:20:20 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -3121,9 +3114,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 9427dca7d647a9dab9effe8593e8177a
+      - 10f878f10a170b99d1505abc8ab25dad
       x-runtime:
-      - '0.001730'
+      - '0.002977'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -3131,29 +3124,29 @@ http_interactions:
       string: '{"success":true,"client_involvement_type":[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]}'
-  recorded_at: Fri, 14 Mar 2025 12:11:05 GMT
+  recorded_at: Wed, 07 May 2025 14:20:20 GMT
 - request:
     method: post
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/proceeding_types/filter
     body:
       encoding: UTF-8
-      string: '{"current_proceedings":["SE014","SE003","SE004"],"allowed_categories":["MAT"],"search_term":""}'
+      string: '{"current_proceedings":["SE014","SE003A","SE004"],"allowed_categories":["MAT"],"search_term":""}'
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:11:06 GMT
+      - Wed, 07 May 2025 14:20:20 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
-      - '15547'
+      - '15523'
       connection:
       - keep-alive
       x-frame-options:
@@ -3169,19 +3162,132 @@ http_interactions:
       vary:
       - Accept, Origin
       etag:
-      - W/"9b091a2e46c24aa91ba986477c80a8e5"
+      - W/"f2467d03713a435c646711d0c9941813"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - d6ab69413f63234f6505c2ac5a7b5be3
+      - ef38f1283f6f0fcb3241826918543507
       x-runtime:
-      - '0.041768'
+      - '0.079175'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"success":true,"data":[{"ccms_code":"DA001","meaning":"Inherent jurisdiction
-        - high court injunction","description":"to be represented on an application
+      string: '{"success":true,"data":[{"ccms_code":"DA004","meaning":"Non-molestation
+        order","description":"to be represented on an application for a non-molestation
+        order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
+        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007","meaning":"Prohibited steps order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
+        or discharge","description":"to be represented on an application to vary or
+        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
+        amendment following breach","description":"to be represented on an application,
+        following breach, for an amendment to an enforcement order or for a further
+        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA007","meaning":"Forced marriage protection
+        order","description":"to be represented on an application for a forced marriage
+        protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
+        be represented on an application to extend, vary or discharge an order under
+        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
+        (CAO) - contact - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
+        - enforcement - vary or discharge","description":"to be represented on an
+        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
+        appeal","description":"to be represented on an application for an enforcement
+        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
+        (CAO) - contact - appeal","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Appeals
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
+        (CAO) - contact","description":"to be represented on an application for a
+        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement - vary","description":"to be represented on
+        an application to vary or discharge a child arrangements order –where the
+        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA020","meaning":"Female genital mutilation
+        (FGM) protection order","description":"To be represented on an application
+        for a Female Genital Mutilation Protection Order under the Female Genital
+        Mutilation Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order - appeal
+        - vary or discharge","description":"to be represented on an application to
+        vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
+        be represented in an action for an injunction under section 3 Protection from
+        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
+        abuse (DA)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order - enforcement","description":"to
+        be represented on an application for a prohibited steps order.  Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement - vary","description":"to be represented on
+        an application to vary/discharge a child arrangements order-who the child(ren)
+        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
+        revocation","description":"to be represented on an application for the revocation
+        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
+        (CAO) - residence - vary","description":"to be represented on an application
+        to vary or discharge a child arrangements order –where the child(ren) will
+        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE003","meaning":"Prohibited steps order","description":"to
+        be represented on an application for a prohibited steps order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
+        (CAO) - contact - enforcement","description":"to be represented on an application
+        for a child arrangements order-who the child(ren) spend time with. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
+        appeal","description":"to be represented on an application for a specific
+        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
+        be represented on an application for an enforcement order under section 11J
+        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
+        enforcement - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
+        (CAO) - residence - appeal - vary","description":"to be represented on an
+        application to vary or discharge a child arrangements order –where the child(ren)
+        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
+        (CAO) - contact - appeal - vary","description":"to be represented on an application
+        to vary/discharge a child arrangements order-who the child(ren) spend time
+        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
+        appeal - vary or discharge","description":"to be represented on an application
+        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
+        be represented on an application for compensation for financial loss under
+        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
+        revocation - appeal","description":"to be represented on an application for
+        the revocation of an enforcement order under section 11J and Schedule A1 Children
+        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
+        (CAO) - residence - enforcement","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Enforcement
+        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
+        (CAO) - residence - appeal","description":"to be represented on an application
+        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
+        enforcement","description":"to be represented on an application for a specific
+        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        8 children (S8)"},{"ccms_code":"DA001","meaning":"Inherent jurisdiction -
+        high court injunction","description":"to be represented on an application
         for an injunction, order or declaration under the inherent jurisdiction of
         the court.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
         abuse (DA)"},{"ccms_code":"DA002","meaning":"Protection from harassment act
@@ -3189,123 +3295,11 @@ http_interactions:
         on an application to vary or discharge an order under section 5 Protection
         from Harassment Act 1997 where the parties are associated persons (as defined
         by Part IV Family Law Act 1996).","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA003","meaning":"Harassment - injunction","description":"to
-        be represented in an action for an injunction under section 3 Protection from
-        Harassment Act 1997.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA004","meaning":"Non-molestation order","description":"to
-        be represented on an application for a non-molestation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA005","meaning":"Occupation order","description":"to
-        be represented on an application for an occupation order.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA006","meaning":"Part IV - extend, vary or discharge","description":"to
-        be represented on an application to extend, vary or discharge an order under
-        Part IV Family Law Act 1996","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA007","meaning":"Forced marriage protection order","description":"to
-        be represented on an application for a forced marriage protection order","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"DA020","meaning":"Female genital mutilation (FGM)
-        protection order","description":"To be represented on an application for a
-        Female Genital Mutilation Protection Order under the Female Genital Mutilation
-        Act.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"MINJN","ccms_matter":"domestic
-        abuse (DA)"},{"ccms_code":"SE003A","meaning":"Prohibited steps order - appeal","description":"to
-        be represented on an application for a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE003E","meaning":"Prohibited steps order
-        - enforcement","description":"to be represented on an application for a prohibited
-        steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004A","meaning":"Specific issue order -
-        appeal","description":"to be represented on an application for a specific
-        issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE004E","meaning":"Specific issue order -
-        enforcement","description":"to be represented on an application for a specific
-        issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007","meaning":"Prohibited steps order -
-        vary or discharge","description":"to be represented on an application to vary
-        or discharge a prohibited steps order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007A","meaning":"Prohibited steps order
-        - appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a prohibited steps order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE007E","meaning":"Prohibited steps order
-        - enforcement - vary or discharge","description":"to be represented on an
-        application to vary or discharge a prohibited steps order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008","meaning":"Specific issue order - vary
-        or discharge","description":"to be represented on an application to vary or
-        discharge a specific issue order.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008A","meaning":"Specific issue order -
-        appeal - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE008E","meaning":"Specific issue order -
-        enforcement - vary or discharge","description":"to be represented on an application
-        to vary or discharge a specific issue order.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013","meaning":"Child arrangements order
-        (CAO) - contact","description":"to be represented on an application for a
-        child arrangements order-who the child(ren) spend time with.","full_s8_only":false,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013A","meaning":"Child arrangements order
-        (CAO) - contact - appeal","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Appeals
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE013E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement","description":"to be represented on an application
-        for a child arrangements order-who the child(ren) spend time with. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014A","meaning":"Child arrangements order
-        (CAO) - residence - appeal","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE014E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement","description":"to be represented on an application
-        for a child arrangements order –where the child(ren) will live. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015","meaning":"Child arrangements order
-        (CAO) - contact - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015A","meaning":"Child arrangements order
-        (CAO) - contact - appeal - vary","description":"to be represented on an application
-        to vary/discharge a child arrangements order-who the child(ren) spend time
-        with. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE015E","meaning":"Child arrangements order
-        (CAO) - contact - enforcement - vary","description":"to be represented on
-        an application to vary/discharge a child arrangements order-who the child(ren)
-        spend time with. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016","meaning":"Child arrangements order
-        (CAO) - residence - vary","description":"to be represented on an application
-        to vary or discharge a child arrangements order –where the child(ren) will
-        live.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016A","meaning":"Child arrangements order
-        (CAO) - residence - appeal - vary","description":"to be represented on an
-        application to vary or discharge a child arrangements order –where the child(ren)
-        will live. Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE016E","meaning":"Child arrangements order
-        (CAO) - residence - enforcement - vary","description":"to be represented on
-        an application to vary or discharge a child arrangements order –where the
-        child(ren) will live. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095","meaning":"Enforcement order 11J","description":"to
-        be represented on an application for an enforcement order under section 11J
-        Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE095A","meaning":"Enforcement order 11J -
-        appeal","description":"to be represented on an application for an enforcement
-        order under section 11J Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and
-        committal","description":"to be represented on an application for committal
-        and for an enforcement order under section 11J Children Act 1989. Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097","meaning":"Enforcement order 11J -
-        revocation","description":"to be represented on an application for the revocation
-        of an enforcement order under section 11J and Schedule A1 Children Act 1989.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE097A","meaning":"Enforcement order 11J -
-        revocation - appeal","description":"to be represented on an application for
-        the revocation of an enforcement order under section 11J and Schedule A1 Children
-        Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE100E","meaning":"Enforcement order 11J -
-        amendment following breach","description":"to be represented on an application,
-        following breach, for an amendment to an enforcement order or for a further
-        enforcement order under section 11J and Schedule A1 Children Act 1989.  Enforcement
-        only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101A","meaning":"Compensation - appeal","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Appeals only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
-        8 children (S8)"},{"ccms_code":"SE101E","meaning":"Compensation - enforcement","description":"to
-        be represented on an application for compensation for financial loss under
-        section 11O Children Act 1989.  Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
+        abuse (DA)"},{"ccms_code":"SE096E","meaning":"Enforcement order 11J and committal","description":"to
+        be represented on an application for committal and for an enforcement order
+        under section 11J Children Act 1989. Enforcement only.","full_s8_only":true,"sca_core":false,"sca_related":false,"non_means_tested_plf":false,"ccms_category_law":"Family","ccms_category_law_code":"MAT","ccms_matter_code":"KSEC8","ccms_matter":"section
         8 children (S8)"}]}'
-  recorded_at: Fri, 14 Mar 2025 12:11:06 GMT
+  recorded_at: Wed, 07 May 2025 14:20:20 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/SE014
@@ -3316,14 +3310,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:11:08 GMT
+      - Wed, 07 May 2025 14:20:21 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -3347,9 +3341,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - '068e150da29f1981593fa47cd1ed9898'
+      - 2bf92084a00faee50149f256f360d131
       x-runtime:
-      - '0.008300'
+      - '0.007698'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -3357,7 +3351,7 @@ http_interactions:
       string: '{"success":true,"client_involvement_type":[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]}'
-  recorded_at: Fri, 14 Mar 2025 12:11:07 GMT
+  recorded_at: Wed, 07 May 2025 14:20:21 GMT
 - request:
     method: get
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/client_involvement_types/SE014
@@ -3368,14 +3362,14 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.12.2
+      - Faraday v2.13.1
   response:
     status:
       code: 200
       message: OK
     headers:
       date:
-      - Fri, 14 Mar 2025 12:11:08 GMT
+      - Wed, 07 May 2025 14:20:22 GMT
       content-type:
       - application/json; charset=utf-8
       content-length:
@@ -3399,9 +3393,9 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - '068e150da29f1981593fa47cd1ed9898'
+      - 73eafee0ff84dd0a492aef732386f872
       x-runtime:
-      - '0.008300'
+      - '0.002753'
       strict-transport-security:
       - max-age=31536000; includeSubDomains
     body:
@@ -3409,5 +3403,5 @@ http_interactions:
       string: '{"success":true,"client_involvement_type":[{"ccms_code":"A","description":"Applicant/claimant/petitioner"},{"ccms_code":"D","description":"Defendant/respondent"},{"ccms_code":"W","description":"Subject
         of proceedings (child)"},{"ccms_code":"I","description":"Intervenor"},{"ccms_code":"Z","description":"Joined
         party"}]}'
-  recorded_at: Fri, 14 Mar 2025 12:11:07 GMT
+  recorded_at: Wed, 07 May 2025 14:20:22 GMT
 recorded_with: VCR 6.3.1

--- a/features/providers/cost_override.feature
+++ b/features/providers/cost_override.feature
@@ -20,7 +20,7 @@ Feature: Emergency cost override
     And I should be on a page showing "What does your client want legal aid for?"
     When I search for proceeding 'Non-molestation order'
     Then proceeding suggestions has results
-    When I choose a proceeding type 'Non-molestation order' radio button
+    When I choose a 'Non-molestation order' radio button
     When I click 'Save and continue'
     Then I should be on a page showing 'Do you want to add another proceeding?'
     When I choose 'No'

--- a/features/providers/proceeding_loop.feature
+++ b/features/providers/proceeding_loop.feature
@@ -29,8 +29,8 @@ Feature: Loop through proceeding questions
     And I should be on a page showing "What does your client want legal aid for?"
 
   Scenario: When provider does not accept default levels of service
-    Given I search for proceeding type "Child arrangements order CAO"
-    And I choose "Child arrangements order (CAO) - residence - appeal"
+    Given I search for proceeding type "Child arrangements order CAO Section 8"
+    And I choose a "Child arrangements order (CAO) - residence - appeal" radio button
 
     When I click 'Save and continue'
     Then I should be on a page with title "Do you want to add another proceeding?"
@@ -169,8 +169,8 @@ Feature: Loop through proceeding questions
     Then I should be on a page with title "Does your client have a National Insurance number?"
 
   Scenario: When provider accepts default levels of service
-    Given I search for proceeding type "Child arrangements order CAO"
-    And I choose "Child arrangements order (CAO) - residence - appeal"
+    Given I search for proceeding type "Child arrangements order CAO Section 8"
+    And I choose a "Child arrangements order (CAO) - residence - appeal" radio button
 
     When I click 'Save and continue'
     Then I should be on a page with title "Do you want to add another proceeding?"

--- a/features/providers/regressions/back_button_on_proceedings.feature
+++ b/features/providers/regressions/back_button_on_proceedings.feature
@@ -22,7 +22,7 @@ Feature: Using the back button on proceedings should not lock a user out
     Then I should be on a page showing "What does your client want legal aid for?"
     When I search for proceeding 'Non-molestation order'
     Then proceeding suggestions has results
-    When I choose a proceeding type 'Non-molestation order' radio button
+    When I choose a 'Non-molestation order' radio button
     And I click 'Save and continue'
     Then I should be on a page showing 'Do you want to add another proceeding?'
 

--- a/features/providers/special_children_act/secure_accomodation_order_cit.feature
+++ b/features/providers/special_children_act/secure_accomodation_order_cit.feature
@@ -21,10 +21,10 @@ Feature: Adding an SCA Secure Accommodation Order proceeding sets all client_inv
     When I click 'Use this address'
 
     Then I should be on a page showing "What does your client want legal aid for?"
-    When I search for proceeding 'Child assessment order'
+    When I search for proceeding 'Child assessment order SCA'
     Then proceeding suggestions has results
 
-    When I choose a proceeding type 'Child assessment order' radio button
+    When I choose a 'Child assessment order' radio button
     And I click 'Save and continue'
 
     Then I should be on the "proceeding_issue_status" page showing "Has this proceeding been issued?"
@@ -46,10 +46,10 @@ Feature: Adding an SCA Secure Accommodation Order proceeding sets all client_inv
     And I click 'Save and continue'
 
     Then I should be on a page showing "What does your client want legal aid for?"
-    When I search for proceeding 'secure accommodation order'
+    When I search for proceeding 'secure accommodation order SCA'
     Then proceeding suggestions has results
 
-    When I choose a proceeding type 'Secure accommodation order' radio button
+    When I choose a 'Secure accommodation order' radio button
     And I click 'Save and continue'
     Then I should be on the "proceeding_issue_status" page showing "Has this proceeding been issued?"
 

--- a/features/providers/start_page.feature
+++ b/features/providers/start_page.feature
@@ -6,11 +6,15 @@ Feature: Start page
     Given I am logged in as a provider
     And the feature flag for collect_hmrc_data is enabled
     And the feature flag for linked_applications is enabled
-    And the feature flag for public_law_family is enabled
 
     When I visit the application service
     Then I should be on a page with title "Apply for civil legal aid - GOV.UK"
     And I should see "Providers can use this service to apply for civil legal aid for their clients"
+    And I should see "You can use it for:"
+    And I should see "domestic abuse, except DAPO \(domestic abuse protection orders\)"
+    And I should see "section 8"
+    And I should see "special children act"
+    And I should see "public law family"
 
     When I click link "Sign in"
     Then I should be on a page with title "Select the account number"

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -170,7 +170,7 @@ Given("the setting to manually review all cases is enabled") do
 end
 
 Then("I choose a {string} radio button") do |radio_button_name|
-  choose(radio_button_name, allow_label_click: true)
+  choose(radio_button_name, allow_label_click: true, match: :first)
 end
 
 Given(/^I view the previously created application$/) do
@@ -1338,10 +1338,6 @@ end
 
 Then("I select a proceeding type and continue") do
   find_by_id("proceeding-list").first(:button, "Select and continue").click
-end
-
-Then("I choose a proceeding type {string} radio button") do |radio_button_name|
-  choose(radio_button_name, allow_label_click: true)
 end
 
 Then("I select proceeding type {int}") do |index|

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Setting do
         expect(rec.alert_via_sentry?).to be true
         expect(rec.linked_applications?).to be false
         expect(rec.collect_hmrc_data?).to be false
-        expect(rec.public_law_family?).to be false
       end
     end
 
@@ -30,7 +29,6 @@ RSpec.describe Setting do
           alert_via_sentry: false,
           linked_applications: true,
           collect_hmrc_data: true,
-          public_law_family: true,
         )
       end
 
@@ -44,7 +42,6 @@ RSpec.describe Setting do
         expect(rec.alert_via_sentry?).to be false
         expect(rec.linked_applications?).to be true
         expect(rec.collect_hmrc_data?).to be true
-        expect(rec.public_law_family?).to be true
       end
     end
   end
@@ -61,7 +58,6 @@ RSpec.describe Setting do
       expect(described_class.alert_via_sentry?).to be true
       expect(described_class.linked_applications?).to be false
       expect(described_class.collect_hmrc_data?).to be false
-      expect(described_class.public_law_family?).to be false
     end
   end
 end

--- a/spec/requests/admin/settings_controller_spec.rb
+++ b/spec/requests/admin/settings_controller_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe Admin::SettingsController do
           linked_applications: "true",
           collect_hmrc_data: "true",
           home_address: "true",
-          public_law_family: "true",
         },
       }
     end
@@ -59,7 +58,6 @@ RSpec.describe Admin::SettingsController do
       expect(setting.allow_welsh_translation?).to be(true)
       expect(setting.linked_applications?).to be(true)
       expect(setting.collect_hmrc_data?).to be(true)
-      expect(setting.public_law_family?).to be(true)
     end
 
     it "create settings if they do not exist" do

--- a/spec/requests/providers/start_spec.rb
+++ b/spec/requests/providers/start_spec.rb
@@ -3,24 +3,26 @@ require "rails_helper"
 RSpec.describe "provider start of journey test" do
   describe "GET /providers" do
     before do
-      allow(Setting).to receive_messages(public_law_family?: public_law_family)
+      allow(Setting).to receive_messages(linked_applications?: linked_applications)
       get providers_root_path
     end
 
-    let(:public_law_family) { false }
+    let(:linked_applications) { false }
 
     it "returns http success" do
       expect(response).to have_http_status(:ok)
     end
 
-    it "does not show the PLF list item" do
-      expect(page).to have_no_content("public law family")
+    it "does not show the linked_applications list item" do
+      expect(page).to have_no_content("you want to make both a family link and legal link to your application")
     end
 
-    context "when the PLF feature flag is on" do
-      let(:public_law_family) { true }
+    context "when the linked_applications feature flag is on" do
+      let(:linked_applications) { true }
 
-      it { expect(page).to have_css("li", text: "public law family") }
+      it "shows the linked_applications list item" do
+        expect(page).to have_css("li", text: "you want to make both a family link and legal link to your application")
+      end
     end
   end
 end

--- a/spec/services/legal_framework/proceeding_types/all_spec.rb
+++ b/spec/services/legal_framework/proceeding_types/all_spec.rb
@@ -4,28 +4,18 @@ RSpec.describe LegalFramework::ProceedingTypes::All do
   subject(:all) { described_class.new(legal_aid_application) }
 
   before do
-    allow(Setting).to receive_messages(public_law_family?: plf_enabled)
     stub_request(:post, uri).to_return(body:)
   end
 
   let(:legal_aid_application) { create :legal_aid_application }
   let(:body) { all_proceeding_types_payload }
   let(:uri) { "#{Rails.configuration.x.legal_framework_api_host}/proceeding_types/filter" }
-  let(:plf_enabled) { false }
 
   describe ".call" do
     subject(:call) { all.call }
 
-    context "when the plf flag is off" do
-      it "returns the expected proceedings" do
-        expect(call.map(&:ccms_code)).to match_array %w[DA001 SE097 DA003 SE016E DA006 PB003]
-      end
-    end
-
-    context "when the plf flag is on" do
-      let(:plf_enabled) { true }
-
-      it "returns the expected proceedings" do
+    context "when all proceedings returned" do
+      it "returns the expected proceedings array" do
         expect(call.map(&:ccms_code)).to match_array %w[DA001 SE097 DA003 SE016E DA006 PB003 PBM01]
       end
     end


### PR DESCRIPTION
## What
Remove all references to public_law_family feature flag

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5324)

It has been signed off by product to remove this feature flag
following a period of monitoring.

## NOTE
First of two parts. the second will drop the settings.public_law_family column.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
