### PR TITLE
AP-5519: Ensure consistent currency validation

### DIFF
--- a/app/forms/providers/regular_transaction_form.rb
+++ b/app/forms/providers/regular_transaction_form.rb
@@ -168,7 +168,7 @@ module Providers
     def all_regular_transactions_valid
       regular_transactions.each do |transaction|
         transaction_type = transaction.transaction_type
-        transaction.amount = clean_amount(public_send(:"#{transaction_type.name}_amount"))
+        transaction.amount = CurrencyCleaner.new(public_send(:"#{transaction_type.name}_amount")).call
         transaction.frequency = public_send(:"#{transaction_type.name}_frequency")
 
         next if transaction.valid?
@@ -180,10 +180,6 @@ module Providers
           )
         end
       end
-    end
-
-    def clean_amount(amount)
-      amount.to_s.tr("£,", "")
     end
 
     def add_regular_transaction_error_to_form(transaction_type, error)

--- a/app/helpers/transaction_type_helper.rb
+++ b/app/helpers/transaction_type_helper.rb
@@ -6,7 +6,7 @@ module TransactionTypeHelper
     if has_transaction_type && total.zero?
       legal_aid_application.client_uploading_bank_statements? ? t("generic.yes") : t("generic.yes_but_none")
     elsif has_transaction_type && total.positive?
-      legal_aid_application.client_uploading_bank_statements? ? t("generic.yes") : number_to_currency(total)
+      legal_aid_application.client_uploading_bank_statements? ? t("generic.yes") : gds_number_to_currency(total)
     else
       t("generic.none")
     end
@@ -15,7 +15,7 @@ module TransactionTypeHelper
   def regular_transaction_answer_by_type(legal_aid_application:, transaction_type:, owner_type:)
     regular_transaction = legal_aid_application.regular_transactions.find_by(transaction_type:, owner_type:)
     if regular_transaction
-      [number_to_currency(regular_transaction.amount), t("transaction_types.frequencies.#{regular_transaction.frequency}").downcase]
+      [gds_number_to_currency(regular_transaction.amount), t("transaction_types.frequencies.#{regular_transaction.frequency}").downcase]
     else
       t("generic.none")
     end
@@ -62,7 +62,7 @@ private
     legal_aid_application.regular_transactions.where(owner_type: individual).send("#{credit_or_debit}s").to_h do |r|
       [
         r.transaction_type.name,
-        "#{number_to_currency(r.amount)} #{t("transaction_types.frequencies.#{r.frequency}").downcase}",
+        "#{gds_number_to_currency(r.amount)} #{t("transaction_types.frequencies.#{r.frequency}").downcase}",
       ]
     end
   end
@@ -72,7 +72,7 @@ private
 
     labels = transactions.group_by { |ct| ct.transaction_type.name }.transform_values do |group|
       group.map { |ct|
-        t("generic.amount_and_date", amount: gds_number_to_currency(ct.amount, precision: 2), month: ct.transaction_date.strftime("%B %Y"))
+        t("generic.amount_and_date", amount: gds_number_to_currency(ct.amount), month: ct.transaction_date.strftime("%B %Y"))
       }.join("<br>")
     end
 

--- a/app/models/base_aggregated_cash_transaction.rb
+++ b/app/models/base_aggregated_cash_transaction.rb
@@ -96,7 +96,7 @@ private
 
   def clean_attributes(params)
     params.each.with_object({}) do |(k, v), new_hash|
-      new_hash[k] = cash_transaction_amount_field?(k) ? v.to_s.tr("£,", "") : v
+      new_hash[k] = cash_transaction_amount_field?(k) ? CurrencyCleaner.new(v).call : v
     end
   end
 

--- a/app/views/shared/check_answers/_benefits_income.html.erb
+++ b/app/views/shared/check_answers/_benefits_income.html.erb
@@ -41,7 +41,7 @@
       <% end %>
       <%= summary_list.with_row do |row| %>
         <%= row.with_key(text: t(".amount"), classes: "govuk-!-width-one-third") %>
-        <%= row.with_value(text: [number_to_currency(state_benefit.amount), t("transaction_types.frequencies.#{state_benefit.frequency}").downcase].join(" ")) %>
+        <%= row.with_value(text: [gds_number_to_currency(state_benefit.amount), t("transaction_types.frequencies.#{state_benefit.frequency}").downcase].join(" ")) %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/shared/check_answers/_housing_benefit.html.erb
+++ b/app/views/shared/check_answers/_housing_benefit.html.erb
@@ -12,16 +12,14 @@
   <%= card.with_summary_list do |summary_list| %>
     <% if @legal_aid_application.applicant_in_receipt_of_housing_benefit? %>
       <% housing_benefit_type = TransactionType.find_by(name: "housing_benefit") %>
+      <% regular_transaction_amount, regular_transaction_frequency = regular_transaction_answer_by_type(
+           legal_aid_application: @legal_aid_application,
+           transaction_type: housing_benefit_type,
+           owner_type: "Applicant",
+         ) %>
       <%= summary_list.with_row do |row| %>
         <%= row.with_key(text: t(".amount"), classes: "govuk-!-width-one-third") %>
-        <%= row.with_value do %>
-          <% regular_transaction_amount, regular_transaction_frequency = regular_transaction_answer_by_type(
-               legal_aid_application: @legal_aid_application,
-               transaction_type: housing_benefit_type,
-               owner_type: "Applicant",
-             ) %>
-          <p><%= regular_transaction_amount %><br><%= regular_transaction_frequency %></p>
-        <% end %>
+        <%= row.with_value(text: [regular_transaction_amount, regular_transaction_frequency].join(" ")) %>
       <% end %>
     <% else %>
       <%= summary_list.with_row(html_attributes: { id: "app-check-your-answers__housing_benefit_question" }) do |row| %>

--- a/features/providers/bank_statement_upload/check_your_means_answers.feature
+++ b/features/providers/bank_statement_upload/check_your_means_answers.feature
@@ -41,20 +41,20 @@ Feature: Bank statement upload check your answers
     And the "Payments your client gets" section's questions and answers should match:
       | question | answer |
       | Financial help from friends or family | None |
-      | Maintenance payments from a former partner | £500.00 every week |
+      | Maintenance payments from a former partner | £500 every week |
       | Income from a property or lodger | None |
       | Pension | None |
 
     And the "Payments your client pays" section's questions and answers should match:
       | question | answer |
-      | Housing payments | £1,600.00 total in last 3 months |
+      | Housing payments | £1,600 total in last 3 months |
       | Childcare payments | None |
       | Maintenance payments to a former partner | None |
       | Payments towards legal aid in a criminal case | None |
 
     And the "Housing Benefit" section's questions and answers should match:
       | question | answer |
-      | Amount of Housing benefit | £1,200.00\ntotal in last 3 months |
+      | Amount of Housing benefit | £1,200 total in last 3 months |
 
     When I click Check Your Answers Change link for "bank statements client"
     And I upload an evidence file named "hello_world.pdf"
@@ -77,7 +77,7 @@ Feature: Bank statement upload check your answers
     When I check "My client gets none of these payments in cash"
     And I click "Save and continue"
     Then I should be on the "check_income_answers" page showing "Check your answers"
-    And I should see "1,000.00"
+    And I should see "1,000"
     And I should see "every 2 weeks"
 
     When I click Check Your Answers Change link for "Payments your client gets"
@@ -110,7 +110,7 @@ Feature: Bank statement upload check your answers
 
     And I click "Save and continue"
     Then I should be on the "check_income_answers" page showing "Check your answers"
-    And I should see "£500.00"
+    And I should see "£500"
     And I should see "monthly"
 
     When I click Check Your Answers Change link for "Payments your client pays"

--- a/features/providers/check_your_answers.feature
+++ b/features/providers/check_your_answers.feature
@@ -324,7 +324,7 @@ Feature: Checking answers backwards and forwards
 
     And the "Payments your client gets" section's questions and answers should match:
       | question | answer |
-      | Benefits, charitable or government payments | £666.00 |
+      | Benefits, charitable or government payments | £666 |
       | Financial help from friends or family | None |
       | Maintenance payments from a former partner | Yes, but none specified |
       | Income from a property or lodger | None |
@@ -332,7 +332,7 @@ Feature: Checking answers backwards and forwards
 
     And the "Payments your client pays" section's questions and answers should match:
       | question | answer |
-      | Housing payments | £999.00 |
+      | Housing payments | £999 |
       | Childcare payments | None |
       | Maintenance payments to a former partner | Yes, but none specified |
       | Payments towards legal aid in a criminal case | None |

--- a/features/providers/partner_means_assessment/bank_statement_upload/check_your_means_answers.feature
+++ b/features/providers/partner_means_assessment/bank_statement_upload/check_your_means_answers.feature
@@ -43,14 +43,14 @@ Feature: Bank statement upload check your answers
 
     And the "Payments the partner pays" section's questions and answers should match:
       | question | answer |
-      | Housing payments | £1,600.00 total in last 3 months |
+      | Housing payments | £1,600 total in last 3 months |
       | Childcare payments | None |
       | Maintenance payments to a former partner | None |
       | Payments towards legal aid in a criminal case | None |
 
     And the "Housing Benefit" section's questions and answers should match:
       | question | answer |
-      | Amount of Housing benefit | £1,200.00\ntotal in last 3 months |
+      | Amount of Housing benefit | £1,200 total in last 3 months |
 
     When I click Check Your Answers Change link for "bank statements partner"
     And I upload an evidence file named "hello_world.pdf"
@@ -74,7 +74,7 @@ Feature: Bank statement upload check your answers
     When I check "The partner gets none of these payments in cash"
     And I click "Save and continue"
     Then I should be on the "check_income_answers" page showing "Check your answers"
-    And I should see "1,000.00"
+    And I should see "1,000"
     And I should see "every 2 weeks"
 
     When I click Check Your Answers Change link for "Payments the partner gets"
@@ -107,7 +107,7 @@ Feature: Bank statement upload check your answers
 
     And I click "Save and continue"
     Then I should be on the "check_income_answers" page showing "Check your answers"
-    And I should see "£500.00"
+    And I should see "£500"
     And I should see "monthly"
 
     When I click Check Your Answers Change link for "Payments the partner pays"

--- a/features/providers/regressions/client_truelayer_partner_bank_statements_check_means_answer.feature
+++ b/features/providers/regressions/client_truelayer_partner_bank_statements_check_means_answer.feature
@@ -13,7 +13,7 @@ Feature: Bank statement upload check your answers
     Then the "Payments your client gets" section's questions and answers should match:
       | question | answer |
       | Benefits, charitable or government payments | None |
-      | Financial help from friends or family | £44.00 |
+      | Financial help from friends or family | £44 |
       | Maintenance payments from a former partner | None |
       | Income from a property or lodger | None |
       | Pension | None |
@@ -22,7 +22,7 @@ Feature: Bank statement upload check your answers
       | question | answer |
       | Benefits, charitable or government payments | None |
       | Financial help from friends or family | None |
-      | Maintenance payments from a former partner | £50.00 every week |
+      | Maintenance payments from a former partner | £50 every week |
       | Income from a property or lodger | None |
       | Pension | None |
 

--- a/spec/helpers/transaction_type_helper_spec.rb
+++ b/spec/helpers/transaction_type_helper_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe TransactionTypeHelper do
                frequency: "weekly")
       end
 
-      it { is_expected.to eq(["£250.00", "every week"]) }
+      it { is_expected.to eq(["£250", "every week"]) }
     end
 
     context "when no regular transactions exist" do
@@ -124,8 +124,8 @@ RSpec.describe TransactionTypeHelper do
         context "with bank statement upload" do
           it "returns a hash of formatted key value pairs" do
             expect(formatted_transactions).to contain_exactly(
-              { label: "Financial help from friends or family", value: "£500.00 every week" },
-              { label: "Maintenance payments from a former partner", value: "£500.00 every week" },
+              { label: "Financial help from friends or family", value: "£500 every week" },
+              { label: "Maintenance payments from a former partner", value: "£500 every week" },
               { label: "Income from a property or lodger", value: "None" },
               { label: "Pension", value: "None" },
             )
@@ -171,7 +171,7 @@ RSpec.describe TransactionTypeHelper do
           it "returns a hash of formatted key value pairs" do
             expect(formatted_transactions).to contain_exactly(
               { label: "Financial help from friends or family", value: "None" },
-              { label: "Benefits, charitable or government payments", value: "£106.00" },
+              { label: "Benefits, charitable or government payments", value: "£106" },
               { label: "Maintenance payments from a former partner", value: "None" },
               { label: "Income from a property or lodger", value: "None" },
               { label: "Pension", value: "None" },
@@ -185,8 +185,8 @@ RSpec.describe TransactionTypeHelper do
 
         it "returns a hash of formatted key value pairs" do
           expect(formatted_transactions).to contain_exactly(
-            { label: "Financial help from friends or family", value: "£500.00 every week" },
-            { label: "Maintenance payments from a former partner", value: "£500.00 every week" },
+            { label: "Financial help from friends or family", value: "£500 every week" },
+            { label: "Maintenance payments from a former partner", value: "£500 every week" },
             { label: "Income from a property or lodger", value: "None" },
             { label: "Pension", value: "None" },
           )
@@ -231,8 +231,8 @@ RSpec.describe TransactionTypeHelper do
         context "with bank statement upload" do
           it "returns a hash of formatted key value pairs" do
             expect(formatted_transactions).to contain_exactly(
-              { label: "Housing payments", value: "£500.00 every week" },
-              { label: "Maintenance payments to a former partner", value: "£500.00 every week" },
+              { label: "Housing payments", value: "£500 every week" },
+              { label: "Maintenance payments to a former partner", value: "£500 every week" },
               { label: "Childcare payments", value: "None" },
               { label: "Payments towards legal aid in a criminal case", value: "None" },
             )
@@ -278,7 +278,7 @@ RSpec.describe TransactionTypeHelper do
           it "returns a hash of formatted key value pairs" do
             expect(formatted_transactions).to contain_exactly(
               { label: "Housing payments", value: "None" },
-              { label: "Maintenance payments to a former partner", value: "£106.00" },
+              { label: "Maintenance payments to a former partner", value: "£106" },
               { label: "Childcare payments", value: "None" },
               { label: "Payments towards legal aid in a criminal case", value: "None" },
             )
@@ -291,8 +291,8 @@ RSpec.describe TransactionTypeHelper do
 
         it "returns a hash of formatted key value pairs" do
           expect(formatted_transactions).to contain_exactly(
-            { label: "Housing payments", value: "£500.00 every week" },
-            { label: "Maintenance payments to a former partner", value: "£500.00 every week" },
+            { label: "Housing payments", value: "£500 every week" },
+            { label: "Maintenance payments to a former partner", value: "£500 every week" },
             { label: "Childcare payments", value: "None" },
             { label: "Payments towards legal aid in a criminal case", value: "None" },
           )


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5519)

Use the CurrencyCleaner class in the forms and handlers that had a different solution used.  This ensures the same substitutions are used in all forms and a consistent return is provided by the system.

This is, possibly, a short term solution as we are using many different ways of validating, storing and displaying currency values between different forms and handlers

This PR also fixes the display of currency amounts on the Check your Answers pages, to display without trailing zeros i.e. `£45` instead of `£45.00`. Amounts with pence still display as `£45.01`.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
