### PR TITLE
Chore: Add CI/CD automatic rerun of 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,6 +321,7 @@ generic-slack-fail-post-step: &generic-slack-fail-post-step
 
 workflows:
   open_pr:
+    max_auto_reruns: 1
     jobs:
       - lint_checks:
           filters:


### PR DESCRIPTION

## What
Add CI/CD automatic rerun of 1

For handling occassional flakiness in tests or ephemeral
infrastructure issues.

New feature in CircleCI - see [here](https://circleci.com/docs/guides/orchestrate/automatic-reruns/)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
