### PR TITLE
AP-5324: Drop the public_law_family column from settings table

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,6 +1,4 @@
 class Setting < ApplicationRecord
-  self.ignored_columns += %w[public_law_family]
-
   def self.mock_true_layer_data?
     setting.mock_true_layer_data?
   end

--- a/db/migrate/20250509071703_drop_public_law_family_from_settings.rb
+++ b/db/migrate/20250509071703_drop_public_law_family_from_settings.rb
@@ -1,0 +1,7 @@
+class DropPublicLawFamilyFromSettings < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured do
+      remove_column :settings, :public_law_family, :boolean, null: false, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_25_114131) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_09_071703) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -1024,7 +1024,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_25_114131) do
     t.datetime "cfe_compare_run_at"
     t.boolean "linked_applications", default: false, null: false
     t.boolean "collect_hmrc_data", default: false, null: false
-    t.boolean "public_law_family", default: false, null: false
   end
 
   create_table "specific_issues", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION


## What
Drop settings.public_law_family column

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5324)

Part 2 of removing the public law family feature flag.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
