### PR TITLE
Chore: Rename executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ executors:
   basic-executor:
     docker:
       - image: cimg/base:2020.01
-  linting-executor:
+  basic-ruby-executor:
     docker:
       - image: cimg/ruby:3.4.4-browsers
         environment:
@@ -132,7 +132,7 @@ commands:
 
 jobs:
   lint_checks:
-    executor: linting-executor
+    executor: basic-ruby-executor
     steps:
     - checkout
     - setup_remote_docker
@@ -265,7 +265,7 @@ jobs:
           - coverage_results
 
   coverage:
-    executor: linting-executor
+    executor: basic-ruby-executor
     steps:
       - attach_workspace:
           at: .


### PR DESCRIPTION


## What

Chore: Rename CI executor

name it after what it is not what its for as used for coverage step too.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
