### PR TITLE
Fix: Amend dump script inline with container changes

### DIFF
--- a/scripts/db_export.sh
+++ b/scripts/db_export.sh
@@ -5,11 +5,11 @@ declare -a envs=("staging" "production")
 case "$1" in
 "staging")
   environment=$1
-  POD=$(kubectl -n "laa-apply-for-legalaid-$environment" get pods | grep -o -m4 "apply-for-.*2/2" | tail -n1 | cut -d' ' -f 1)
+  POD=$(kubectl -n "laa-apply-for-legalaid-$environment" get pods | grep -o -m4 "apply-for-legal-aid-worker-.*1/1" | tail -n1 | cut -d' ' -f 1)
   ;;
 "production")
   environment=$1
-  POD=$(kubectl -n "laa-apply-for-legalaid-$environment" get pods | grep -o -m4 "apply-for-.*2/2" | tail -n1 | cut -d' ' -f 1)
+  POD=$(kubectl -n "laa-apply-for-legalaid-$environment" get pods | grep -o -m4 "apply-for-legal-aid-worker-.*1/1" | tail -n1 | cut -d' ' -f 1)
  ;;
 "")
   echo "Usage: db_export.sh [environment]
@@ -19,13 +19,13 @@ environment  [staging, production or a branch name, i.e. ap-1234]"
   ;;
 *)
   environment='uat'
-  POD=$(kubectl -n laa-apply-for-legalaid-uat get pods | grep -o -m4 "apply-$1-.*2/2" | head -n1 | cut -d' ' -f 1)
+  POD=$(kubectl -n laa-apply-for-legalaid-uat get pods | grep -o -m4 "apply-$1-.*1/1" | head -n1 | cut -d' ' -f 1)
 esac
 
 echo "Finding pod for $environment"
 echo "Connecting to $POD, anonymizing, compressing and exporting DB"
-kubectl -n laa-apply-for-legalaid-$environment -c web exec "$POD" -- rake db:export
-kubectl -n laa-apply-for-legalaid-$environment cp --retries=10 -c web "laa-apply-for-legalaid-$environment/$POD:tmp/temp.sql.gz" "./tmp/$environment.anon.sql.gz"
+kubectl -n laa-apply-for-legalaid-$environment exec "$POD" -- rake db:export
+kubectl -n laa-apply-for-legalaid-$environment cp --retries=10 "laa-apply-for-legalaid-$environment/$POD:tmp/temp.sql.gz" "./tmp/$environment.anon.sql.gz"
 gunzip "./tmp/$environment.anon.sql.gz"
 cat << INSTRUCTIONS
 Do you care about the current state of your dev DB? read on, otherwise skip to step 2


### PR DESCRIPTION

## What
Amend dump script inline with container changes

[Relates to/caused by story](https://dsdmoj.atlassian.net/browse/AP-6070)

The separation of the clamav container into its own pod
requires changes to script to enable it to find a pod to use
for dump file. Namely, only 1 container in the pod and it does
not need the `-c web` therefore.

I have moved to using work pods specifically too. This is to avoid
overloading web server containers and avoids the potential to inadvertently
choose a clamav or metrics pod for the dum (which would then fail).


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
