### PR TITLE
Chore: tidy up abbreviations for CCMS

### DIFF
--- a/app/views/providers/invalid_schedules/show.html.erb
+++ b/app/views/providers/invalid_schedules/show.html.erb
@@ -6,8 +6,8 @@
 
     <%= govuk_list(
           t(".actions_list_html",
-            ccms_login: Rails.configuration.x.laa_landing_page_target_url,
-            online_support: Rails.configuration.x.online_support),
+            ccms_url: Rails.configuration.x.laa_landing_page_target_url,
+            support_url: Rails.configuration.x.online_support),
           type: :bullet,
         ) %>
   <% end %>

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -905,7 +905,7 @@ en:
         audit: You may need to show these if you’re audited by the LAA in the future.
         what_next: What happens next
         application_to_be_checked: We'll check your application to see if your client is entitled to legal aid.
-        decision_in_ccms_html: We'll let you know our decision in <abbr title='Client and Cost Management System'>CCMS</abbr>.
+        decision_in_ccms_html: We'll let you know our decision in CCMS (Client and Cost Management System).
         feedback_prefix: "Give feedback"
         feedback_suffix: " to help us improve this service."
         view_completed_application: View completed application
@@ -1894,8 +1894,7 @@ en:
             - you want to amend a submitted application
         use_ccms_para_html: |
           If any of these apply, or you want to apply for other proceedings, use
-          <a href=%{url}><abbr title='Client and
-          Cost Management System'>CCMS</abbr> (Client and Cost Management System)</a>
+          <a href=%{url}>CCMS (Client and Cost Management System)</a>
           instead.
         progress_saved: Your progress is saved so that you can come back to it later.
     start_chances_of_successes:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -981,8 +981,8 @@ en:
         button_text: Choose a different office
         actions_list_html:
             - go back and choose a different office
-            - apply in <a class="govuk-link govuk-link--inverse" href="%{ccms_login}">CCMS (Client and Cost Management System)</a> for all other proceedings
-            - <a class="govuk-link govuk-link--inverse" href="%{online_support}">contact online support</a> if you think this is wrong, and you should have access
+            - apply in <a class="govuk-link govuk-link--inverse" href="%{ccms_url}">CCMS (Client and Cost Management System)</a> for all other proceedings
+            - <a class="govuk-link govuk-link--inverse" href="%{support_url}">contact online support</a> if you think this is wrong, and you should have access
     legal_aid_applications:
       index:
         heading_1: Your applications


### PR DESCRIPTION
## What
Tidy up abbreviations for CCMS

[came out of design review of interrupt page as part of ticket](https://dsdmoj.atlassian.net/browse/AP-6202)

- abbreviations tags `<abbr>` are not for[ CCMS] when fullname visible in content.
- design patterns state that acronyms should be fully written the first time they are used, then can be used with `<abbr>` tags.

> For example, we spell out acronyms the first time we use them on every page. Then we use an abbreviation tag in the HTML to spell out the acronym for any other instance on the page. This came from user testing we did earlier this year on the citizen-facing GOV.UK content.  We know that users can and will arrive anywhere on GOV.UK - search engines provide “deep links” into the content of websites - so the acronym has to make sense with little or no context.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
