### PR TITLE
Fix: remove duplicate k8s attribute

### DIFF
--- a/helm_deploy/apply-for-legal-aid/templates/deployment_clamav.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/deployment_clamav.yaml
@@ -51,7 +51,6 @@ spec:
             limits:
               cpu: 500m
               memory: 3Gi
-              memory: 3Gi
           startupProbe:
             exec:
               command:


### PR DESCRIPTION
## What
Remove duplicate k8s attribute

typo fix
## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
