### PR TITLE
AP-6089: These test also need updating to avoid flicker errors

### DIFF
--- a/spec/requests/admin/legal_aid_applications_controller_spec.rb
+++ b/spec/requests/admin/legal_aid_applications_controller_spec.rb
@@ -61,7 +61,10 @@ RSpec.describe Admin::LegalAidApplicationsController do
 
         it "shows pagination" do
           get_request
-          expect(page).to have_css(".govuk-pagination", text: "12\nNext page")
+          expect(page)
+            .to have_css(".govuk-pagination", text: "Next page")
+            .and have_css(".govuk-pagination__link", text: "1")
+            .and have_css(".govuk-pagination__link", text: "2")
         end
       end
     end

--- a/spec/requests/admin/submitted_applications_reports_controller_spec.rb
+++ b/spec/requests/admin/submitted_applications_reports_controller_spec.rb
@@ -58,7 +58,10 @@ RSpec.describe Admin::SubmittedApplicationsReportsController do
 
         it "shows pagination" do
           get_request
-          expect(page).to have_css(".govuk-pagination", text: "12\nNext page")
+          expect(page)
+            .to have_css(".govuk-pagination", text: "Next page")
+            .and have_css(".govuk-pagination__link", text: "1")
+            .and have_css(".govuk-pagination__link", text: "2")
         end
       end
     end


### PR DESCRIPTION

## What
Fix othere tests impacted by system test capybara changes

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6089)

The introduction of system tests has made of capybara matchers
different but only for system tests. However if they load before
another test that requests more basic capybnara matchers for requests
it can break.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
