### PR TITLE
Fix: Remove unneeded vars from deploy

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -27,8 +27,6 @@ deploy_branch() {
                 --set ingress.annotations."external-dns\.alpha\.kubernetes\.io/set-identifier"="$INGRESS_IDENTIFIER" \
                 --set publicIngress.annotations."external-dns\.alpha\.kubernetes\.io/set-identifier"="$PUBLIC_INGRESS_IDENTIFIER" \
                 --set omniauth_entraid.redirect_uri="https://${RELEASE_HOST}/auth/entra_id/callback" \
-                --set-string clientlessVpnIPs="$CLIENTLESS_VPN_IPS" \
-                --set-string sharedIPs="$SHARED_IPS"
                 --set-string pingdomIPs="$PINGDOM_IPS"
 }
 


### PR DESCRIPTION
## What
fix bad merge conflict resolution that results in broken deployment

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
