### PR TITLE
Chore: Update circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
     - run:
         name: Install Puppeteer with Chromium
         command: |
-          yarn add puppeteer@22.15.0
+          yarn add puppeteer
     - run:
         name: Setup Code Climate test-reporter
         command: |


### PR DESCRIPTION

## What

remove the puppeteer lock.  This was added at a time when a breakign change was introduced. It is not currently needed and should be removed to stop it introducing more issues by mismatching the version in use in the app

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
