### PR TITLE
Fix: Broken feature test

### DIFF
--- a/features/providers/regressions/scope_limitations.feature
+++ b/features/providers/regressions/scope_limitations.feature
@@ -36,7 +36,7 @@ Feature: Scope limitations not being set
     And proceeding suggestions has results
     Then I should be on a page showing 'Prohibited steps order'
     And proceeding suggestions has results
-    When I choose a 'Prohibited steps order' radio button
+    When I choose a 'Prohibited steps order - enforcement' radio button
     And I click 'Save and continue'
 
     Then I should be on a page showing 'Is this proceeding for a change of name application?'


### PR DESCRIPTION


## What

This started failing today but was fine yesterday. 

The cause seems to be sequencing... a recent update re-recorded the VCR cassette expecting the first radio button in the SE003 results to be the enforcement option.  

The first option, today, is the appeal option.  

I have changed the radio button select to the explicit `Prohibited steps order - enforcement` option so that the VCR condition will always be met

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
