### PR TITLE
Fix: Report rendering

### DIFF
--- a/app/controllers/providers/means_reports_controller.rb
+++ b/app/controllers/providers/means_reports_controller.rb
@@ -10,9 +10,17 @@ module Providers
         render "show", layout: "pdf"
       else
         html = render_to_string "show", layout: "pdf"
-        pdf = Grover.new(html).to_pdf
+        pdf = Grover.new(html, style_tag_options:).to_pdf
         send_data pdf, filename: "means_report.pdf", type: "application/pdf", disposition: "inline"
       end
+    end
+
+  private
+
+    def style_tag_options
+      [
+        content: Rails.root.join("app/assets/builds/application.css").read,
+      ]
     end
   end
 end

--- a/app/controllers/providers/merits_reports_controller.rb
+++ b/app/controllers/providers/merits_reports_controller.rb
@@ -7,9 +7,17 @@ module Providers
         render "show", layout: "pdf"
       else
         html = render_to_string "show", layout: "pdf"
-        pdf = Grover.new(html).to_pdf
+        pdf = Grover.new(html, style_tag_options:).to_pdf
         send_data pdf, filename: "merits_report.pdf", type: "application/pdf", disposition: "inline"
       end
+    end
+
+  private
+
+    def style_tag_options
+      [
+        content: Rails.root.join("app/assets/builds/application.css").read,
+      ]
     end
   end
 end

--- a/config/initializers/grover.rb
+++ b/config/initializers/grover.rb
@@ -8,7 +8,7 @@ Grover.configure do |config|
     cache: false,
     wait_until: "networkidle2",
     display_url: Rails.configuration.x.application.host_url,
-    style_tag_options: [content: Rails.root.join("app/assets/builds/application.css").read],
+    # style_tag_options: [content: Rails.root.join("app/assets/builds/application.css").read],
     margin: {
       top: "10mm",
       bottom: "10mm",

--- a/config/initializers/grover.rb
+++ b/config/initializers/grover.rb
@@ -7,7 +7,8 @@ Grover.configure do |config|
     bypass_csp: true,
     cache: false,
     wait_until: "networkidle2",
-    # display_url: Rails.configuration.x.application.host_url,
+    display_url: Rails.configuration.x.application.host_url,
+    style_tag_options: [content: Rails.root.join("app/assets/builds/application.css").read],
     margin: {
       top: "10mm",
       bottom: "10mm",

--- a/config/initializers/grover.rb
+++ b/config/initializers/grover.rb
@@ -7,7 +7,7 @@ Grover.configure do |config|
     bypass_csp: true,
     cache: false,
     wait_until: "networkidle2",
-    display_url: Rails.configuration.x.application.host_url,
+    # display_url: Rails.configuration.x.application.host_url,
     margin: {
       top: "10mm",
       bottom: "10mm",

--- a/helm_deploy/apply-for-legal-aid/templates/_helpers.tpl
+++ b/helm_deploy/apply-for-legal-aid/templates/_helpers.tpl
@@ -76,6 +76,6 @@ If branch name contains "redis" then the redis-release-name appends "-master", o
 Function to return a list of whitelisted IPs allowed to access the service.
 */}}
 {{- define "apply-for-legal-aid.whitelist" -}}
-    {{- .Values.pingdomIPs }},{{- .Values.sharedIPs }}
+    {{- if .Values.ingress.whitelist.addresses }}{{- join "," .Values.ingress.whitelist.addresses }},{{- end }}{{- .Values.pingdomIPs }},{{- .Values.sharedIPs }}
 {{- end -}}
 

--- a/helm_deploy/apply-for-legal-aid/values-uat.yaml
+++ b/helm_deploy/apply-for-legal-aid/values-uat.yaml
@@ -12,7 +12,7 @@ ingress:
   enabled: true
   className: default-non-prod
   whitelist:
-    enabled: true
+    enabled: false
   annotations:
     external-dns.alpha.kubernetes.io/aws-weight: '100'
   path: /

--- a/helm_deploy/apply-for-legal-aid/values-uat.yaml
+++ b/helm_deploy/apply-for-legal-aid/values-uat.yaml
@@ -12,7 +12,9 @@ ingress:
   enabled: true
   className: default-non-prod
   whitelist:
-    enabled: false
+    enabled: true
+    addresses:
+      - 0.0.0.0
   annotations:
     external-dns.alpha.kubernetes.io/aws-weight: '100'
   path: /

--- a/helm_deploy/apply-for-legal-aid/values-uat.yaml
+++ b/helm_deploy/apply-for-legal-aid/values-uat.yaml
@@ -13,8 +13,6 @@ ingress:
   className: default-non-prod
   whitelist:
     enabled: true
-    addresses:
-      - 127.0.0.1
   annotations:
     external-dns.alpha.kubernetes.io/aws-weight: '100'
   path: /

--- a/helm_deploy/apply-for-legal-aid/values-uat.yaml
+++ b/helm_deploy/apply-for-legal-aid/values-uat.yaml
@@ -14,7 +14,7 @@ ingress:
   whitelist:
     enabled: true
     addresses:
-      - 0.0.0.0
+      - 127.0.0.1
   annotations:
     external-dns.alpha.kubernetes.io/aws-weight: '100'
   path: /

--- a/spec/requests/providers/means_reports_controller_spec.rb
+++ b/spec/requests/providers/means_reports_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Providers::MeansReportsController do
         expect(response.headers["Content-Type"]).to eq("application/pdf")
         expect(Grover)
           .to have_received(:new)
-          .with(a_string_including("L-123-456"))
+          .with(a_string_including("L-123-456"), style_tag_options: [content: Rails.root.join("app/assets/builds/application.css").read])
       end
     end
 

--- a/spec/requests/providers/merits_reports_controller_spec.rb
+++ b/spec/requests/providers/merits_reports_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Providers::MeritsReportsController do
         expect(response.headers["Content-Type"]).to eq("application/pdf")
         expect(Grover)
           .to have_received(:new)
-          .with(a_string_including("L-123-456"))
+          .with(a_string_including("L-123-456"), style_tag_options: [content: Rails.root.join("app/assets/builds/application.css").read])
       end
     end
 


### PR DESCRIPTION
## What

While testing Clientless VPN, it appeared that CSS rendering in the PDFs was failing

I assume that is because we remove node_modules and clear yarn cache, so this returns us to the previous flow to test that hypothesis

The ultimate goal is working PDF rendering and no snyk issues caused by esbuild

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
