### PR TITLE
Chore: restrict pingdom IPs

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
   # Prevent health checks from clogging up the logs.
-  config.silence_healthcheck_path = "/status"
+  config.silence_healthcheck_path = "/ping"
 
   # Don't log any deprecations.
   config.active_support.report_deprecations = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 Rails.application.routes.draw do
   get "ping", to: "status#ping", format: :json
   get "healthcheck", to: "status#status", format: :json
-  get "status", to: "status#ping", format: :json
 
   match "(*any)", to: "pages#servicedown", via: :all if Rails.application.config.x.maintenance_mode
 

--- a/helm_deploy/apply-for-legal-aid/templates/deployment_web.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/deployment_web.yaml
@@ -39,13 +39,13 @@ spec:
               mountPath: /etc/clamav
           livenessProbe:
             httpGet:
-              path: /status
+              path: /ping
               port: http
             initialDelaySeconds: 60
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
-              path: /status
+              path: /ping
               port: http
             initialDelaySeconds: 60
             timeoutSeconds: 10

--- a/helm_deploy/apply-for-legal-aid/templates/ingress-public.yaml
+++ b/helm_deploy/apply-for-legal-aid/templates/ingress-public.yaml
@@ -34,12 +34,5 @@ spec:
                 name: {{ $fullName }}
                 port:
                   name: http
-          - path: /status
-            pathType: Exact
-            backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  name: http
     {{- end }}
 {{- end }}

--- a/spec/routing/routes_spec.rb
+++ b/spec/routing/routes_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe "Routes" do
-  describe "GET /status" do
+  describe "GET /ping" do
     it "renders the correct route" do
-      expect(get: "/status").to route_to("status#ping")
+      expect(get: "/ping").to route_to("status#ping")
     end
   end
 end


### PR DESCRIPTION
## What

- Remove /status from ingress as it is the same as /ping. Update references to status to reference ping instad.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
