### PR TITLE
Chore: Rename "Sign In" to "Sign in"

### DIFF
--- a/config/locales/en/layouts.yml
+++ b/config/locales/en/layouts.yml
@@ -37,4 +37,4 @@ en:
     logout:
       admin: Admin sign out
       provider: Sign out
-    login: Sign In
+    login: Sign in

--- a/features/citizens/citizens.feature
+++ b/features/citizens/citizens.feature
@@ -28,7 +28,7 @@ Feature: Citizen journey
   Scenario: View privacy policy
     Given An application has been created
     Then I visit the start of the financial assessment
-    Then I should not see 'Sign In'
+    Then I should not see 'Sign in'
     Then I click link "Privacy policy"
     Then I should be on a page showing "Types of personal data we process"
     Then I should be on a page showing "Complaints"

--- a/features/providers/selecting_office.feature
+++ b/features/providers/selecting_office.feature
@@ -44,7 +44,7 @@ Feature: Selecting office
     Given I visit the root page
     And I should see "Providers can use this service to apply for civil legal aid for their clients"
 
-    When I click link "Sign in"
+    When I click govuk-button "Sign in"
     Then I should be on a page with title "Sign in"
 
     When I fill in the mock user email and password
@@ -59,7 +59,7 @@ Feature: Selecting office
     Then I should see "Help us improve the Apply for civil legal aid service"
     And I should see "You have been signed out"
 
-    When I click link "Sign In"
+    When I click link "Sign in"
     Then I should be on a page with title "Sign in"
 
     When I fill in the mock user email and password

--- a/features/providers/sign_in.feature
+++ b/features/providers/sign_in.feature
@@ -5,7 +5,7 @@ Feature: Sign in
     When I visit the root page
     Then I should see "Providers can use this service to apply for civil legal aid for their clients"
 
-    When I click link "Sign in"
+    When I click govuk-button "Sign in"
     Then I should be on a page with title "Sign in"
 
     When I fill 'email' with 'test@test.com'
@@ -32,6 +32,6 @@ Feature: Sign in
     When I visit the root page
     Then I should see "Providers can use this service to apply for civil legal aid for their clients"
 
-    When I click link "Sign in"
+    When I click govuk-button "Sign in"
     Then I should be on a page with title "Select the account number of the office handling this application"
     And I should see "Signed in successfully"

--- a/features/step_definitions/generic_steps.rb
+++ b/features/step_definitions/generic_steps.rb
@@ -20,6 +20,10 @@ Then("I should see a mailto link text {string} for email {string}") do |locator,
   expect(page).to have_link(locator, href: "mailto:#{email}")
 end
 
+When("I click govuk-button {string}") do |text|
+  click_on(class: "govuk-button", text:)
+end
+
 Then("I should see govuk error summary {string}") do |error_text|
   summary = page.find("div.govuk-error-summary > div[role='alert']")
   expect(summary).to have_css(

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ApplicationHelper do
 
         it "returns a login link" do
           expect(user_header_navigation).to have_css("li", count: 1)
-            .and have_css("li", text: "Sign In")
+            .and have_css("li", text: "Sign in")
         end
       end
     end

--- a/spec/system/mock_auth/sign_in_spec.rb
+++ b/spec/system/mock_auth/sign_in_spec.rb
@@ -2,7 +2,7 @@ require "system_helper"
 require Rails.root.join("db/seeds/test_provider_populator")
 
 RSpec.describe "The mock entra path works as expected" do
-  feature "When I click the sign in link, from the landing page, I see the select office list" do
+  feature "When I click the sign in button, from the landing page, I see the select office list" do
     around do |example|
       OmniAuth.config.test_mode = true
       OmniAuth::Strategies::Silas.mock_auth
@@ -14,7 +14,7 @@ RSpec.describe "The mock entra path works as expected" do
 
     scenario "I can see the select office choice list" do
       visit "/"
-      click_link "Sign in"
+      click_on(class: "govuk-button", text: "Sign in")
       expect(page).to have_css("h1", text: "Select the account number of the office handling this application")
     end
   end


### PR DESCRIPTION


## What
Rename "Sign In" to "Sign in"

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

For consistency and adherence to govuk conventions.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
