### PR TITLE
AP-6125: Add explicit provider/sign_in route

### DIFF
--- a/app/controllers/providers/omniauth_callbacks_controller.rb
+++ b/app/controllers/providers/omniauth_callbacks_controller.rb
@@ -10,14 +10,14 @@ module Providers
       else
         flash[:notice] = I18n.t "devise.omniauth_callbacks.unauthorised"
         Rails.logger.error "Couldn't login user"
-        redirect_back(fallback_location: unauthenticated_root_path, allow_other_host: false)
+        redirect_back(fallback_location: root_path, allow_other_host: false)
       end
     end
 
     def failure
       flash[:alert] = I18n.t "devise.omniauth_callbacks.failure"
       Rails.logger.error "omniauth error authenticating a user!"
-      redirect_to unauthenticated_root_path
+      redirect_to root_path
     end
 
   protected

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -44,7 +44,7 @@ module ApplicationHelper
         content_tag(:li, link_to(t("layouts.logout.provider"), destroy_provider_session_path, class: "moj-header__navigation-link", method: :delete), class: "moj-header__navigation-item"),
       ])
     else
-      content_tag(:li, link_to(t("layouts.login"), "/auth/entra_id", class: "moj-header__navigation-link"), class: "moj-header__navigation-item")
+      content_tag(:li, link_to(t("layouts.login"), providers_confirm_office_path, class: "moj-header__navigation-link"), class: "moj-header__navigation-item")
     end
   end
 

--- a/app/views/providers/start/index.html.erb
+++ b/app/views/providers/start/index.html.erb
@@ -17,6 +17,6 @@
     <p class="govuk-body"><%= t(".use_ccms_para_html") %></p>
     <p class="govuk-body"><%= t(".progress_saved") %></p>
 
-    <%= govuk_start_button(text: t("generic.sign_in"), href: "/auth/entra_id", html_attributes: { id: "start" }) %>
+    <%= govuk_start_button(text: t("generic.sign_in"), href: providers_confirm_office_path, html_attributes: { id: "start" }) %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,10 +38,6 @@ Rails.application.routes.draw do
   end
 
   devise_scope :provider do
-    unauthenticated :provider do
-      root "providers/start#index", as: :unauthenticated_root
-    end
-
     authenticated :provider do
       root to: "start#index", as: :authenticated_root
     end
@@ -53,6 +49,8 @@ Rails.application.routes.draw do
       as: :provider_entra_id_omniauth_callback,
     )
 
+    get "/providers/sign_in", to: "providers/sessions#new", as: :new_provider_session
+    post "/providers/sign_in", to: "providers/sessions#create", as: :provider_session
     delete "/providers/sign_out", to: "providers/sessions#destroy", as: :destroy_provider_session
   end
 

--- a/spec/support/shared_examples/provider_auth_shared_examples.rb
+++ b/spec/support/shared_examples/provider_auth_shared_examples.rb
@@ -1,6 +1,6 @@
 RSpec.shared_examples "a provider not authenticated" do
   it "redirects the user to the login page" do
-    expect(response).to redirect_to(unauthenticated_root_path)
+    expect(response).to redirect_to(new_provider_session_path)
   end
 end
 


### PR DESCRIPTION
## What

This is normally provided by devise but we are only using :trackable so some routes are not handled silently

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
