### PR TITLE
AP-6202: Ensure office selection before provider access

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -9,6 +9,9 @@ SimpleCov.start "rails" do
   add_filter "lib/tasks/helpers/cy_helper.rb"
   add_filter "lib/utilities/redis_scanner.rb"
 
+  # TODO: AP-6201: remove if office confirmation flow is reimplemented
+  add_filter "app/controllers/providers/confirm_offices_controller.rb"
+
   enable_coverage :branch
 
   unless ENV["CIRCLE_JOB"]

--- a/app/controllers/concerns/providers/appointable.rb
+++ b/app/controllers/concerns/providers/appointable.rb
@@ -11,7 +11,7 @@ module Providers
     #   before_action :appoint_provider!
     #
     def appoint_provider!
-      return if current_provider.selected_office.present? || request.fullpath == providers_select_office_path
+      return if current_provider.selected_office.present? || allowed_unappointed_path?
 
       store_location_for(:provider, request.fullpath)
       redirect_to providers_select_office_path
@@ -22,8 +22,8 @@ module Providers
     #
     # Example:
     #
-    #   store_location_for(:user, dashboard_path)
-    #   redirect_to user_facebook_omniauth_authorize_path
+    #   store_location_for(:provider, home_path)
+    #   redirect_to providers_select_office_path
     #
     def store_location_for(resource_or_scope, location)
       session_key = stored_location_key_for(resource_or_scope)
@@ -46,6 +46,14 @@ module Providers
     end
 
   private
+
+    def allowed_unappointed_path?
+      request.fullpath.in? [
+        providers_select_office_path,
+        providers_invalid_schedules_path,
+        providers_provider_path,
+      ]
+    end
 
     def parse_uri(location)
       location && URI.parse(location)

--- a/app/controllers/concerns/providers/appointable.rb
+++ b/app/controllers/concerns/providers/appointable.rb
@@ -2,86 +2,90 @@ module Providers
   module Appointable
     extend ActiveSupport::Concern
 
-    # Redirects to the office selection page if there is no `selected_office`,
-    # remembering wheree the user/provider came from. The office select controller
-    # will then redirect back to the remebered location or home page for provider
-    #
-    # Example:
-    #
-    #   before_action :appoint_provider!
-    #
-    def appoint_provider!
-      return if current_provider.selected_office.present? || allowed_unappointed_path?
+    included do
+      before_action :appoint_provider!
 
-      store_location_for(:provider, request.fullpath)
-      redirect_to providers_select_office_path
-    end
+      # Redirects to the office selection page if there is no `selected_office`,
+      # remembering wheree the user/provider came from. The office select controller
+      # will then redirect back to the remebered location or home page for provider
+      #
+      # Example:
+      #
+      #   before_action :appoint_provider!
+      #
+      def appoint_provider!
+        return if current_provider.selected_office.present? || allowed_unappointed_path?
 
-    # Stores the provided location to redirect the user after selecting an office.
-    # Useful in combination with the `stored_location_for` helper.
-    #
-    # Example:
-    #
-    #   store_location_for(:provider, home_path)
-    #   redirect_to providers_select_office_path
-    #
-    def store_location_for(resource_or_scope, location)
-      session_key = stored_location_key_for(resource_or_scope)
-
-      path = extract_path_from_location(location)
-      session[session_key] = path if path
-    end
-
-    # Returns and deletes the url stored in the session for
-    # the given scope. Useful for giving redirect backs after office selection:
-    #
-    # Example:
-    #
-    #   redirect_to stored_location_for(:user) || root_path
-    #
-    def stored_location_for(resource_or_scope)
-      session_key = stored_location_key_for(resource_or_scope)
-
-      session.delete(session_key)
-    end
-
-  private
-
-    def allowed_unappointed_path?
-      request.fullpath.in? [
-        providers_select_office_path,
-        providers_invalid_schedules_path,
-        providers_provider_path,
-      ]
-    end
-
-    def parse_uri(location)
-      location && URI.parse(location)
-    rescue URI::InvalidURIError
-      nil
-    end
-
-    def stored_location_key_for(resource_or_scope)
-      scope = Devise::Mapping.find_scope!(resource_or_scope)
-      "#{scope}_select_office_return_to"
-    end
-
-    def extract_path_from_location(location)
-      uri = parse_uri(location)
-
-      if uri
-        path = remove_domain_from_uri(uri)
-        add_fragment_back_to_path(uri, path)
-
+        store_location_for(:provider, request.fullpath)
+        redirect_to providers_select_office_path
       end
-    end
 
-    def remove_domain_from_uri(uri)
-      [uri.path.sub(/\A\/+/, "/"), uri.query].compact.join("?")
-    end
+      # Stores the provided location to redirect the user after selecting an office.
+      # Useful in combination with the `stored_location_for` helper.
+      #
+      # Example:
+      #
+      #   store_location_for(:provider, home_path)
+      #   redirect_to providers_select_office_path
+      #
+      def store_location_for(resource_or_scope, location)
+        session_key = stored_location_key_for(resource_or_scope)
 
-    def add_fragment_back_to_path(uri, path)
-      [path, uri.fragment].compact.join("#")
+        path = extract_path_from_location(location)
+        session[session_key] = path if path
+      end
+
+      # Returns and deletes the url stored in the session for
+      # the given scope. Useful for giving redirect backs after office selection:
+      #
+      # Example:
+      #
+      #   redirect_to stored_location_for(:user) || root_path
+      #
+      def stored_location_for(resource_or_scope)
+        session_key = stored_location_key_for(resource_or_scope)
+
+        session.delete(session_key)
+      end
+
+    private
+
+      def allowed_unappointed_path?
+        request.fullpath.in? [
+          providers_select_office_path,
+          providers_invalid_schedules_path,
+          providers_provider_path,
+        ]
+      end
+
+      def parse_uri(location)
+        location && URI.parse(location)
+      rescue URI::InvalidURIError
+        nil
+      end
+
+      def stored_location_key_for(resource_or_scope)
+        scope = Devise::Mapping.find_scope!(resource_or_scope)
+        "#{scope}_select_office_return_to"
+      end
+
+      def extract_path_from_location(location)
+        uri = parse_uri(location)
+
+        if uri
+          path = remove_domain_from_uri(uri)
+          add_fragment_back_to_path(uri, path)
+
+        end
+      end
+
+      def remove_domain_from_uri(uri)
+        [uri.path.sub(/\A\/+/, "/"), uri.query].compact.join("?")
+      end
+
+      def add_fragment_back_to_path(uri, path)
+        [path, uri.fragment].compact.join("#")
+      end
     end
   end
 end

--- a/app/controllers/concerns/providers/appointable.rb
+++ b/app/controllers/concerns/providers/appointable.rb
@@ -1,0 +1,79 @@
+module Providers
+  module Appointable
+    extend ActiveSupport::Concern
+
+    # Redirects to the office selection page if there is no `selected_office`,
+    # remembering wheree the user/provider came from. The office select controller
+    # will then redirect back to the remebered location or home page for provider
+    #
+    # Example:
+    #
+    #   before_action :appoint_provider!
+    #
+    def appoint_provider!
+      return if current_provider.selected_office.present? || request.fullpath == providers_select_office_path
+
+      store_location_for(:provider, request.fullpath)
+      redirect_to providers_select_office_path
+    end
+
+    # Stores the provided location to redirect the user after selecting an office.
+    # Useful in combination with the `stored_location_for` helper.
+    #
+    # Example:
+    #
+    #   store_location_for(:user, dashboard_path)
+    #   redirect_to user_facebook_omniauth_authorize_path
+    #
+    def store_location_for(resource_or_scope, location)
+      session_key = stored_location_key_for(resource_or_scope)
+
+      path = extract_path_from_location(location)
+      session[session_key] = path if path
+    end
+
+    # Returns and deletes the url stored in the session for
+    # the given scope. Useful for giving redirect backs after office selection:
+    #
+    # Example:
+    #
+    #   redirect_to stored_location_for(:user) || root_path
+    #
+    def stored_location_for(resource_or_scope)
+      session_key = stored_location_key_for(resource_or_scope)
+
+      session.delete(session_key)
+    end
+
+  private
+
+    def parse_uri(location)
+      location && URI.parse(location)
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    def stored_location_key_for(resource_or_scope)
+      scope = Devise::Mapping.find_scope!(resource_or_scope)
+      "#{scope}_select_office_return_to"
+    end
+
+    def extract_path_from_location(location)
+      uri = parse_uri(location)
+
+      if uri
+        path = remove_domain_from_uri(uri)
+        add_fragment_back_to_path(uri, path)
+
+      end
+    end
+
+    def remove_domain_from_uri(uri)
+      [uri.path.sub(/\A\/+/, "/"), uri.query].compact.join("?")
+    end
+
+    def add_fragment_back_to_path(uri, path)
+      [path, uri.fragment].compact.join("#")
+    end
+  end
+end

--- a/app/controllers/concerns/providers/appointable.rb
+++ b/app/controllers/concerns/providers/appointable.rb
@@ -60,9 +60,11 @@ module Providers
 
       def parse_uri(location)
         location && URI.parse(location)
+      # :nocov:
       rescue URI::InvalidURIError
         nil
       end
+      # :nocov:
 
       def stored_location_key_for(resource_or_scope)
         scope = Devise::Mapping.find_scope!(resource_or_scope)

--- a/app/controllers/providers/invalid_schedules_controller.rb
+++ b/app/controllers/providers/invalid_schedules_controller.rb
@@ -1,12 +1,5 @@
 module Providers
   class InvalidSchedulesController < ProviderBaseController
     legal_aid_application_not_required!
-
-    def show
-      @provider = Provider.find(current_provider.id)
-      session["signed_out"] = true
-      session["feedback_return_path"] = destroy_provider_session_path
-      sign_out current_provider
-    end
   end
 end

--- a/app/controllers/providers/provider_base_controller.rb
+++ b/app/controllers/providers/provider_base_controller.rb
@@ -1,12 +1,14 @@
 module Providers
   class ProviderBaseController < FlowBaseController
     before_action :authenticate_provider!
+    before_action :appoint_provider!
     before_action :set_cache_buster
     before_action :update_locale
     include ApplicationDependable
     include Draftable
     include Authorizable
     include Reviewable::Controller
+    include Appointable
 
   private
 

--- a/app/controllers/providers/provider_base_controller.rb
+++ b/app/controllers/providers/provider_base_controller.rb
@@ -1,14 +1,13 @@
 module Providers
   class ProviderBaseController < FlowBaseController
     before_action :authenticate_provider!
-    before_action :appoint_provider!
     before_action :set_cache_buster
     before_action :update_locale
+    include Appointable
     include ApplicationDependable
     include Draftable
     include Authorizable
     include Reviewable::Controller
-    include Appointable
 
   private
 

--- a/app/controllers/providers/select_offices_controller.rb
+++ b/app/controllers/providers/select_offices_controller.rb
@@ -17,7 +17,7 @@ module Providers
         ProviderContractDetailsWorker.perform_async(form_params[:selected_office_code])
 
         if provider_details_updater.has_valid_schedules?
-          redirect_to your_applications_default_tab_path
+          redirect_to stored_location_for(:provider) || your_applications_default_tab_path
         else
           redirect_to providers_invalid_schedules_path
         end

--- a/app/helpers/home_path_helper.rb
+++ b/app/helpers/home_path_helper.rb
@@ -17,6 +17,6 @@ private
   end
 
   def before_applications_page?
-    [providers_confirm_office_path, providers_select_office_path].any? { |page| request.path.include?(URI.parse(page).path) }
+    [providers_confirm_office_path, providers_select_office_path, providers_provider_path].any? { |page| request.path.include?(URI.parse(page).path) }
   end
 end

--- a/app/helpers/home_path_helper.rb
+++ b/app/helpers/home_path_helper.rb
@@ -17,6 +17,6 @@ private
   end
 
   def before_applications_page?
-    [providers_confirm_office_path, providers_select_office_path, providers_provider_path].any? { |page| request.path.include?(URI.parse(page).path) }
+    [providers_confirm_office_path, providers_select_office_path].any? { |page| request.path.include?(URI.parse(page).path) }
   end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -33,6 +33,7 @@ class Provider < ApplicationRecord
         silas_id: auth.extra.raw_info.USER_NAME,
         email: auth.info.email,
         office_codes: [office_codes].join(":"),
+        selected_office: nil,
       )
     end
   rescue StandardError => e

--- a/features/providers/selecting_office.feature
+++ b/features/providers/selecting_office.feature
@@ -30,6 +30,9 @@ Feature: Selecting office
     When I visit the My profile page
     Then I should be on a page showing 'Your profile'
 
+    When I click link "Apply for civil legal aid"
+    Then I should be on a page showing 'Select the account number of the office handling this application'
+
   @javascript @stub_office_schedules_and_user
   Scenario: I am unable to bypass selecting an office
     Given I am logged in as a provider but have never selected an office

--- a/features/providers/selecting_office.feature
+++ b/features/providers/selecting_office.feature
@@ -40,6 +40,36 @@ Feature: Selecting office
     Then I should be on a page showing 'Select the account number of the office handling this application'
 
   @javascript @mock_auth_enabled @vcr_turned_off
+  Scenario: I am forced to select an office again after sign out and sign in
+    Given I visit the root page
+    And I should see "Providers can use this service to apply for civil legal aid for their clients"
+
+    When I click link "Sign in"
+    Then I should be on a page with title "Sign in"
+
+    When I fill in the mock user email and password
+    And I click 'Sign in'
+    Then I should be on a page showing 'Select the account number of the office handling this application'
+
+    When I choose "0X395U"
+    And I click "Save and continue"
+    Then I should be on a page with title "Your applications"
+
+    When I click link "Sign out"
+    Then I should see "Help us improve the Apply for civil legal aid service"
+    And I should see "You have been signed out"
+
+    When I click link "Sign In"
+    Then I should be on a page with title "Sign in"
+
+    When I fill in the mock user email and password
+    And I click 'Sign in'
+    Then I should be on a page showing 'Select the account number of the office handling this application'
+
+    When I visit the in progress applications page
+    Then I should be on a page showing 'Select the account number of the office handling this application'
+
+  @javascript @mock_auth_enabled @vcr_turned_off
   Scenario: I am able to select an office when mock auth is enabled
     Given I am logged in as a provider with silas_id "51cdbbb4-75d2-48d0-aaac-fa67f013c50a"
     When I visit the select office page

--- a/features/providers/selecting_office.feature
+++ b/features/providers/selecting_office.feature
@@ -16,6 +16,26 @@ Feature: Selecting office
     Then I click 'Save and continue'
     Then I should be on a page showing 'The office you selected does not have a family contract with the Legal Aid Agency (LAA).'
 
+  @javascript @stub_office_schedules_and_user
+  Scenario: I am still able to see the invalid schedule interrupt page even when never having selected an office
+    Given I am logged in as a provider but have never selected an office
+    Then I visit the select office page
+    Then I choose 'A123456'
+    Then I click 'Save and continue'
+    Then I should be on a page showing 'The office you selected does not have a family contract with the Legal Aid Agency (LAA).'
+
+  @javascript @stub_office_schedules_and_user
+  Scenario: I am still able to see my profile page even when never having selected an office
+    Given I am logged in as a provider but have never selected an office
+    When I visit the My profile page
+    Then I should be on a page showing 'Your profile'
+
+  @javascript @stub_office_schedules_and_user
+  Scenario: I am unable to bypass selecting an office
+    Given I am logged in as a provider but have never selected an office
+    When I visit the in progress applications page
+    Then I should be on a page showing 'Select the account number of the office handling this application'
+
   @javascript @mock_auth_enabled @vcr_turned_off
   Scenario: I am able to select an office when mock auth is enabled
     Given I am logged in as a provider with silas_id "51cdbbb4-75d2-48d0-aaac-fa67f013c50a"
@@ -24,7 +44,7 @@ Feature: Selecting office
     And I click 'Save and continue'
     Then I should be on a page showing 'Your applications'
 
-# TODO: Remove or reinstate depending on whether feature is removed/reinstated
+# TODO: AP-6201 - Remove or reinstate depending on whether feature is removed/reinstated
 #  @javascript @stub_pda_provider_details
 #  Scenario: I am able to confirm my office
 #    Given I am logged in as a provider
@@ -34,7 +54,7 @@ Feature: Selecting office
 #    Then I click 'Save and continue'
 #    Then I should be on a page showing 'Your applications'
 
-# TODO: Remove or reinstate depending on whether feature is removed/reinstated
+# TODO: AP-6201 - Remove or reinstate depending on whether feature is removed/reinstated
 #  @javascript
 #  Scenario: I am able to change my registered office
 #    Given I am logged in as a provider

--- a/features/step_definitions/civil_journey_steps.rb
+++ b/features/step_definitions/civil_journey_steps.rb
@@ -32,6 +32,10 @@ Given(/^I visit the voided applications page$/) do
   visit voided_providers_legal_aid_applications_path
 end
 
+Given(/^I visit the My profile page$/) do
+  visit providers_provider_path
+end
+
 Given("I have previously created multiple applications") do
   provider = create(:provider)
   create_list(:legal_aid_application, 3, :with_non_passported_state_machine, provider:)

--- a/features/step_definitions/sign_in_steps.rb
+++ b/features/step_definitions/sign_in_steps.rb
@@ -10,6 +10,13 @@ Given("I am logged in as a provider with silas_id {string}") do |silas_id|
   login_as @registered_provider
 end
 
+Given("I am logged in as a provider but have never selected an office") do
+  @registered_provider = create_provider_with_firm_and_office
+  @registered_provider.update!(offices: [], selected_office: nil)
+
+  login_as @registered_provider
+end
+
 When("I fill in the mock user email and password") do
   fill_in "Email", with: Rails.configuration.x.omniauth_entraid.mock_username
   fill_in "Password", with: Rails.configuration.x.omniauth_entraid.mock_password

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -5,6 +5,11 @@ FactoryBot.define do
     username { "#{Faker::Internet.username}_#{Random.rand(1...999).to_s.rjust(3, '0')}" }
     email { Faker::Internet.email }
 
+    after(:build) do |provider, _evaluator|
+      office = build(:office, firm: provider.firm)
+      provider.selected_office = office
+    end
+
     trait :with_provider_details_api_username do
       username { "NEETADESOR" }
     end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -5,9 +5,16 @@ FactoryBot.define do
     username { "#{Faker::Internet.username}_#{Random.rand(1...999).to_s.rjust(3, '0')}" }
     email { Faker::Internet.email }
 
-    after(:build) do |provider, _evaluator|
-      office = build(:office, firm: provider.firm)
-      provider.selected_office = office
+    transient do
+      with_office_selected { true }
+    end
+
+    after(:build) do |provider, evaluator|
+      if evaluator.with_office_selected
+        office = build(:office, firm: provider.firm, code: "0X00000")
+        provider.offices << office
+        provider.selected_office = office
+      end
     end
 
     trait :with_provider_details_api_username do

--- a/spec/helpers/home_path_helper_spec.rb
+++ b/spec/helpers/home_path_helper_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe HomePathHelper do
           allow(request).to receive(:path).and_return(providers_provider_path)
         end
 
-        it { is_expected.to eq(root_path) }
+        it { is_expected.to eq(in_progress_providers_legal_aid_applications_path) }
       end
 
       context "and user is on the providers confirm office profile page" do

--- a/spec/helpers/home_path_helper_spec.rb
+++ b/spec/helpers/home_path_helper_spec.rb
@@ -7,9 +7,25 @@ RSpec.describe HomePathHelper do
     subject { home_path }
 
     context "when on provider journey" do
-      context "and user has not reached the application page yet" do
+      context "and user is on providers select office page" do
         before do
           allow(request).to receive(:path).and_return(providers_select_office_path)
+        end
+
+        it { is_expected.to eq(root_path) }
+      end
+
+      context "and user is on providers profile page" do
+        before do
+          allow(request).to receive(:path).and_return(providers_provider_path)
+        end
+
+        it { is_expected.to eq(root_path) }
+      end
+
+      context "and user is on the providers confirm office profile page" do
+        before do
+          allow(request).to receive(:path).and_return(providers_confirm_office_path)
         end
 
         it { is_expected.to eq(root_path) }

--- a/spec/requests/providers/invalid_schedules_spec.rb
+++ b/spec/requests/providers/invalid_schedules_spec.rb
@@ -17,10 +17,6 @@ RSpec.describe "provider invalid schedules" do
       expect(page).to have_css("h1", text: "You cannot use this service")
     end
 
-    it "logs the provider out" do
-      expect(session["signed_out"]).to be true
-    end
-
     it "displays link to LAA landing page (a.k.a portal) for CCMS login" do
       expect(page).to have_link("CCMS", href: Rails.configuration.x.laa_landing_page_target_url)
     end

--- a/spec/requests/providers/select_offices_spec.rb
+++ b/spec/requests/providers/select_offices_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "provider selects office" do
-  let(:provider) { create(:provider, office_codes: "0X395U:2N078D:A123456") }
+  let(:provider) { create(:provider, office_codes: "0X395U:2N078D:A123456", with_office_selected: false) }
 
   let(:body) do
     {
@@ -174,7 +174,7 @@ RSpec.describe "provider selects office" do
           patch_request
         end
 
-        it "does not update the select office" do
+        it "does not update the selected office" do
           expect(provider.reload.selected_office_id).to be_blank
         end
 

--- a/spec/services/pda/provider_details_updater_spec.rb
+++ b/spec/services/pda/provider_details_updater_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe PDA::ProviderDetailsUpdater do
         .to_return(body: user, status:)
     end
 
-    let(:provider) { create(:provider) }
+    let(:provider) { create(:provider, with_office_selected: false) }
     let(:firm) { create(:firm, name: "original firm name", ccms_id: "56789") }
     let(:office) { create(:office, code: office_code, ccms_id: "12345") }
     let(:office_code) { "4A497U" }


### PR DESCRIPTION
## What
Ensure office selection before provider access

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6202)

This borrows from devise logic to prevent navigation to any provider page without having selected
an office for that provider, barring 3 exceptions*1.

## Why
This is important because, for new logins in particular, if a provider has no office then any applications they create will not have an office and will not be injectable into CCMS as a result.

Current logic signs users out "just in case" if they select an office without the correct schedules/contract-details. However, there was a clickable journey via the profile page that allowed circumnavigation of current logic which has been corrected separately by preventing the banner link going to the in progress app list _[this may need amending if that was intended]_.

*1 exceptions are the office select page itself, the invalid schedules interrupt page, and the users profile page. The first two must be accessible without an office being selected, the third is an option but makes sense to allow it.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
