### PR TITLE
Chore: Move whitelist IPs to deploy script

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -2,6 +2,7 @@
 
 ENVIRONMENT=$1
 
+CLIENTLESS_VPN_IPS="165.1.170.106\,165.1.170.107\,134.231.143.70\,134.231.143.71"
 PINGDOM_IPS=$(curl -s https://my.pingdom.com/probes/ipv4 | tr -d ' ' | tr '\n' ',' | sed 's/,/\\,/g' | sed 's/\\,$//')
 SHARED_IPS=$(curl -s https://raw.githubusercontent.com/ministryofjustice/laa-ip-allowlist/main/cidrs.txt | tr -d ' ' | tr '\n' ',' | sed 's/,/\\,/g' | sed 's/\\,$//')
 
@@ -25,6 +26,7 @@ deploy_branch() {
                 --set image.tag="${CIRCLE_SHA1}" \
                 --set ingress.hosts="{$RELEASE_HOST}" \
                 --set ingress.annotations."external-dns\.alpha\.kubernetes\.io/set-identifier"="$IDENTIFIER" \
+                --set-string clientlessVpnIPs="$CLIENTLESS_VPN_IPS" \
                 --set-string pingdomIPs="$PINGDOM_IPS" \
                 --set-string sharedIPs="$SHARED_IPS"
 }
@@ -36,6 +38,7 @@ deploy_main() {
                 --values ./helm_deploy/apply-for-legal-aid/values-"$ENVIRONMENT".yaml \
                 --set image.repository="${ECR_REGISTRY}/${ECR_REPOSITORY}" \
                 --set image.tag="${CIRCLE_SHA1}" \
+                --set-string clientlessVpnIPs="$CLIENTLESS_VPN_IPS" \
                 --set-string pingdomIPs="$PINGDOM_IPS" \
                 --set-string sharedIPs="$SHARED_IPS"
 }

--- a/helm_deploy/apply-for-legal-aid/templates/_helpers.tpl
+++ b/helm_deploy/apply-for-legal-aid/templates/_helpers.tpl
@@ -76,6 +76,6 @@ If branch name contains "redis" then the redis-release-name appends "-master", o
 Function to return a list of whitelisted IPs allowed to access the service.
 */}}
 {{- define "apply-for-legal-aid.whitelist" -}}
-    {{- .Values.pingdomIPs }},{{- .Values.sharedIPs }}
+    {{- .Values.clientlessVpnIPs }},{{- .Values.pingdomIPs }},{{- .Values.sharedIPs }}
 {{- end -}}
 


### PR DESCRIPTION
## What
Move whitelist IP to deploy script

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

This centralises them in one location and simplifies the
helm templates. The IPs may change but would be a small change to apply in any event


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
