### PR TITLE
Incident: Redirect to holding page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,7 +2,7 @@ class PagesController < ApplicationController
   def servicedown
     respond_to do |format|
       format.html do
-        render :servicedown
+        redirect_to "https://laa-holding-page-production.apps.live.cloud-platform.service.justice.gov.uk/", allow_other_host: true
       end
       format.json do
         render  json:

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -28,9 +28,8 @@ RSpec.describe PagesController, :clamav do
     end
 
     shared_examples "maintenance page" do
-      it { expect(response).to have_http_status(:ok) }
-      it { expect(response).to render_template("pages/servicedown") }
-      it { expect(response.body).to include("Sorry, the service is unavailable") }
+      it { expect(response).to have_http_status(:redirect) }
+      it { expect(response).to redirect_to("https://laa-holding-page-production.apps.live.cloud-platform.service.justice.gov.uk/") }
     end
 
     shared_examples "maintenance json" do


### PR DESCRIPTION
## What
Redirect maintenance page to holding

At request of leaders, so there is a single page for messaging.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
