### PR TITLE
AP-6125: Update my profile

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,7 +40,7 @@ module ApplicationHelper
   def provider_header_navigation
     if provider_signed_in?
       safe_join([
-        content_tag(:li, link_to(current_provider.username, providers_provider_path, class: "moj-header__navigation-link"), class: "moj-header__navigation-item"),
+        content_tag(:li, link_to(t("layouts.application.header.my_profile"), providers_provider_path, class: "moj-header__navigation-link"), class: "moj-header__navigation-item"),
         content_tag(:li, link_to(t("layouts.logout.provider"), destroy_provider_session_path, class: "moj-header__navigation-link", method: :delete), class: "moj-header__navigation-item"),
       ])
     else

--- a/app/views/providers/providers/show.html.erb
+++ b/app/views/providers/providers/show.html.erb
@@ -15,10 +15,6 @@
               row.with_cell(text: @provider.name)
             end
             body.with_row do |row|
-              row.with_cell(header: true, text: t(".username"))
-              row.with_cell(text: @provider.username)
-            end
-            body.with_row do |row|
               row.with_cell(header: true, text: t(".email"))
               row.with_cell(text: @provider.email)
             end

--- a/config/locales/en/layouts.yml
+++ b/config/locales/en/layouts.yml
@@ -31,6 +31,7 @@ en:
         phase_banner_html: This is a new service – your %{link} will help us to improve it.
         title: Apply for civil legal aid
         notice: Notice
+        my_profile: My profile
     logout:
       admin: Admin sign out
       provider: Sign out

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ApplicationHelper do
       context "when provider is signed in" do
         it "returns a link to edit provider details and a logout link" do
           expect(user_header_navigation).to have_css("li", count: 2)
-            .and have_css("li", text: "Test User")
+            .and have_css("li", text: "My profile")
             .and have_css("li", text: "Sign out")
         end
       end

--- a/spec/requests/providers/providers_controller_spec.rb
+++ b/spec/requests/providers/providers_controller_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe Providers::ProvidersController do
 
   it "displays provider data" do
     expect(unescaped_response_body).to include(provider.name)
-    expect(unescaped_response_body).to include(provider.username)
     expect(unescaped_response_body).to include(provider.email)
   end
 end


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6125)

Agreed with design, show static text for "My profile" in header when signed in and remove the username/guid field from the profile page

The heading text will be reviewed once the service is live and we can confirm that the data for first/last name is consistently filled in by provider admins when creating accounts

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
