### PR TITLE
AP-6144: Benefit Checker Fallback

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -23,7 +23,8 @@ module Admin
                                 allow_welsh_translation
                                 enable_ccms_submission
                                 linked_applications
-                                collect_hmrc_data])
+                                collect_hmrc_data
+                                collect_dwp_data])
     end
 
     def setting

--- a/app/controllers/providers/check_benefits_controller.rb
+++ b/app/controllers/providers/check_benefits_controller.rb
@@ -8,6 +8,8 @@ module Providers
       @applicant = legal_aid_application.applicant
       return skip_benefit_check_and_go_forward! if known_issue_prevents_benefit_check?
 
+      return redirect_to providers_legal_aid_application_dwp_result_path unless Setting.collect_dwp_data?
+
       check_benefits && return if legal_aid_application.benefit_check_result_needs_updating?
 
       go_forward(true) if legal_aid_application.non_passported?
@@ -20,7 +22,7 @@ module Providers
   private
 
     def check_benefits
-      redirect_to error_path(:benefit_checker_down) unless legal_aid_application.add_benefit_check_result
+      redirect_to providers_legal_aid_application_dwp_result_path unless legal_aid_application.add_benefit_check_result
     end
 
     def known_issue_prevents_benefit_check?

--- a/app/controllers/providers/dwp/overrides_controller.rb
+++ b/app/controllers/providers/dwp/overrides_controller.rb
@@ -1,0 +1,82 @@
+module Providers
+  module DWP
+    class OverridesController < ProviderBaseController
+      include ApplicantDetailsCheckable
+
+      prefix_step_with :dwp
+
+      helper_method :display_hmrc_text?
+
+      def show
+        @form = Providers::DWP::OverridesForm.new(model: partner)
+      end
+
+      def update
+        return continue_or_draft if draft_selected?
+
+        @form = Providers::DWP::OverridesForm.new(form_params)
+
+        if @form.valid?
+          remove_dwp_override if correct_dwp_result?
+          update_joint_benefit_response
+          update_application_state
+          HMRC::CreateResponsesService.call(legal_aid_application) if make_hmrc_call?
+          return go_forward(confirm_receipt_of_benefit?)
+        end
+
+        render :show
+      end
+
+    private
+
+      def remove_dwp_override
+        legal_aid_application.dwp_override&.destroy!
+      end
+
+      def partner
+        @partner = legal_aid_application.partner
+      end
+
+      def update_joint_benefit_response
+        applicant.update!(shared_benefit_with_partner: @form.receives_joint_benefit?)
+        return if partner.nil?
+
+        partner.shared_benefit_with_applicant = @form.receives_joint_benefit?
+        partner.save!
+      end
+
+      def form_params
+        merge_with_model(partner) do
+          return {} unless params[:partner]
+
+          params.expect(partner: [:confirm_dwp_result])
+        end
+      end
+
+      def update_application_state
+        if correct_dwp_result?
+          details_checked! unless details_checked?
+        else
+          legal_aid_application.override_dwp_result! unless legal_aid_application.overriding_dwp_result?
+        end
+      end
+
+      def confirm_receipt_of_benefit?
+        @form.confirm_receipt_of_benefit?
+      end
+
+      def correct_dwp_result?
+        @form.correct_dwp_result?
+      end
+
+      def hmrc_call_enabled?
+        Setting.collect_hmrc_data?
+      end
+
+      def make_hmrc_call?
+        hmrc_call_enabled?
+      end
+      alias_method :display_hmrc_text?, :make_hmrc_call?
+    end
+  end
+end

--- a/app/controllers/providers/dwp/results_controller.rb
+++ b/app/controllers/providers/dwp/results_controller.rb
@@ -1,0 +1,13 @@
+module Providers
+  module DWP
+    class ResultsController < ProviderBaseController
+      prefix_step_with :dwp
+
+      def show; end
+
+      def update
+        go_forward
+      end
+    end
+  end
+end

--- a/app/forms/providers/dwp/overrides_form.rb
+++ b/app/forms/providers/dwp/overrides_form.rb
@@ -1,0 +1,37 @@
+module Providers
+  module DWP
+    class OverridesForm < BaseForm
+      form_for Partner
+
+      RESPONSE_ATTRIBUTES = %w[
+        benefit_received
+        joint_benefit_with_partner
+        no_benefit_received
+      ].freeze
+
+      attr_accessor :confirm_dwp_result
+
+      validate :response_present?
+
+      def correct_dwp_result?
+        attributes["confirm_dwp_result"] == "no_benefit_received"
+      end
+
+      def confirm_receipt_of_benefit?
+        attributes["confirm_dwp_result"] != "no_benefit_received"
+      end
+
+      def receives_joint_benefit?
+        attributes["confirm_dwp_result"] == "joint_benefit_with_partner"
+      end
+
+      def response_present?
+        return false if draft?
+
+        if confirm_dwp_result.nil? || RESPONSE_ATTRIBUTES.exclude?(confirm_dwp_result)
+          errors.add(:confirm_dwp_result, I18n.t("providers.confirm_dwp_non_passported_applications.show.error"))
+        end
+      end
+    end
+  end
+end

--- a/app/forms/settings/setting_form.rb
+++ b/app/forms/settings/setting_form.rb
@@ -7,7 +7,8 @@ module Settings
                   :allow_welsh_translation,
                   :enable_ccms_submission,
                   :linked_applications,
-                  :collect_hmrc_data
+                  :collect_hmrc_data,
+                  :collect_dwp_data
 
     validates :mock_true_layer_data,
               :manually_review_all_cases,
@@ -15,6 +16,7 @@ module Settings
               :enable_ccms_submission,
               :linked_applications,
               :collect_hmrc_data,
+              :collect_dwp_data,
               presence: true
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -31,6 +31,10 @@ class Setting < ApplicationRecord
     setting.collect_hmrc_data
   end
 
+  def self.collect_dwp_data?
+    setting.collect_dwp_data
+  end
+
   def self.setting
     Setting.first || Setting.create!
   end

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -39,6 +39,7 @@ module Flow
         check_provider_answers: Steps::ProviderStart::CheckProviderAnswersStep,
         confirm_non_means_tested_applications: Steps::ProviderStart::ConfirmNonMeansTestedApplicationStep,
         no_national_insurance_numbers: Steps::ProviderStart::NoNationalInsuranceNumbersStep,
+        dwp_results: Steps::ProviderDWP::DWPResultsStep,
         check_benefits: Steps::ProviderStart::CheckBenefitsStep,
         substantive_applications: Steps::ProviderStart::SubstantiveApplicationsStep,
         delegated_confirmation: Steps::ProviderStart::DelegatedConfirmationStep,

--- a/app/services/flow/flows/provider_start.rb
+++ b/app/services/flow/flows/provider_start.rb
@@ -40,6 +40,7 @@ module Flow
         confirm_non_means_tested_applications: Steps::ProviderStart::ConfirmNonMeansTestedApplicationStep,
         no_national_insurance_numbers: Steps::ProviderStart::NoNationalInsuranceNumbersStep,
         dwp_results: Steps::ProviderDWP::DWPResultsStep,
+        dwp_overrides: Steps::ProviderDWP::DWPOverridesStep,
         check_benefits: Steps::ProviderStart::CheckBenefitsStep,
         substantive_applications: Steps::ProviderStart::SubstantiveApplicationsStep,
         delegated_confirmation: Steps::ProviderStart::DelegatedConfirmationStep,

--- a/app/services/flow/steps/provider_dwp/dwp_overrides_step.rb
+++ b/app/services/flow/steps/provider_dwp/dwp_overrides_step.rb
@@ -1,0 +1,18 @@
+module Flow
+  module Steps
+    module ProviderDWP
+      DWPOverridesStep = Step.new(
+        path: ->(application) { Steps.urls.providers_legal_aid_application_dwp_override_path(application) },
+        forward: lambda do |application, confirm_receipt_of_benefit|
+          if confirm_receipt_of_benefit
+            application.change_state_machine_type("PassportedStateMachine")
+            :received_benefit_confirmations
+          else
+            application.change_state_machine_type("NonPassportedStateMachine")
+            :about_financial_means
+          end
+        end,
+      )
+    end
+  end
+end

--- a/app/services/flow/steps/provider_dwp/dwp_results_step.rb
+++ b/app/services/flow/steps/provider_dwp/dwp_results_step.rb
@@ -1,0 +1,13 @@
+module Flow
+  module Steps
+    module ProviderDWP
+      DWPResultsStep = Step.new(
+        path: ->(application) { Steps.urls.providers_legal_aid_application_dwp_result_path(application) },
+        forward: lambda do |application|
+          application.change_state_machine_type("NonPassportedStateMachine")
+          :dwp_overrides
+        end,
+      )
+    end
+  end
+end

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -66,6 +66,16 @@
           legend: { text: t(".labels.collect_hmrc_data") },
         ) %>
 
+    <%= form.govuk_collection_radio_buttons(
+          :collect_dwp_data,
+          yes_no_options,
+          :value,
+          :label,
+          inline: true,
+          hint: { text: t(".hints.collect_dwp_data") },
+          legend: { text: t(".labels.collect_dwp_data") },
+        ) %>
+
     <%= form.govuk_submit(t("generic.submit")) %>
   <% end %>
 <% end %>

--- a/app/views/providers/dwp/overrides/show.html.erb
+++ b/app/views/providers/dwp/overrides/show.html.erb
@@ -1,0 +1,36 @@
+<%= form_with(
+      model: @form,
+      url: providers_legal_aid_application_dwp_override_path,
+      method: :patch,
+      local: true,
+    ) do |form| %>
+
+  <%= page_template(
+        page_title: t(".tab_title"),
+        template: :basic,
+        column_width: :full,
+        form:,
+      ) do %>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= form.govuk_radio_buttons_fieldset(:confirm_dwp_result,
+                                              legend: { size: "l", tag: "h1", text: t(".title") },
+                                              classes: "govuk-!-margin-bottom-6") do %>
+
+          <% if display_hmrc_text? %>
+            <p class="govuk-body"><%= t(".hmrc_text") %></p>
+          <% end %>
+
+          <%= form.govuk_radio_button :confirm_dwp_result, "benefit_received", link_errors: true, label: { text: t("generic.yes") } %>
+          <% if @legal_aid_application.applicant.has_partner? %>
+            <%= form.govuk_radio_button :confirm_dwp_result, "joint_benefit_with_partner", label: { text: t(".option_partner") } %>
+          <% end %>
+          <%= form.govuk_radio_button :confirm_dwp_result, "no_benefit_received", label: { text: t("generic.no") } %>
+      <% end %>
+      </div>
+    </div>
+
+    <%= next_action_buttons(show_draft: true, form:) %>
+  <% end %>
+<% end %>

--- a/app/views/providers/dwp/results/_actions.html.erb
+++ b/app/views/providers/dwp/results/_actions.html.erb
@@ -1,0 +1,7 @@
+   <%= next_action_buttons_with_form(
+         url: providers_legal_aid_application_dwp_result_path,
+         method: :patch,
+         show_draft: false,
+         inverse_continue: true,
+         continue_button_text: t("generic.continue"),
+       ) %>

--- a/app/views/providers/dwp/results/show.html.erb
+++ b/app/views/providers/dwp/results/show.html.erb
@@ -1,0 +1,6 @@
+<%= page_template(page_title: t(".unsuccessful.tab_title"), template: :basic, column_width: "full") do %>
+  <%= interruption_card(heading: t(".unsuccessful.title_html"),
+                        actions: -> { render "actions" }) do
+        t(".unsuccessful.body")
+      end %>
+<% end %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -81,6 +81,7 @@ en:
           enable_evidence_upload: Enable the new evidence upload feature
           linked_applications: Enable linking and copying cases
           collect_hmrc_data: Collect HMRC data
+          collect_dwp_data: Collect DWP data
         hints:
           mock_true_layer_data: Select Yes and TrueLayer data will be replaced by mock data from %{bank_transaction_filename}
           manually_review_all_cases: |
@@ -91,6 +92,7 @@ en:
           enable_evidence_upload: Select Yes to enable the new evidence upload feature for solicitors
           linked_applications: Select Yes to enable the linking and copying cases feature for solicitors
           collect_hmrc_data: Select Yes to enable calls to HMRC for employment data
+          collect_dwp_data: Select Yes to enable calls to Benefit Checker for passporting benefits data
 
       update:
         notice: Settings have been updated

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -70,15 +70,6 @@ en:
         understands_terms_of_court_order_details: Tell us why you think the court would enforce a breach of an order
       application_merits_task_statement_of_case:
         statement: Enter your client's statement of case
-      setting:
-        mock_true_layer_data:
-          <<: *true_false
-        manually_review_all_cases:
-          <<: *true_false
-        allow_welsh_translation:
-          <<: *true_false
-        enable_evidence_upload:
-          <<: *true_false
     legend:
       providers_means_housing_benefit_form:
         housing_benefit_frequency: Select frequency

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -185,6 +185,13 @@ en:
           title: "DWP records show that your client receives a passporting benefit"
           must_answer_financial_questions: "answer questions about your client's property, savings and other assets"
           provide_details: provide details of the case
+    dwp:
+      results:
+        show:
+          unsuccessful:
+            tab_title: There was a problem connecting to DWP
+            title_html: There was a problem connecting to <abbr title='Department for Work and Pensions'>DWP</abbr>
+            body: Your client’s benefit status cannot be checked at this time. You will need to tell us about any passporting benefits.
     cookies:
       show:
         page_title: Cookies on Apply for civil legal aid

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -192,6 +192,12 @@ en:
             tab_title: There was a problem connecting to DWP
             title_html: There was a problem connecting to <abbr title='Department for Work and Pensions'>DWP</abbr>
             body: Your client’s benefit status cannot be checked at this time. You will need to tell us about any passporting benefits.
+      overrides:
+        show:
+          tab_title: Does your client get a passporting benefit?
+          title: Does your client get a passporting benefit?
+          hmrc_text: If your client does not receive a passporting benefit, we'll check their details with HM Revenue and Customs (HMRC). You can review these details later.
+          option_partner: Yes, they get a passporting benefit with a partner
     cookies:
       show:
         page_title: Cookies on Apply for civil legal aid

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -233,6 +233,7 @@ Rails.application.routes.draw do
       resource :applicant_details, only: %i[show update]
       resource :previous_references, only: %i[show update]
       resource :check_benefit, only: %i[show update]
+      resource :dwp_result, only: %i[show update], controller: "dwp/results", path: "dwp-result"
       resource :has_national_insurance_number, only: %i[show update]
       resources :applicant_employed, only: %i[index create]
       resource :about_financial_means, only: %i[show update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -234,6 +234,7 @@ Rails.application.routes.draw do
       resource :previous_references, only: %i[show update]
       resource :check_benefit, only: %i[show update]
       resource :dwp_result, only: %i[show update], controller: "dwp/results", path: "dwp-result"
+      resource :dwp_override, only: %i[show update], controller: "dwp/overrides", path: "advise-of-passport-benefit"
       resource :has_national_insurance_number, only: %i[show update]
       resources :applicant_employed, only: %i[index create]
       resource :about_financial_means, only: %i[show update]

--- a/db/migrate/20250728135041_add_collect_dwp_data_to_settings.rb
+++ b/db/migrate/20250728135041_add_collect_dwp_data_to_settings.rb
@@ -1,0 +1,5 @@
+class AddCollectDWPDataToSettings < ActiveRecord::Migration[8.0]
+  def change
+    add_column :settings, :collect_dwp_data, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1043,6 +1043,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_21_145938) do
     t.datetime "cfe_compare_run_at"
     t.boolean "linked_applications", default: false, null: false
     t.boolean "collect_hmrc_data", default: false, null: false
+    t.boolean "collect_dwp_data", default: true, null: false
   end
 
   create_table "specific_issues", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/forms/providers/dwp/overrides_form_spec.rb
+++ b/spec/forms/providers/dwp/overrides_form_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe Providers::DWP::OverridesForm, type: :form do
+  subject(:form) { described_class.new(params) }
+
+  let(:params) { { confirm_dwp_result: nil } }
+
+  describe "validation" do
+    before { form.valid? }
+
+    context "when the dwp result is correct" do
+      let(:params) { { confirm_dwp_result: "no_benefit_received" } }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when the applicant receives a passporting benefit that is not joint" do
+      let(:params) { { confirm_dwp_result: "benefit_received" } }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when the applicant receives a joint passporting benefit with their partner" do
+      let(:params) { { confirm_dwp_result: "joint_benefit_with_partner" } }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when the parameters are missing" do
+      it { is_expected.not_to be_valid }
+
+      it "records the error message" do
+        expect(form.errors[:confirm_dwp_result]).to eq [I18n.t("providers.confirm_dwp_non_passported_applications.show.error")]
+      end
+    end
+
+    context "when saving as draft" do
+      before { form.save_as_draft }
+
+      it { is_expected.to be_valid }
+    end
+  end
+end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Setting do
         expect(rec.alert_via_sentry?).to be true
         expect(rec.linked_applications?).to be false
         expect(rec.collect_hmrc_data?).to be false
+        expect(rec.collect_dwp_data?).to be true
       end
     end
 
@@ -29,6 +30,7 @@ RSpec.describe Setting do
           alert_via_sentry: false,
           linked_applications: true,
           collect_hmrc_data: true,
+          collect_dwp_data: true,
         )
       end
 
@@ -42,6 +44,7 @@ RSpec.describe Setting do
         expect(rec.alert_via_sentry?).to be false
         expect(rec.linked_applications?).to be true
         expect(rec.collect_hmrc_data?).to be true
+        expect(rec.collect_dwp_data?).to be true
       end
     end
   end
@@ -58,6 +61,7 @@ RSpec.describe Setting do
       expect(described_class.alert_via_sentry?).to be true
       expect(described_class.linked_applications?).to be false
       expect(described_class.collect_hmrc_data?).to be false
+      expect(described_class.collect_dwp_data?).to be true
     end
   end
 end

--- a/spec/requests/admin/settings_controller_spec.rb
+++ b/spec/requests/admin/settings_controller_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Admin::SettingsController do
           linked_applications: "true",
           collect_hmrc_data: "true",
           home_address: "true",
+          collect_dwp_data: "true",
         },
       }
     end
@@ -52,15 +53,16 @@ RSpec.describe Admin::SettingsController do
       Setting.delete_all
     end
 
-    it "change settings values" do
+    it "changes settings values" do
       patch_request
       expect(setting.mock_true_layer_data?).to be(true)
       expect(setting.allow_welsh_translation?).to be(true)
       expect(setting.linked_applications?).to be(true)
       expect(setting.collect_hmrc_data?).to be(true)
+      expect(setting.collect_dwp_data?).to be(true)
     end
 
-    it "create settings if they do not exist" do
+    it "creates settings if they do not exist" do
       expect { patch_request }.to change(Setting, :count).from(0).to(1)
     end
 

--- a/spec/requests/providers/check_benefits_controller_spec.rb
+++ b/spec/requests/providers/check_benefits_controller_spec.rb
@@ -72,9 +72,9 @@ RSpec.describe Providers::CheckBenefitsController do
     context "when the benefit check service is down" do
       before { allow(BenefitCheckService).to receive(:call).and_return(false) }
 
-      it "redirects to the Problem page" do
+      it "redirects to the DWP results page" do
         get_request
-        expect(response).to redirect_to(error_path(:benefit_checker_down))
+        expect(response).to redirect_to(providers_legal_aid_application_dwp_result_path)
       end
     end
 

--- a/spec/requests/providers/dwp/overrides_controller_spec.rb
+++ b/spec/requests/providers/dwp/overrides_controller_spec.rb
@@ -1,0 +1,257 @@
+require "rails_helper"
+
+RSpec.describe Providers::DWP::OverridesController do
+  let(:application) { create(:legal_aid_application, :with_proceedings, :at_checking_applicant_details, :with_applicant_and_address) }
+  let(:enable_hmrc_collection) { true }
+
+  before { allow(Setting).to receive(:collect_hmrc_data?).and_return(enable_hmrc_collection) }
+
+  describe "GET /providers/applications/:legal_aid_application_id/dwp/advise-of-passport-benefit" do
+    subject(:get_request) { get providers_legal_aid_application_dwp_override_path(application) }
+
+    context "when the provider is not authenticated" do
+      before { get_request }
+
+      it_behaves_like "a provider not authenticated"
+    end
+
+    context "when the provider is authenticated" do
+      before do
+        login_as application.provider
+        get_request
+      end
+
+      it "returns success" do
+        expect(response).to be_successful
+      end
+    end
+
+    describe "HMRC inset text" do
+      before { login_as application.provider }
+
+      it "displays the HMRC inset text" do
+        get_request
+        expect(unescaped_response_body).to include(I18n.t(".providers.confirm_dwp_non_passported_applications.show.hmrc_text"))
+      end
+    end
+
+    context "when the application has a partner" do
+      let(:application) { create(:legal_aid_application, :with_applicant_and_partner, :with_proceedings, :at_checking_applicant_details) }
+
+      before do
+        login_as application.provider
+      end
+
+      it "displays the joint passporting benefit option" do
+        get_request
+        expect(unescaped_response_body).to include("Yes, they get a passporting benefit with a partner")
+      end
+    end
+
+    context "when the application does not have a partner" do
+      it "does not display the joint passporting benefit option" do
+        get_request
+        expect(unescaped_response_body).not_to include("Yes, they get a passporting benefit with a partner")
+      end
+    end
+  end
+
+  describe "PATCH /providers/applications/:legal_aid_application_id/dwp/advise-of-passport-benefit" do
+    context "when submitting with the Continue button" do
+      subject(:patch_request) { patch providers_legal_aid_application_dwp_override_path(application), params: }
+
+      let(:params) do
+        {
+          continue_button: "Continue",
+        }
+      end
+
+      before do
+        login_as application.provider
+        allow(HMRC::CreateResponsesService).to receive(:call).with(application).and_return(instance_double(HMRC::CreateResponsesService, call: %w[one two]))
+      end
+
+      context "and the results are correct" do
+        let(:params) do
+          {
+            continue_button: "Continue",
+            partner: {
+              confirm_dwp_result: "no_benefit_received",
+            },
+          }
+        end
+
+        context "when the status is already applicant_details_checked" do
+          before { application.applicant_details_checked! }
+
+          it { expect { patch_request }.not_to change { application.reload.state } }
+        end
+
+        context "when the state is not already applicant_details_checked" do
+          it "sets the application state to overriding applicant_details_checked result" do
+            expect { patch_request }.to change { application.reload.state }.to("applicant_details_checked")
+          end
+        end
+
+        it "redirects to the next page" do
+          patch_request
+          expect(response).to have_http_status(:redirect)
+        end
+
+        it "uses the non-passported state machine" do
+          patch_request
+          expect(application.reload.state_machine_proxy.type).to eq "NonPassportedStateMachine"
+        end
+
+        context "and the hmrc toggle is true" do
+          it "calls the HMRC::CreateResponsesService" do
+            patch_request
+            expect(HMRC::CreateResponsesService).to have_received(:call).once
+          end
+        end
+
+        context "and the hmrc toggle is false" do
+          let(:enable_hmrc_collection) { false }
+
+          it "doesn't call the HMRC::CreateResponsesService" do
+            patch_request
+            expect(HMRC::CreateResponsesService).not_to have_received(:call)
+          end
+        end
+
+        it "successfully deletes any existing dwp override" do
+          create(:dwp_override, legal_aid_application: application)
+          patch_request
+          expect(application.reload.dwp_override).to be_nil
+        end
+      end
+
+      context "and the solicitor wants to override the results with a non joint benefit" do
+        let(:application) { create(:legal_aid_application, :with_applicant_and_partner, :with_proceedings, :at_checking_applicant_details) }
+        let(:partner) { application.partner }
+
+        let(:params) do
+          {
+            continue_button: "Continue",
+            partner: {
+              confirm_dwp_result: "benefit_received",
+            },
+          }
+        end
+
+        context "when the status is already overriding_dwp_result" do
+          before { application.override_dwp_result! }
+
+          it { expect { patch_request }.not_to change { application.reload.state } }
+        end
+
+        context "when the state is not already override_dwp_result" do
+          it "sets the application state to overriding DWP result" do
+            expect { patch_request }.to change { application.reload.state }.to("overriding_dwp_result")
+          end
+        end
+
+        it "redirects to the next page" do
+          patch_request
+          expect(response).to have_http_status(:redirect)
+        end
+
+        it "does not update the partner shared benefit field" do
+          patch_request
+          expect(partner.reload.shared_benefit_with_applicant).to be false
+        end
+
+        it "uses the passported state machine" do
+          patch_request
+          expect(application.reload.state_machine_proxy.type).to eq "PassportedStateMachine"
+        end
+
+        it "calls the HMRC::CreateResponsesService" do
+          patch_request
+          expect(HMRC::CreateResponsesService).to have_received(:call)
+        end
+      end
+
+      context "and the solicitor wants to override the results with a partner" do
+        let(:application) { create(:legal_aid_application, :with_proceedings, :at_checking_applicant_details, :with_applicant_and_partner) }
+        let(:partner) { application.partner }
+
+        let(:params) do
+          {
+            continue_button: "Continue",
+            partner: {
+              confirm_dwp_result: "joint_benefit_with_partner",
+            },
+          }
+        end
+
+        it "sets the application state to overriding DWP result" do
+          patch_request
+          expect(application.reload.state).to eq "overriding_dwp_result"
+        end
+
+        it "sets the partner shared benefit field to true" do
+          patch_request
+          expect(partner.reload.shared_benefit_with_applicant).to be true
+        end
+
+        it "sets the applicant shared benefit field to true" do
+          patch_request
+          expect(application.reload.applicant.shared_benefit_with_partner).to be true
+        end
+
+        it "redirects to the next page" do
+          patch_request
+          expect(response).to have_http_status(:redirect)
+        end
+
+        it "uses the passported state machine" do
+          patch_request
+          expect(application.reload.state_machine_proxy.type).to eq "PassportedStateMachine"
+        end
+
+        it "calls the HMRC::CreateResponsesService" do
+          patch_request
+          expect(HMRC::CreateResponsesService).to have_received(:call)
+        end
+      end
+
+      context "and the solicitor does not select a radio button" do
+        it "displays an error" do
+          patch_request
+          expect(response.body).to include(I18n.t("providers.confirm_dwp_non_passported_applications.show.error"))
+        end
+      end
+    end
+
+    context "when submitting with the Save As Draft button" do
+      subject(:patch_request) { patch providers_legal_aid_application_dwp_override_path(application), params: }
+
+      let(:params) do
+        {
+          draft_button: "Save as draft",
+        }
+      end
+
+      before do
+        login_as application.provider
+        allow(HMRC::CreateResponsesService).to receive(:call).with(application).and_return(instance_double(HMRC::CreateResponsesService, call: %w[one two]))
+      end
+
+      it "redirects provider to provider's applications page" do
+        patch_request
+        expect(response).to redirect_to(in_progress_providers_legal_aid_applications_path)
+      end
+
+      it "sets the application as draft" do
+        patch_request
+        expect(application.reload).to be_draft
+      end
+
+      it "does not call the HMRC::CreateResponsesService" do
+        patch_request
+        expect(HMRC::CreateResponsesService).not_to have_received(:call)
+      end
+    end
+  end
+end

--- a/spec/requests/providers/dwp/results_controller_spec.rb
+++ b/spec/requests/providers/dwp/results_controller_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe Providers::DWP::ResultsController do
+  let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings, :at_checking_applicant_details, :with_applicant_and_address) }
+
+  describe "GET /providers/applications/:legal_aid_application_id/dwp/advise-of-passport-benefit" do
+    subject(:get_request) { get providers_legal_aid_application_dwp_override_path(legal_aid_application) }
+
+    context "when the provider is not authenticated" do
+      before { get_request }
+
+      it_behaves_like "a provider not authenticated"
+    end
+
+    context "when the provider is authenticated" do
+      before do
+        login_as legal_aid_application.provider
+        get_request
+      end
+
+      it "returns success" do
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe "PATCH /providers/applications/:legal_aid_application_id/dwp/advise-of-passport-benefit" do
+    subject(:patch_request) { patch providers_legal_aid_application_dwp_override_path(legal_aid_application), params: }
+
+    let(:params) do
+      {
+        continue_button: "Continue",
+      }
+    end
+
+    it "redirects to the next page" do
+      patch_request
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+end

--- a/spec/services/flow/steps/provider_dwp/dwp_overrides_step_spec.rb
+++ b/spec/services/flow/steps/provider_dwp/dwp_overrides_step_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::ProviderDWP::DWPOverridesStep, type: :request do
+  let(:legal_aid_application) { create(:legal_aid_application) }
+
+  describe "#path" do
+    subject { described_class.path.call(legal_aid_application) }
+
+    it { is_expected.to eql providers_legal_aid_application_dwp_override_path(legal_aid_application) }
+  end
+
+  describe "#forward" do
+    subject(:forward_step) { described_class.forward.call(legal_aid_application, confirm_receipt_of_benefit) }
+
+    context "when the provider says a benefit is received" do
+      let(:confirm_receipt_of_benefit) { true }
+
+      it { is_expected.to eq :received_benefit_confirmations }
+
+      it "sets the state machine" do
+        forward_step
+        expect(legal_aid_application.state_machine.type).to eq "PassportedStateMachine"
+      end
+    end
+
+    context "when the provider says a benefit is not received" do
+      let(:confirm_receipt_of_benefit) { false }
+
+      it { is_expected.to eq :about_financial_means }
+
+      it "sets the state machine" do
+        forward_step
+        expect(legal_aid_application.state_machine.type).to eq "NonPassportedStateMachine"
+      end
+    end
+  end
+end

--- a/spec/services/flow/steps/provider_dwp/dwp_results_step_spec.rb
+++ b/spec/services/flow/steps/provider_dwp/dwp_results_step_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::ProviderDWP::DWPResultsStep, type: :request do
+  let(:legal_aid_application) { create(:legal_aid_application) }
+
+  describe "#path" do
+    subject { described_class.path.call(legal_aid_application) }
+
+    it { is_expected.to eql providers_legal_aid_application_dwp_result_path(legal_aid_application) }
+  end
+
+  describe "#forward" do
+    subject(:forward_step) { described_class.forward.call(legal_aid_application) }
+
+    it { is_expected.to eq :dwp_overrides }
+  end
+end

--- a/spec/system/client_details/benefit_checker_override_spec.rb
+++ b/spec/system/client_details/benefit_checker_override_spec.rb
@@ -1,0 +1,96 @@
+require "system_helper"
+
+RSpec.describe "Client and case details section - benefit checker fallback", :vcr do
+  before do
+    login_as_a_provider
+    allow(Setting).to receive_messages(collect_dwp_data?: collect_dwp_data)
+    create_an_application_and_complete_client_details(with_partner)
+    visit providers_legal_aid_application_check_provider_answers_path(@legal_aid_application)
+  end
+
+  let(:with_partner) { false }
+
+  context "when the collect_dwp_data setting is off" do
+    let(:collect_dwp_data) { false }
+
+    scenario "I am routed from Check your Answers to the benefit confirmation page via an interrupt page" do
+      click_on "Save and continue"
+      expect(page).to have_css("h1", text: "There was a problem connecting to DWP")
+
+      click_on "Continue"
+      expect(page).to have_css("h1", text: "Does your client get a passporting benefit?")
+
+      govuk_choose("Yes")
+      click_on "Save and continue"
+      expect(page).to have_css("h1", text: "Which passporting benefit does your client get?")
+    end
+
+    scenario "when the client does not receive a passported benefit I am routed from Check your Answers to the start of the means flow via an interrupt page" do
+      click_on "Save and continue"
+      expect(page).to have_css("h1", text: "There was a problem connecting to DWP")
+
+      click_on "Continue"
+      expect(page).to have_css("h1", text: "Does your client get a passporting benefit?")
+
+      govuk_choose("No")
+      click_on "Save and continue"
+      expect(page.current_url).to eql providers_legal_aid_application_about_financial_means_url(@legal_aid_application)
+      expect(page).to have_css("h1", text: "What you need to do")
+    end
+
+    scenario "when the client receives a joint passporting benefit with their partner" do
+      click_on "Save and continue"
+      expect(page).to have_css("h1", text: "There was a problem connecting to DWP")
+
+      click_on "Continue"
+      expect(page).to have_css("h1", text: "Does your client get a passporting benefit?")
+
+      govuk_choose("Yes, they get a passporting benefit with a partner")
+      click_on "Save and continue"
+      expect(page).to have_css("h1", text: "Which joint passporting benefit does your client and their partner get?")
+    end
+  end
+
+  context "when the collect_dwp_data setting is on" do
+    let(:collect_dwp_data) { true }
+
+    context "and the call to benefit checker does not return a 200" do
+      before { allow(BenefitCheckService).to receive(:call).and_return(false) }
+
+      scenario "I am routed from Check your answers to an interrupt page and then to the benefit confirmation page" do
+        click_on "Save and continue"
+        expect(page).to have_css("h1", text: "There was a problem connecting to DWP")
+
+        click_on "Continue"
+        expect(page).to have_css("h1", text: "Does your client get a passporting benefit?")
+
+        click_on "Save and continue"
+        expect(page).to have_css("h2", text: "There is a problem")
+        expect(page).to have_css("a", text: "Select yes if the DWP records are correct")
+
+        govuk_choose("Yes")
+        click_on "Save and continue"
+        expect(page).to have_css("h1", text: "Which passporting benefit does your client get?")
+      end
+    end
+
+    context "and the call to benefit checker returns 200" do
+      before { allow(BenefitCheckService).to receive(:call).with(@legal_aid_application).and_return(benefit_check_response) }
+
+      let(:benefit_check_response) do
+        {
+          benefit_checker_status: "Yes",
+          confirmation_ref: SecureRandom.hex,
+        }
+      end
+
+      scenario "I am routed from Check your answers to the DWP results page" do
+        click_on "Save and continue"
+        expect(page).to have_css("h1", text: "DWP records show that your client receives a passporting benefit")
+
+        click_on "Continue"
+        expect(page).to have_css("h1", text: "What you need to do") # on capital_introductions page
+      end
+    end
+  end
+end

--- a/spec/system/support/gouk_form_helpers.rb
+++ b/spec/system/support/gouk_form_helpers.rb
@@ -8,6 +8,6 @@ module GovukFormHelpers
   end
 
   def govuk_choose(locator, **)
-    choose(locator, **, visible: :hidden)
+    choose(locator, **, visible: :all)
   end
 end

--- a/spec/system/support/step_helpers.rb
+++ b/spec/system/support/step_helpers.rb
@@ -36,4 +36,15 @@ module StepHelpers
 
     nil if step_name == :previous_references
   end
+
+  def create_an_application_and_complete_client_details(with_partner)
+    applicant = with_partner ? :with_applicant : :with_applicant_and_partner
+    @legal_aid_application = create(
+      :application,
+      :with_proceedings,
+      :at_entering_applicant_details,
+      applicant,
+      provider: @registered_provider,
+    )
+  end
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6144)

This adds a setting to turn off Benefit Checker if we know it will be off for some time, it matches the `collect_hmrc_data?` name and pattern.

This will redirect to a new set of pages when the switch is off, or a call to benefit checker call fails.

It could be expanded to handle the whole DWP flow, but (while work was started) it was taking too long so this is the initial, simplified version

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
