### PR TITLE
Correct invalid schedules interrupt content and styling

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -75,3 +75,5 @@ OMNIAUTH_ENTRAID_CLIENT_ID="<retrieve-from-secrets>"
 OMNIAUTH_ENTRAID_CLIENT_SECRET="<retrieve-from-secrets>"
 OMNIAUTH_ENTRAID_REDIRECT_URI="https://localhost:3000/auth/entra_id/callback" # default redirect_uri is taken from EntraID unless supplied here, must be regestred with EntraID regardless
 OMNIAUTH_ENTRAID_TENANT_ID="<retrieve-from-secrets>"
+
+LAA_LANDING_PAGE_TARGET_URL=<retrieve-from-secrets>

--- a/app/views/providers/invalid_schedules/show.html.erb
+++ b/app/views/providers/invalid_schedules/show.html.erb
@@ -4,6 +4,11 @@
     <p><%= t(".paragraph-2") %></p>
     <p><%= t(".actions_text") %></p>
 
-    <%= govuk_list t(".actions_list_html"), type: :bullet %>
+    <%= govuk_list(
+          t(".actions_list_html",
+            ccms_login: Rails.configuration.x.laa_landing_page_target_url,
+            online_support: Rails.configuration.x.online_support),
+          type: :bullet,
+        ) %>
   <% end %>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -78,6 +78,7 @@ module LaaApplyForLegalAid
     config.govuk_notify_templates = YAML.load_file(Rails.root.join("config/govuk_notify_templates.yml")).symbolize_keys
 
     config.x.support_email_address = "apply-for-civil-legal-aid@justice.gov.uk".freeze
+    config.x.online_support = "https://legalaidlearning.justice.gov.uk/online-support-2/".freeze
     config.x.govuk_notify_api_key = ENV.fetch("GOVUK_NOTIFY_API_KEY", nil)
 
     config.x.admin_portal.allow_reset = ENV["ADMIN_ALLOW_RESET"] == "true"

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -981,8 +981,8 @@ en:
         button_text: Choose a different office
         actions_list_html:
             - go back and choose a different office
-            - apply in <a href="https://portal.legalservices.gov.uk/"><abbr title='Client and Cost Management System'>CCMS</abbr></a> for all other proceedings
-            - <a href="mailto:%{team_email}">contact online support</a> (if you think this is wrong, and you should have access)
+            - apply in <a class="govuk-link govuk-link--inverse" href="%{ccms_login}"><abbr title='Client and Cost Management System'>CCMS</abbr></a> for all other proceedings
+            - <a class="govuk-link govuk-link--inverse" href="%{online_support}">contact online support</a> if you think this is wrong, and you should have access
     legal_aid_applications:
       index:
         heading_1: Your applications

--- a/helm_deploy/apply-for-legal-aid/values-uat.yaml
+++ b/helm_deploy/apply-for-legal-aid/values-uat.yaml
@@ -117,7 +117,6 @@ omniauth_entraid:
   mock_auth_enabled: true
   redirect_uri: https://main-applyforlegalaid-uat.cloud-platform.service.justice.gov.uk/auth/entra_id/callback # overridden for branches (see deploy script)
 
-
 pda:
   url: "https://laa-provider-details-api-uat.apps.live.cloud-platform.service.justice.gov.uk"
 

--- a/spec/requests/providers/invalid_schedules_spec.rb
+++ b/spec/requests/providers/invalid_schedules_spec.rb
@@ -11,11 +11,22 @@ RSpec.describe "provider invalid schedules" do
 
     it "returns http success" do
       expect(response).to have_http_status(:ok)
-      expect(unescaped_response_body).to include(I18n.t("providers.invalid_schedules.show.h1-heading"))
+    end
+
+    it "has expected title" do
+      expect(page).to have_css("h1", text: "You cannot use this service")
     end
 
     it "logs the provider out" do
       expect(session["signed_out"]).to be true
+    end
+
+    it "displays link to LAA landing page (a.k.a portal) for CCMS login" do
+      expect(page).to have_link("CCMS", href: Rails.configuration.x.laa_landing_page_target_url)
+    end
+
+    it "displays link to contact online support" do
+      expect(page).to have_link("contact online support", href: Rails.configuration.x.online_support)
     end
   end
 end


### PR DESCRIPTION
## What
Correct invalid schedules interrupt content and styling

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6146)

- add correct links (confirmed by designer)
- add white/reverse links


## Before
<img width="965" height="622" alt="Screenshot 2025-08-19 at 13 28 44" src="https://github.com/user-attachments/assets/c96e00ab-5829-411e-8767-ba71317cc6fe" />


## After
<img width="1200" height="793" alt="Screenshot 2025-08-19 at 13 26 44" src="https://github.com/user-attachments/assets/e22b1924-3888-4b84-a137-bcc3ef48e530" />


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
