### PR TITLE
AP-6008: Notification banner full width on applications page

### DIFF
--- a/app/helpers/page_template_helper.rb
+++ b/app/helpers/page_template_helper.rb
@@ -54,7 +54,7 @@ module PageTemplateHelper
     page_heading_options: {},
     &content
   )
-    template = :default unless %i[form basic].include?(template)
+    template = :default unless template.eql?(:basic)
     content_for(:navigation) { back_link(**back_link) unless back_link == :none }
     has_errors = form&.object&.errors || show_errors_for&.errors
     page_title_possibly_with_error({ page_title:, head_title: }, has_errors)

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -13,30 +13,26 @@
   <% end %>
 
   <% if flash[:hash] && flash[:hash].symbolize_keys! %>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <% if flash[:hash][:text] && flash[:hash][:heading_text] %>
-          <%= govuk_notification_banner(title_text: flash[:hash][:title_text],
-                                        success: flash[:hash][:success]) do |nb| %>
-            <% nb.with_heading(text: flash[:hash][:heading_text],
-                               link_text: flash[:hash][:link_text],
-                               link_href: flash[:hash][:link_href]) %>
-            <p><%= flash[:hash][:text] %></p>
-          <% end %>
-        <% elsif flash[:hash][:heading_text] %>
-          <%= govuk_notification_banner(title_text: flash[:hash][:title_text],
-                                        success: flash[:hash][:success]) do |nb|
-                nb.with_heading(text: flash[:hash][:heading_text],
-                                link_text: flash[:hash][:link_text],
-                                link_href: flash[:hash][:link_href])
-              end %>
-        <% else %>
-          <%= govuk_notification_banner(title_text: flash[:hash][:title_text],
-                                        success: flash[:hash][:success],
-                                        text: flash[:hash][:text]) %>
-        <% end %>
-      </div>
-    </div>
+    <% if flash[:hash][:text] && flash[:hash][:heading_text] %>
+      <%= govuk_notification_banner(title_text: flash[:hash][:title_text],
+                                    success: flash[:hash][:success]) do |nb| %>
+        <% nb.with_heading(text: flash[:hash][:heading_text],
+                           link_text: flash[:hash][:link_text],
+                           link_href: flash[:hash][:link_href]) %>
+        <p><%= flash[:hash][:text] %></p>
+      <% end %>
+    <% elsif flash[:hash][:heading_text] %>
+      <%= govuk_notification_banner(title_text: flash[:hash][:title_text],
+                                    success: flash[:hash][:success]) do |nb|
+            nb.with_heading(text: flash[:hash][:heading_text],
+                            link_text: flash[:hash][:link_text],
+                            link_href: flash[:hash][:link_href])
+          end %>
+    <% else %>
+      <%= govuk_notification_banner(title_text: flash[:hash][:title_text],
+                                    success: flash[:hash][:success],
+                                    text: flash[:hash][:text]) %>
+    <% end %>
     <% flash.clear %>
   <% end %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,8 +57,6 @@
           <%= image_tag("laa_logo.svg", alt: "LAA logo", width: "276px", height: "40px") %>
         </div>
 
-        <%= render partial: "layouts/flash" %>
-
         <%= yield %>
       </main>
 

--- a/app/views/providers/legal_aid_applications/index.html.erb
+++ b/app/views/providers/legal_aid_applications/index.html.erb
@@ -1,4 +1,4 @@
-<%= page_template(page_title: t(".heading_1"), back_link: :none) do %>
+<%= page_template(page_title: t(".heading_1"), back_link: :none, column_width: "full") do %>
   <div class="govuk-button-group">
     <%= govuk_button_link_to(t("generic.new_app"), providers_declaration_path, html_attributes: { id: "start" }) %>
   </div>

--- a/app/views/shared/page_templates/_basic_page_template.html.erb
+++ b/app/views/shared/page_templates/_basic_page_template.html.erb
@@ -1,5 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-<%= column_width %>">
+    <%= render(partial: "layouts/flash") %>
     <%= render(partial: "shared/forms/error_summary", locals: { model: show_errors_for }) if show_errors_for %>
     <%= form.govuk_error_summary if form %>
     <%= if notification_banner_title

--- a/app/views/shared/page_templates/_default_page_template.html.erb
+++ b/app/views/shared/page_templates/_default_page_template.html.erb
@@ -1,5 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-<%= column_width %>">
+    <%= render(partial: "layouts/flash") %>
     <%= render(partial: "shared/forms/error_summary", locals: { model: show_errors_for }) if show_errors_for %>
     <%= form.govuk_error_summary if form %>
     <%= if notification_banner_title

--- a/spec/requests/providers/bank_transactions_controller_spec.rb
+++ b/spec/requests/providers/bank_transactions_controller_spec.rb
@@ -52,11 +52,9 @@ RSpec.describe Providers::BankTransactionsController do
 
       it "redirects back" do
         patch_request
-        expect(response).to have_http_status(:redirect)
-        follow_redirect!
-
         happened_at = I18n.l(bank_transaction.happened_at.to_date, format: :short_date)
-        expect(response.body).to include("You removed transaction #{happened_at} JOE BLOGGS from the list")
+        expect(flash["hash"][:heading_text]).to eq("You removed transaction #{happened_at} JOE BLOGGS from the list")
+        expect(response).to have_http_status(:redirect)
       end
 
       context "with javascript enabled" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6008)

Move flash partial into template partials, so that it is inside the div which determines the column width. This means that the flash messages will match the width of page content, which is specified in the govuk design system.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
