### PR TITLE
AP-6141: Make changes to proceedings search pages

### DIFF
--- a/app/views/providers/has_other_proceedings/show.html.erb
+++ b/app/views/providers/has_other_proceedings/show.html.erb
@@ -46,7 +46,9 @@
     <% else %>
       <%= form.govuk_collection_radio_buttons :has_other_proceeding, yes_no_options, :value, :label,
                                               legend: { text: content_for(:page_title), tag: "h2", size: "m" } do %>
-        <%= govuk_inset_text(text: t(".inset")) %>
+        <p class="govuk-body">
+          <%= t(".inset") %>
+        </p>
       <% end %>
     <% end %>
 

--- a/app/views/providers/proceedings_types/index.html.erb
+++ b/app/views/providers/proceedings_types/index.html.erb
@@ -66,8 +66,16 @@
       <span class="govuk-body"><%= t ".no_results" %></span>
     </div>
   </div>
-  <div class="govuk-grid-row govuk-!-margin-top-5">
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <%= govuk_details(summary_text: t(".details.summary_text"), text: simple_format(t(".details.text"))) %>
+
+      <% if @legal_aid_application.proceedings.any? %>
+        <p class="govuk-body">
+          <%= govuk_link_to(t(".chosen_proceedings"), providers_legal_aid_application_has_other_proceedings_path) %>
+        </p>
+      <% end %>
+
       <%= next_action_buttons(form:, show_draft: true) %>
     </div>
   </div>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1821,6 +1821,15 @@ en:
         accessibility_message: Tab out of this box to select returned options
         accessibility_message_safari_browser: "You are in a search field, tab out to see results"
         you_have_selected: You have selected %{count}
+        details:
+          summary_text: Applying for multiple proceedings
+          text: |
+            You will only be shown the proceedings that you can select. Each proceeding can only be added once.
+
+            Special children act proceedings should be added before related ones.
+
+            For public law family, means-tested and non-means-tested proceedings cannot be combined.
+        chosen_proceedings: See your chosen proceedings
     has_other_proceedings:
       show:
         page_title: Do you want to add another proceeding?


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6141)

Make changes as per designs:
- add details component to proceedings_types page
- add link to has_other_proceedings page from proceedings_types page
- change inset text to paragraph text

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
