### PR TITLE
Remove portal_enable - part 1

### DIFF
--- a/app/controllers/concerns/providers/authorizable.rb
+++ b/app/controllers/concerns/providers/authorizable.rb
@@ -18,7 +18,6 @@ module Providers
     included do
       include Pundit::Authorization
 
-      before_action :authorize_portal_user?
       before_action :authorize_legal_aid_application
       rescue_from Pundit::NotAuthorizedError, with: :provider_not_authorized
 
@@ -46,12 +45,6 @@ module Providers
 
       def current_policy
         Pundit.policy pundit_user, legal_aid_application
-      end
-
-      def authorize_portal_user?
-        return false if current_provider.portal_enabled?
-
-        redirect_to error_path(:access_denied)
       end
 
       def authorize_legal_aid_application

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -1,4 +1,6 @@
 class Provider < ApplicationRecord
+  self.ignored_columns += %w[portal_enabled]
+
   encrypts :auth_subject_uid, deterministic: true
 
   devise :trackable

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -4,11 +4,6 @@ FactoryBot.define do
     name { Faker::Name.name }
     username { "#{Faker::Internet.username}_#{Random.rand(1...999).to_s.rjust(3, '0')}" }
     email { Faker::Internet.email }
-    portal_enabled { true }
-
-    trait :without_portal_enabled do
-      portal_enabled { false }
-    end
 
     trait :with_provider_details_api_username do
       username { "NEETADESOR" }

--- a/spec/requests/providers/legal_aid_applications_spec.rb
+++ b/spec/requests/providers/legal_aid_applications_spec.rb
@@ -26,15 +26,6 @@ RSpec.describe "providers legal aid application requests" do
         expect(response).to have_http_status(:ok)
       end
 
-      context "when the provider is not a portal_enabled user" do
-        let(:provider) { create(:provider, :without_portal_enabled) }
-
-        it "redirects to error page" do
-          get_request
-          expect(response).to redirect_to(error_path(:access_denied))
-        end
-      end
-
       it "includes a link to the legal aid application's default start path" do
         get_request
         expect(response.body).to include(providers_legal_aid_application_proceedings_types_path(legal_aid_application))


### PR DESCRIPTION
## What
Remove portal_enable - part 1

This column is defaulted to true=, is all true on production for all providers
and is never set to any other value anywhere. So removing this dead code.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
