### PR TITLE
Chore: Revert to using underscore step names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,22 +286,22 @@ jobs:
     - setup_remote_docker
     - build-and-push-to-ecr
 
-  deploy-uat: &deploy-uat
+  deploy_uat: &deploy_uat
     executor: cloud-platform-executor
     steps:
       - deploy-to-environment:
           environment: uat
 
-  deploy-main-uat:
-    <<: *deploy-uat
+  deploy_main_uat:
+    <<: *deploy_uat
 
-  deploy-staging:
+  deploy_staging:
     executor: cloud-platform-executor
     steps:
       - deploy-to-environment:
           environment: staging
 
-  deploy-production:
+  deploy_production:
     executor: cloud-platform-executor
     steps:
       - deploy-to-environment:
@@ -336,7 +336,7 @@ workflows:
           requires:
           - lint_checks
           <<: *generic-slack-fail-post-step
-      - deploy-uat:
+      - deploy_uat:
           context: laa-apply-for-legalaid-uat
           requires:
           - build_and_push
@@ -361,7 +361,7 @@ workflows:
               only:
                 - /dependabot.*/
           requires:
-          - deploy-uat
+          - deploy_uat
           <<: *generic-slack-fail-post-step
 
   merge_pr:
@@ -383,14 +383,14 @@ workflows:
           requires:
             - lint_checks
           <<: *generic-slack-fail-post-step
-      - deploy-main-uat:
+      - deploy_main_uat:
           context: laa-apply-for-legalaid-uat
           requires:
             - integration_tests
             - unit_tests
             - build_and_push
           <<: *generic-slack-fail-post-step
-      - deploy-staging:
+      - deploy_staging:
           context: laa-apply-for-legalaid-staging
           requires:
             - integration_tests
@@ -437,14 +437,14 @@ workflows:
               ]
             }
           requires:
-            - deploy-main-uat
-            - deploy-staging
+            - deploy_main_uat
+            - deploy_staging
       - hold_production:
           type: approval
           requires:
-            - deploy-main-uat
-            - deploy-staging
-      - deploy-production:
+            - deploy_main_uat
+            - deploy_staging
+      - deploy_production:
           context: laa-apply-for-legalaid-production
           requires:
             - hold_production


### PR DESCRIPTION
## What
Chore: Revert to using underscore step names

[Came out of story](https://dsdmoj.atlassian.net/browse/AP-6023)

For consistency, despite myself preferring hyphenated-keys.

NOTE: This qill require removing and then readding the deploy-uat step
as required from github branch protection. Re add `deploy_uat` as required
once merged.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
