### PR TITLE
Fix: Inline styles for PDF generation

### DIFF
--- a/app/controllers/concerns/grover_optionable.rb
+++ b/app/controllers/concerns/grover_optionable.rb
@@ -1,0 +1,13 @@
+module GroverOptionable
+  extend ActiveSupport::Concern
+
+  included do
+  private
+
+    def style_tag_options
+      [
+        content: Rails.root.join("app/assets/builds/application.css").read,
+      ]
+    end
+  end
+end

--- a/app/controllers/providers/means_reports_controller.rb
+++ b/app/controllers/providers/means_reports_controller.rb
@@ -1,5 +1,6 @@
 module Providers
   class MeansReportsController < ProviderBaseController
+    include GroverOptionable
     authorize_with_policy_method :show_submitted_application?
 
     def show
@@ -10,7 +11,7 @@ module Providers
         render "show", layout: "pdf"
       else
         html = render_to_string "show", layout: "pdf"
-        pdf = Grover.new(html).to_pdf
+        pdf = Grover.new(html, style_tag_options:).to_pdf
         send_data pdf, filename: "means_report.pdf", type: "application/pdf", disposition: "inline"
       end
     end

--- a/app/controllers/providers/merits_reports_controller.rb
+++ b/app/controllers/providers/merits_reports_controller.rb
@@ -1,5 +1,6 @@
 module Providers
   class MeritsReportsController < ProviderBaseController
+    include GroverOptionable
     authorize_with_policy_method :show_submitted_application?
 
     def show
@@ -7,7 +8,7 @@ module Providers
         render "show", layout: "pdf"
       else
         html = render_to_string "show", layout: "pdf"
-        pdf = Grover.new(html).to_pdf
+        pdf = Grover.new(html, style_tag_options:).to_pdf
         send_data pdf, filename: "merits_report.pdf", type: "application/pdf", disposition: "inline"
       end
     end

--- a/app/services/reports/base_report_creator.rb
+++ b/app/services/reports/base_report_creator.rb
@@ -1,5 +1,7 @@
 module Reports
   class BaseReportCreator
+    include GroverOptionable
+
     def self.call(legal_aid_application)
       new(legal_aid_application).call
     end
@@ -13,7 +15,7 @@ module Reports
   private
 
     def pdf_report
-      Grover.new(html_report).to_pdf
+      Grover.new(html_report, style_tag_options:).to_pdf
     end
 
     def ensure_case_ccms_reference_exists

--- a/spec/requests/providers/means_reports_controller_spec.rb
+++ b/spec/requests/providers/means_reports_controller_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe Providers::MeansReportsController do
     context "when authenticated and authorised" do
       let(:login_provider) { login_as legal_aid_application.provider }
 
-      it "renders the means report PDF", :aggregate_failures do
+      it "renders the means report PDF, with inline css", :aggregate_failures do
         expect(response).to have_http_status(:ok)
         expect(response.headers["Content-Type"]).to eq("application/pdf")
         expect(Grover)
           .to have_received(:new)
-          .with(a_string_including("L-123-456"))
+          .with(a_string_including("L-123-456"), hash_including(:style_tag_options))
       end
     end
 

--- a/spec/requests/providers/merits_reports_controller_spec.rb
+++ b/spec/requests/providers/merits_reports_controller_spec.rb
@@ -33,12 +33,12 @@ RSpec.describe Providers::MeritsReportsController do
     context "when authenticated and authorised" do
       let(:login_provider) { login_as legal_aid_application.provider }
 
-      it "renders the merits report PDF", :aggregate_failures do
+      it "renders the merits report PDF, with inline css", :aggregate_failures do
         expect(response).to have_http_status(:ok)
         expect(response.headers["Content-Type"]).to eq("application/pdf")
         expect(Grover)
           .to have_received(:new)
-          .with(a_string_including("L-123-456"))
+          .with(a_string_including("L-123-456"), hash_including(:style_tag_options))
       end
     end
 


### PR DESCRIPTION

## What
Inline styles for PDF generation

To avoid whitelisting issues. Taken from [this PR](ministryofjustice/laa-submit-crime-forms#1526)

This should be in a shared/central location but putting it in the
grover intializer fails tests with error below so adding it to call
instead.

```sh
Errno::ENOENT: No such file or directory @ rb_sysopen - /home/circleci/project/app/assets/builds/application.css (Errno::ENOENT)
```


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
