### PR TITLE
Chore: Remove jquery

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,3 @@
-import './src/jquery'
-
 import * as MOJFrontend from '@ministryofjustice/frontend'
 import * as GOVUKFrontend from 'govuk-frontend'
 

--- a/app/javascript/src/jquery.js
+++ b/app/javascript/src/jquery.js
@@ -1,3 +1,0 @@
-import jquery from 'jquery'
-window.jQuery = jquery
-window.$ = jquery

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "esbuild": "^0.25.4",
     "govuk-frontend": "^5.10.1",
     "jest": "^29.7.0",
-    "jquery": "^3.7.1",
     "js-search": "^2.0.1",
     "moment": "^2.30.1",
     "sass": "^1.89.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4244,11 +4244,6 @@ jest@^29.7.0:
     import-local "^3.0.2"
     jest-cli "^29.7.0"
 
-jquery@^3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
-  integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==
-
 js-search@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/js-search/-/js-search-2.0.1.tgz#a9c0fe92a3945aa839ba6bae5910d26eac850984"


### PR DESCRIPTION
## What

A recent change to the MOJ frontend package removed the requirement for jquery, this is a speculative PR to remove the dependency and check that it is not needed by any other packages

It has been tested locally with no adverse affects

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
