### PR TITLE
Fix: Hardcoded test dates

### DIFF
--- a/spec/models/aggregated_cash_outgoings_spec.rb
+++ b/spec/models/aggregated_cash_outgoings_spec.rb
@@ -141,10 +141,6 @@ RSpec.describe AggregatedCashOutgoings do
           expect(aco.errors[:rent_or_mortgage1][0]).to eq error_msg("housing", month1_name)
           expect(aco.errors[:rent_or_mortgage3][0]).to eq error_msg("housing", month3_name)
         end
-
-        def error_msg(name, month)
-          "Enter the amount paid for #{name} in #{month}, like 1,000 or 20.30"
-        end
       end
 
       context "with amount negative" do
@@ -168,8 +164,7 @@ RSpec.describe AggregatedCashOutgoings do
         end
 
         it "populates the errors" do
-          error_msg = "Enter the amount paid for housing in June, like 1,000 or 20.30"
-          expect(aco.errors[:rent_or_mortgage1][0]).to eq error_msg
+          expect(aco.errors[:rent_or_mortgage1][0]).to eq error_msg("housing", month1_name)
         end
       end
 
@@ -181,8 +176,7 @@ RSpec.describe AggregatedCashOutgoings do
         end
 
         it "populates the errors" do
-          error_msg = "Enter the amount paid for housing in June, like 1,000 or 20.30"
-          expect(aco.errors[:rent_or_mortgage1][0]).to eq error_msg
+          expect(aco.errors[:rent_or_mortgage1][0]).to eq error_msg("housing", month1_name)
         end
       end
 
@@ -274,7 +268,7 @@ RSpec.describe AggregatedCashOutgoings do
 
           it "populates the errors" do
             call_update
-            expect(aco.errors[:rent_or_mortgage2]).to include "Enter the amount paid for housing in May, like 1,000 or 20.30"
+            expect(aco.errors[:rent_or_mortgage2]).to include error_msg("housing", month2_name)
           end
         end
 
@@ -292,7 +286,7 @@ RSpec.describe AggregatedCashOutgoings do
 
           it "populates the errors" do
             call_update
-            expect(aco.errors[:maintenance_out3]).to include "Enter the amount paid for maintenance in April, like 1,000 or 20.30"
+            expect(aco.errors[:maintenance_out3]).to include error_msg("maintenance", month3_name)
           end
         end
 
@@ -402,6 +396,10 @@ RSpec.describe AggregatedCashOutgoings do
         end
       end
     end
+  end
+
+  def error_msg(name, month)
+    "Enter the amount paid for #{name} in #{month}, like 1,000 or 20.30"
   end
 
   def valid_params


### PR DESCRIPTION
## What

These were hard coded with the dates during the month written

As the month clicked over today, they started to break.

This reuses an error_msg method by extracting to the top level so all tests can use it.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
