### PR TITLE
AP-5959: Add involved children back into merits cya

### DIFF
--- a/app/views/shared/check_answers/merits/_merits_proceeding_section.html.erb
+++ b/app/views/shared/check_answers/merits/_merits_proceeding_section.html.erb
@@ -25,7 +25,7 @@
       end %>
 <% end %>
 
-<% if proceeding.attempts_to_settle || proceeding.section8? || proceeding.specific_issue || proceeding.prohibited_steps || proceeding.special_children_act? %>
+<% if proceeding.attempts_to_settle || proceeding.involved_children.any? || proceeding.section8? || proceeding.specific_issue || proceeding.prohibited_steps || proceeding.special_children_act? %>
   <% if proceeding.attempts_to_settle %>
      <%= govuk_summary_card(title: t(".attempts_to_settle_heading"), html_attributes: { id: "app-check-your-answers__#{proceeding.id}_attempts_to_settle" }, heading_level: 3) do |card|
            unless read_only
@@ -43,7 +43,7 @@
          end %>
   <% end %>
 
-  <% if proceeding.section8? || (proceeding.special_children_act? && proceeding.client_involvement_type_ccms_code.in?(["A", "D"])) %>
+  <% if proceeding.involved_children.any? %>
      <%= govuk_summary_card(title: t(".linked_children_heading"), html_attributes: { id: "app-check-your-answers__#{proceeding.id}_linked_children" }, heading_level: 3) do |card|
            unless read_only
              card.with_action do

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -998,6 +998,9 @@ Given("I complete the journey as far as check merits answers with multiple proce
     set_lead_proceeding: :da001,
   )
   create(:legal_framework_merits_task_list, :da001_da004_as_defendant_se014, legal_aid_application: @legal_aid_application)
+
+  @legal_aid_application.proceedings.first.involved_children << @legal_aid_application.involved_children.first
+
   login_as @legal_aid_application.provider
   visit(providers_legal_aid_application_check_merits_answers_path(@legal_aid_application))
 

--- a/spec/requests/providers/check_merits_answers_controller_spec.rb
+++ b/spec/requests/providers/check_merits_answers_controller_spec.rb
@@ -22,8 +22,13 @@ RSpec.describe Providers::CheckMeritsAnswersController do
     let(:smtl) { create(:legal_framework_merits_task_list, legal_aid_application: application) }
     let(:domestic_abuse_summary) { create(:domestic_abuse_summary, :police_notified_true) }
     let(:matter_opposition) { create(:matter_opposition) }
+    let(:involved_child) { application.involved_children.first }
 
-    before { allow(LegalFramework::MeritsTasksService).to receive(:call).with(application).and_return(smtl) }
+    before do
+      allow(LegalFramework::MeritsTasksService).to receive(:call).with(application).and_return(smtl)
+      application.proceedings.find_by(ccms_code: "SE014").involved_children << involved_child
+      application.save!
+    end
 
     context "when the provider is unauthenticated" do
       before { get_request }


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5959)

Involved children for proceeding were not being shown so add them back into cya page

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
