### PR TITLE
Chore: Add autorerun to merge of PR CI/CD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,6 +361,7 @@ workflows:
           <<: *generic-slack-fail-post-step
 
   merge_pr:
+    max_auto_reruns: 1
     jobs:
       - lint_checks:
           filters:


### PR DESCRIPTION
## What
Add auto rerun to merge of PR CI/CD

Flickers in the test suite should be retried automatically. Having
redeployment failures retry should be ok to.

As agreed by devs.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
