### PR TITLE
Fix: Flickering feature

### DIFF
--- a/features/providers/proceeding_loop.feature
+++ b/features/providers/proceeding_loop.feature
@@ -34,7 +34,7 @@ Feature: Loop through proceeding questions
 
   Scenario: When provider does not accept default levels of service
     Given I search for proceeding type "Child arrangements order CAO Section 8"
-    And I choose a "Child arrangements order (CAO) - residence - appeal" radio button
+    And I choose a "Child arrangements order (CAO) - residence - appeal - vary" radio button
 
     When I click 'Save and continue'
     Then I should be on a page with title "Do you want to add another proceeding?"
@@ -174,7 +174,7 @@ Feature: Loop through proceeding questions
 
   Scenario: When provider accepts default levels of service
     Given I search for proceeding type "Child arrangements order CAO Section 8"
-    And I choose a "Child arrangements order (CAO) - residence - appeal" radio button
+    And I choose a "Child arrangements order (CAO) - residence - appeal - vary" radio button
 
     When I click 'Save and continue'
     Then I should be on a page with title "Do you want to add another proceeding?"


### PR DESCRIPTION
## What

Once again, the sequence of LFA returns seems to have shifted

Where yesterday, `Child arrangements order (CAO) - residence - appeal` would have selected the vary option, today it does not :(

This makes the text selection explicit, the recorded VCR cassette expected `SE016A` to have been chosen, and now the text selector matches it precisely

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
