### PR TITLE
AP-6082 Standardise display of currency values

### DIFF
--- a/app/views/providers/means/capital_disregards/add_details/show.html.erb
+++ b/app/views/providers/means/capital_disregards/add_details/show.html.erb
@@ -17,7 +17,11 @@
       <% if @capital_disregard.name.in?(["compensation_for_personal_harm", "loss_or_harm_relating_to_this_application"]) %>
         <%= form.govuk_text_field :payment_reason, label: { text: t(".payment_reason") } %>
       <% end %>
-      <%= form.govuk_text_field :amount, width: "one-quarter", label: { text: t(".amount") }, prefix_text: "£" %>
+      <%= form.govuk_text_field :amount,
+                                label: { text: t(".amount") },
+                                value: number_to_currency_or_original_string(@form.amount),
+                                prefix_text: "£",
+                                width: "one-quarter" %>
       <%= form.govuk_text_field :account_name, width: "three-quarters", label: { text: t(".bank_account") }, hint: { text: t(".bank_account_hint") } %>
       <%= form.govuk_date_field :date_received, legend: { text: t(".received_date"), size: "s", class: "govuk-body govuk-!-font-weight-regular" } %>
     <% end %>

--- a/app/views/providers/means/housing_benefits/show.html.erb
+++ b/app/views/providers/means/housing_benefits/show.html.erb
@@ -10,7 +10,10 @@
                                link_errors: true,
                                label: { text: t(".labels.housing_benefit.yes") },
                                checked: @form.housing_benefit_selected? do %>
-        <%= f.govuk_text_field :housing_benefit_amount, width: "one-quarter", prefix_text: "£" %>
+        <%= f.govuk_text_field :housing_benefit_amount,
+                               value: number_to_currency_or_original_string(@form.housing_benefit_amount),
+                               width: "one-quarter",
+                               prefix_text: "£" %>
         <%= f.govuk_collection_radio_buttons :housing_benefit_frequency,
                                              @form.frequency_options,
                                              :itself,

--- a/app/views/providers/means/property_details/show.html.erb
+++ b/app/views/providers/means/property_details/show.html.erb
@@ -14,6 +14,7 @@
       <%= form.govuk_text_field :property_value,
                                 label: { text: t(".values_question.#{individual}"), tag: "h2", size: "m" },
                                 hint: { text: t(".values_hint") },
+                                value: number_to_currency_or_original_string(@form.property_value),
                                 prefix_text: t("currency.gbp"),
                                 classes: "govuk-!-margin-top-6",
                                 width: 5 %>
@@ -22,6 +23,7 @@
         <%= form.govuk_text_field :outstanding_mortgage_amount,
                                   label: { text: t(".mortgage_question"), tag: "h2", size: "m" },
                                   hint: { text: t(".mortgage_hint.#{individual}") },
+                                  value: number_to_currency_or_original_string(@form.outstanding_mortgage_amount),
                                   prefix_text: t("currency.gbp"),
                                   width: 5 %>
       <% end %>

--- a/app/views/shared/_student_finances.html.erb
+++ b/app/views/shared/_student_finances.html.erb
@@ -22,6 +22,7 @@
               :student_finance_amount,
               label: { text: t(".amount_label") },
               hint: { text: t(".amount_hint", individual:) },
+              value: number_to_currency_or_original_string(@form.model.student_finance_amount),
               prefix_text: t("currency.gbp"),
               width: "one-quarter",
             ) %>

--- a/app/views/shared/means/_regular_income.html.erb
+++ b/app/views/shared/means/_regular_income.html.erb
@@ -12,6 +12,7 @@
                               label: { text: t(".labels.#{transaction_type.name}") },
                               hint: { text: t(".hints.#{transaction_type.name}", individual: type.eql?(:partner) ? "the partner" : "your client") } do %>
           <%= f.govuk_text_field :"#{transaction_type.name}_amount",
+                                 value: number_to_currency_or_original_string(@form.send("#{transaction_type.name}_amount")),
                                  width: "one-quarter",
                                  prefix_text: "£" %>
           <%= f.govuk_collection_radio_buttons :"#{transaction_type.name}_frequency",

--- a/app/views/shared/means/_regular_outgoing.html.erb
+++ b/app/views/shared/means/_regular_outgoing.html.erb
@@ -14,6 +14,7 @@
                               label: { text: t(".labels.#{transaction_type.name}") },
                               hint: { text: t(".hints.#{transaction_type.name}") } do %>
           <%= f.govuk_text_field :"#{transaction_type.name}_amount",
+                                 value: number_to_currency_or_original_string(@form.send("#{transaction_type.name}_amount")),
                                  width: "one-quarter",
                                  prefix_text: "£" %>
           <%= f.govuk_collection_radio_buttons :"#{transaction_type.name}_frequency",

--- a/app/views/shared/partials/_revealing_checkbox.html.erb
+++ b/app/views/shared/partials/_revealing_checkbox.html.erb
@@ -25,7 +25,7 @@
     <%= form.govuk_text_field "#{name}#{number}",
                               id: id,
                               label: { text: model.period(number), for: id },
-                              value: model.__send__(:"#{name}#{number}"),
+                              value: number_to_currency_or_original_string(model.__send__(:"#{name}#{number}")),
                               prefix_text: defined?(input_prefix) ? input_prefix : nil,
                               form_group: { class: form_group_classes },
                               class: input_classes,

--- a/app/views/shared/state_benefits/_new_benefit_form.erb
+++ b/app/views/shared/state_benefits/_new_benefit_form.erb
@@ -21,6 +21,7 @@
                                 width: "full" %>
       <%= form.govuk_text_field :amount,
                                 width: "one-quarter",
+                                value: number_to_currency_or_original_string(@form.amount),
                                 label: { text: t(".benefits_amount") },
                                 prefix_text: "£" %>
       <%= form.govuk_collection_radio_buttons :frequency,

--- a/spec/requests/providers/means/housing_benefits_controller_spec.rb
+++ b/spec/requests/providers/means/housing_benefits_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Providers::Means::HousingBenefitsController do
         )
         expect(page).to have_field(
           "providers_means_housing_benefit_form[housing_benefit_amount]",
-          with: housing_benefit.amount,
+          with: housing_benefit.amount.to_i,
         )
         expect(page).to have_field(
           "providers_means_housing_benefit_form[housing_benefit_frequency]",

--- a/spec/requests/providers/means/regular_incomes_controller_spec.rb
+++ b/spec/requests/providers/means/regular_incomes_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Providers::Means::RegularIncomesController do
 
         expect(page).to have_checked_field("Pension")
         pension_amount = page.find_field("providers-means-regular-income-form-pension-amount-field").value
-        expect(pension_amount).to eq("500.0")
+        expect(pension_amount).to eq("500")
         frequency_amount = page.find_field("providers-means-regular-income-form-pension-frequency-weekly-field").value
         expect(frequency_amount).to eq("weekly")
       end

--- a/spec/requests/providers/means/student_finances_controller_spec.rb
+++ b/spec/requests/providers/means/student_finances_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Providers::Means::StudentFinancesController do
         request
 
         expect(page).to have_checked_field("Yes")
-        expect(page).to have_field("applicant[student_finance_amount]", with: "1234.56")
+        expect(page).to have_field("applicant[student_finance_amount]", with: "1,234.56")
       end
     end
 
@@ -144,7 +144,7 @@ RSpec.describe Providers::Means::StudentFinancesController do
         login_as provider
         request
 
-        expect(applicant.reload.student_finance_amount).to eq(1234.56)
+        expect(applicant.reload.student_finance_amount).to eq(1_234.56)
       end
     end
 

--- a/spec/requests/providers/partners/regular_incomes_controller_spec.rb
+++ b/spec/requests/providers/partners/regular_incomes_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Providers::Partners::RegularIncomesController do
 
         expect(page).to have_checked_field("Pension")
         pension_amount = page.find_field("providers-partners-regular-income-form-pension-amount-field").value
-        expect(pension_amount).to eq("500.0")
+        expect(pension_amount).to eq("500")
         frequency_amount = page.find_field("providers-partners-regular-income-form-pension-frequency-weekly-field").value
         expect(frequency_amount).to eq("weekly")
       end

--- a/spec/requests/providers/partners/student_finances_controller_spec.rb
+++ b/spec/requests/providers/partners/student_finances_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Providers::Partners::StudentFinancesController do
         request
 
         expect(page).to have_checked_field("Yes")
-        expect(page).to have_field("partner[student_finance_amount]", with: "1234.56")
+        expect(page).to have_field("partner[student_finance_amount]", with: "1,234.56")
       end
     end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6082)

When returning to a form with a currency field, values should display in a humanised format e.g. 1,000 rather than 1000.0

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
