### PR TITLE
Chore: Remove CodeClimate from repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,11 +201,6 @@ jobs:
         name: Install Puppeteer with Chromium
         command: |
           yarn add puppeteer
-    - run:
-        name: Setup Code Climate test-reporter
-        command: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./tmp/cc-test-reporter
-          chmod +x ./tmp/cc-test-reporter
     - run: bundle exec rails assets:precompile
     - run:
         name: Run ruby tests

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 
 
 [![CircleCI](https://circleci.com/gh/ministryofjustice/laa-apply-for-legal-aid.svg?style=shield)](https://circleci.com/gh/ministryofjustice/laa-apply-for-legal-aid/tree/main)
-[![Maintainability](https://api.codeclimate.com/v1/badges/687f23bf19d8c76a9467/maintainability)](https://codeclimate.com/github/ministryofjustice/laa-apply-for-legal-aid/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/687f23bf19d8c76a9467/test_coverage)](https://codeclimate.com/github/ministryofjustice/laa-apply-for-legal-aid/test_coverage)
 
 # LAA Apply for civil legal aid
 


### PR DESCRIPTION
## What

The CodeClimate quality checks were deprecated over the weekend, this PR removes the circle ci test report setup and removes the badges from the Readme

It turns out that the data wasn't being pushed to CC on this repo anyway!

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
