### PR TITLE
AP-5243: Remove linked applications feature flag

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -22,7 +22,6 @@ module Admin
                                 manually_review_all_cases
                                 allow_welsh_translation
                                 enable_ccms_submission
-                                linked_applications
                                 collect_hmrc_data
                                 collect_dwp_data])
     end

--- a/app/forms/settings/setting_form.rb
+++ b/app/forms/settings/setting_form.rb
@@ -6,7 +6,6 @@ module Settings
                   :manually_review_all_cases,
                   :allow_welsh_translation,
                   :enable_ccms_submission,
-                  :linked_applications,
                   :collect_hmrc_data,
                   :collect_dwp_data
 
@@ -14,7 +13,6 @@ module Settings
               :manually_review_all_cases,
               :allow_welsh_translation,
               :enable_ccms_submission,
-              :linked_applications,
               :collect_hmrc_data,
               :collect_dwp_data,
               presence: true

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -23,10 +23,6 @@ class Setting < ApplicationRecord
     setting.alert_via_sentry
   end
 
-  def self.linked_applications?
-    setting.linked_applications
-  end
-
   def self.collect_hmrc_data?
     setting.collect_hmrc_data
   end

--- a/app/services/flow/steps/addresses/home_address_manuals_step.rb
+++ b/app/services/flow/steps/addresses/home_address_manuals_step.rb
@@ -3,13 +3,7 @@ module Flow
     module Addresses
       HomeAddressManualsStep = Step.new(
         path: ->(application) { Steps.urls.providers_legal_aid_application_home_address_manual_path(application) },
-        forward: lambda do |application|
-          if Setting.linked_applications?
-            :link_application_make_links
-          else
-            application.proceedings.any? ? :has_other_proceedings : :proceedings_types
-          end
-        end,
+        forward: :link_application_make_links,
         check_answers: :check_provider_answers,
       )
     end

--- a/app/services/flow/steps/addresses/home_address_selections_step.rb
+++ b/app/services/flow/steps/addresses/home_address_selections_step.rb
@@ -3,13 +3,7 @@ module Flow
     module Addresses
       HomeAddressSelectionsStep = Step.new(
         path: ->(application) { Steps.urls.providers_legal_aid_application_home_address_selection_path(application) },
-        forward: lambda do |application|
-          if Setting.linked_applications?
-            :link_application_make_links
-          else
-            application.proceedings.any? ? :has_other_proceedings : :proceedings_types
-          end
-        end,
+        forward: :link_application_make_links,
         check_answers: :check_provider_answers,
       )
     end

--- a/app/services/flow/steps/addresses/home_address_statuses_step.rb
+++ b/app/services/flow/steps/addresses/home_address_statuses_step.rb
@@ -5,11 +5,7 @@ module Flow
         path: ->(application) { Steps.urls.providers_legal_aid_application_home_address_status_path(application) },
         forward: lambda do |application|
           if application.applicant.no_fixed_residence?
-            if Setting.linked_applications?
-              :link_application_make_links
-            else
-              application.proceedings.any? ? :has_other_proceedings : :proceedings_types
-            end
+            :link_application_make_links
           else
             :home_address_lookups
           end

--- a/app/services/flow/steps/addresses/non_uk_home_addresses_step.rb
+++ b/app/services/flow/steps/addresses/non_uk_home_addresses_step.rb
@@ -3,13 +3,7 @@ module Flow
     module Addresses
       NonUkHomeAddressesStep = Step.new(
         path: ->(application) { Steps.urls.providers_legal_aid_application_home_address_non_uk_home_address_path(application) },
-        forward: lambda do |application|
-          if Setting.linked_applications?
-            :link_application_make_links
-          else
-            application.proceedings.any? ? :has_other_proceedings : :proceedings_types
-          end
-        end,
+        forward: :link_application_make_links,
         check_answers: :check_provider_answers,
       )
     end

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -47,16 +47,6 @@
         ) %>
 
     <%= form.govuk_collection_radio_buttons(
-          :linked_applications,
-          yes_no_options,
-          :value,
-          :label,
-          inline: true,
-          hint: { text: t(".hints.linked_applications") },
-          legend: { text: t(".labels.linked_applications") },
-        ) %>
-
-    <%= form.govuk_collection_radio_buttons(
           :collect_hmrc_data,
           yes_no_options,
           :value,

--- a/app/views/providers/check_provider_answers/index.html.erb
+++ b/app/views/providers/check_provider_answers/index.html.erb
@@ -53,10 +53,8 @@
                read_only: @read_only) %>
   <% end %>
 
-  <% if Setting.linked_applications? %>
-    <h2 class="govuk-heading-l"><%= t(".section_linking_and_copying.heading") %></h2>
-    <%= render("shared/check_answers/linking_and_copying", read_only: @read_only) %>
-  <% end %>
+  <h2 class="govuk-heading-l"><%= t(".section_linking_and_copying.heading") %></h2>
+  <%= render("shared/check_answers/linking_and_copying", read_only: @read_only) %>
 
   <h2 class="govuk-heading-l"><%= t(".section_proceeding.heading") %></h2>
   <%= render("shared/check_answers/proceedings") %>

--- a/app/views/providers/limitations/show.html.erb
+++ b/app/views/providers/limitations/show.html.erb
@@ -27,7 +27,7 @@
           </strong>
         </p>
 
-        <% if Setting.linked_applications? && !@legal_aid_application.family_linked_associated_application? %>
+        <% if !@legal_aid_application.family_linked_associated_application? %>
           <%= govuk_details(summary_text: t(".emergency_certificate_details_heading")) do %>
             <p><%= sanitize(t(".emergency_certificate_details", limit: "<strong>#{gds_number_to_currency(
                      @legal_aid_application.additional_family_lead_delegated_functions_cost_limitation,

--- a/app/views/providers/start/index.html.erb
+++ b/app/views/providers/start/index.html.erb
@@ -12,7 +12,7 @@
 
     <p class="govuk-body"><%= t(".dont_use_service.list_title") %></p>
 
-    <%= govuk_list Setting.linked_applications? ? t(".dont_use_service.linked_applications_list") : t(".dont_use_service.list"), type: :bullet %>
+    <%= govuk_list t(".dont_use_service.list"), type: :bullet %>
 
     <p class="govuk-body"><%= t(".use_ccms_para_html", url: Rails.configuration.x.laa_landing_page_target_url) %></p>
     <p class="govuk-body"><%= t(".progress_saved") %></p>

--- a/app/views/shared/review_application/_questions_and_answers.html.erb
+++ b/app/views/shared/review_application/_questions_and_answers.html.erb
@@ -41,10 +41,8 @@
         ) %>
   <% end %>
 
-  <% if Setting.linked_applications? %>
-    <h2 class="govuk-heading-l"><%= t(".linking_and_copying_heading") %></h2>
-    <%= render("shared/check_answers/linking_and_copying", read_only: true) %>
-  <% end %>
+  <h2 class="govuk-heading-l"><%= t(".linking_and_copying_heading") %></h2>
+  <%= render("shared/check_answers/linking_and_copying", read_only: true) %>
 
   <section class="proceeding_details print-no-break">
     <h2 class="govuk-heading-l"><%= t(".proceeding_details_section_heading") %></h2>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -79,7 +79,6 @@ en:
           allow_welsh_translation: Allow Welsh translation
           enable_ccms_submission: Allow CCMS submissions
           enable_evidence_upload: Enable the new evidence upload feature
-          linked_applications: Enable linking and copying cases
           collect_hmrc_data: Collect HMRC data
           collect_dwp_data: Collect DWP data
         hints:
@@ -90,7 +89,6 @@ en:
           allow_welsh_translation: Select Yes to translate the service into Welsh
           enable_ccms_submission: Yes by default, only set to No if CCMS is being taken offline
           enable_evidence_upload: Select Yes to enable the new evidence upload feature for solicitors
-          linked_applications: Select Yes to enable the linking and copying cases feature for solicitors
           collect_hmrc_data: Select Yes to enable calls to HMRC for employment data
           collect_dwp_data: Select Yes to enable calls to Benefit Checker for passporting benefits data
 

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -1899,10 +1899,6 @@ en:
           list:
             - the client is self-employed or is a member of the armed forces
             - you want to make an emergency application and delegated functions have not been used
-            - you want to amend a submitted application
-          linked_applications_list:
-            - the client is self-employed or is a member of the armed forces
-            - you want to make an emergency application and delegated functions have not been used
             - you want to make both a family link and legal link to your application
             - you want to amend a submitted application
         use_ccms_para_html: |

--- a/db/migrate/20250827103452_remove_linked_applications_from_settings.rb
+++ b/db/migrate/20250827103452_remove_linked_applications_from_settings.rb
@@ -1,0 +1,7 @@
+class RemoveLinkedApplicationsFromSettings < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured do
+      remove_column :settings, :linked_applications, :boolean, null: false, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_21_145938) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_27_103452) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -1041,7 +1041,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_21_145938) do
     t.boolean "alert_via_sentry", default: true, null: false
     t.datetime "digest_extracted_at", precision: nil, default: "1970-01-01 00:00:01"
     t.datetime "cfe_compare_run_at"
-    t.boolean "linked_applications", default: false, null: false
     t.boolean "collect_hmrc_data", default: false, null: false
     t.boolean "collect_dwp_data", default: true, null: false
   end

--- a/features/providers/applicant_details.feature
+++ b/features/providers/applicant_details.feature
@@ -1,4 +1,9 @@
 Feature: Applicant details
+
+Background: I have started an application and not linked or copied it
+  Given I am logged in as a provider
+  And I have created and submitted an application with the application reference 'L-123-456'
+
   @javascript @vcr @billy @stub_pda_provider_details
   Scenario: Completes the application using address lookup with multiple proceedings
     Given I start the journey as far as the applicant page
@@ -22,6 +27,9 @@ Feature: Applicant details
     Then I click find address
     Then I choose an address 'Transport For London, 98 Petty France, London, SW1H 9EA'
     Then I click 'Use this address'
+    Then I should be on a page showing "Do you want to link this application with another one?"
+    When I choose "No"
+    And I click "Save and continue"
     And I should be on a page showing "What does your client want legal aid for?"
     Then I search for proceeding 'Non-molestation order'
     Then proceeding suggestions has results
@@ -161,6 +169,22 @@ Feature: Applicant details
     Then I click find address
     Then I choose an address 'Transport For London, 98 Petty France, London, SW1H 9EA'
     Then I click 'Use this address'
+    Then I should be on a page showing "Do you want to link this application with another one?"
+
+    When I choose "Yes, I want to make a family link"
+    And I click "Save and continue"
+    Then I should be on a page showing "What is the LAA reference of the application you want to link to?"
+    
+    Then I enter linked_application 'L123456'
+    And I click "Search"
+    Then I should be on a page showing "Search result"
+
+    When I choose "Yes"
+    And I click "Save and continue"
+    Then I should be on a page showing "Linked application"
+
+    When I choose "No, I need to make changes"
+    And I click "Save and continue"
     And I should be on a page showing "What does your client want legal aid for?"
     Then I search for proceeding 'Non-molestation order'
     Then proceeding suggestions has results
@@ -230,6 +254,22 @@ Feature: Applicant details
     And I enter a building number name '100'
     Then I click find address
     Then I click 'Use this address'
+    Then I should be on a page showing "Do you want to link this application with another one?"
+
+    When I choose "Yes, I want to make a family link"
+    And I click "Save and continue"
+    Then I should be on a page showing "What is the LAA reference of the application you want to link to?"
+    
+    Then I enter linked_application 'L123456'
+    And I click "Search"
+    Then I should be on a page showing "Search result"
+
+    When I choose "Yes"
+    And I click "Save and continue"
+    Then I should be on a page showing "Linked application"
+
+    When I choose "No, I need to make changes"
+    And I click "Save and continue"
     And I should be on a page showing "What does your client want legal aid for?"
 
   @javascript @vcr @billy @stub_pda_provider_details
@@ -257,6 +297,22 @@ Feature: Applicant details
     Then I enter city 'Fake City'
     Then I enter postcode 'XX1 1XX'
     Then I click 'Save and continue'
+    Then I should be on a page showing "Do you want to link this application with another one?"
+
+    When I choose "Yes, I want to make a family link"
+    And I click "Save and continue"
+    Then I should be on a page showing "What is the LAA reference of the application you want to link to?"
+    
+    Then I enter linked_application 'L123456'
+    And I click "Search"
+    Then I should be on a page showing "Search result"
+
+    When I choose "Yes"
+    And I click "Save and continue"
+    Then I should be on a page showing "Linked application"
+
+    When I choose "No, I need to make changes"
+    And I click "Save and continue"
     And I should be on a page showing "What does your client want legal aid for?"
     Then I search for proceeding 'Non-molestation order'
     Then proceeding suggestions has results
@@ -342,6 +398,9 @@ Feature: Applicant details
     Then I click find address
     Then I choose an address 'Transport For London, 98 Petty France, London, SW1H 9EA'
     Then I click 'Use this address'
+    Then I should be on a page showing "Do you want to link this application with another one?"
+    When I choose "No"
+    And I click "Save and continue"
     And I should be on a page showing "What does your client want legal aid for?"
     Then I search for proceeding 'Non-molestation order'
     Then proceeding suggestions has results
@@ -404,6 +463,22 @@ Feature: Applicant details
     Then I click find address
     Then I choose an address 'Transport For London, 98 Petty France, London, SW1H 9EA'
     Then I click 'Use this address'
+    Then I should be on a page showing "Do you want to link this application with another one?"
+
+    When I choose "Yes, I want to make a family link"
+    And I click "Save and continue"
+    Then I should be on a page showing "What is the LAA reference of the application you want to link to?"
+    
+    Then I enter linked_application 'L123456'
+    And I click "Search"
+    Then I should be on a page showing "Search result"
+
+    When I choose "Yes"
+    And I click "Save and continue"
+    Then I should be on a page showing "Linked application"
+
+    When I choose "No, I need to make changes"
+    And I click "Save and continue"
     And I should be on a page showing "What does your client want legal aid for?"
     Then I search for proceeding 'Non-molestation order'
     Then proceeding suggestions has results
@@ -475,6 +550,22 @@ Feature: Applicant details
     Then I click find address
     Then I choose an address 'Transport For London, 98 Petty France, London, SW1H 9EA'
     Then I click 'Use this address'
+    Then I should be on a page showing "Do you want to link this application with another one?"
+
+    When I choose "Yes, I want to make a family link"
+    And I click "Save and continue"
+    Then I should be on a page showing "What is the LAA reference of the application you want to link to?"
+    
+    Then I enter linked_application 'L123456'
+    And I click "Search"
+    Then I should be on a page showing "Search result"
+
+    When I choose "Yes"
+    And I click "Save and continue"
+    Then I should be on a page showing "Linked application"
+
+    When I choose "No, I need to make changes"
+    And I click "Save and continue"
     And I should be on a page showing "What does your client want legal aid for?"
     Then I search for proceeding 'Non-molestation order'
     Then proceeding suggestions has results

--- a/features/providers/cost_override.feature
+++ b/features/providers/cost_override.feature
@@ -21,6 +21,10 @@ Feature: Emergency cost override
     And I click find address
     And I choose an address 'Transport For London, 98 Petty France, London, SW1H 9EA'
     When I click 'Use this address'
+    Then I should be on a page showing "Do you want to link this application with another one?"
+
+    When I choose "No"
+    And I click "Save and continue"
     And I should be on a page showing "What does your client want legal aid for?"
     When I search for proceeding 'Non-molestation order'
     Then proceeding suggestions has results

--- a/features/providers/linked_applications/back_button.feature
+++ b/features/providers/linked_applications/back_button.feature
@@ -3,7 +3,6 @@ Feature: Linking cases back button use
   Scenario: Complete flow reversion with back button
     Given I am logged in as a provider
     And I have created and submitted an application with the application reference 'L-123-456'
-    And the feature flag for linked_applications is enabled
 
     When I visit the application service
     And I click link "Start"

--- a/features/providers/linked_applications/check_your_answers_link_and_copy.feature
+++ b/features/providers/linked_applications/check_your_answers_link_and_copy.feature
@@ -4,7 +4,6 @@ Feature: Checking answers for linked and copied cases
 Background: I have started linking and copying a submitted application
   Given I am logged in as a provider
   And I have created and submitted an application with the application reference 'L-123-456'
-  And the feature flag for linked_applications is enabled
 
   When I complete the non-passported journey as far as check your answers
   And I have linked and copied the 'L-123-456' application with a 'Family' link

--- a/features/providers/linked_applications/check_your_answers_link_only.feature
+++ b/features/providers/linked_applications/check_your_answers_link_only.feature
@@ -4,7 +4,6 @@ Feature: Checking answers for linked cases without copying
 Background: I have started linking to a submitted application
   Given I am logged in as a provider
   And I have created and submitted an application with the application reference 'L-123-456'
-  And the feature flag for linked_applications is enabled
 
   When I complete the non-passported journey as far as check your answers
   And I have linked not copied the 'L-123-456' application with a 'Family' link

--- a/features/providers/linked_applications/check_your_answers_not_linked.feature
+++ b/features/providers/linked_applications/check_your_answers_not_linked.feature
@@ -3,7 +3,6 @@ Feature: Starting a case with no linking or copying
 Background: I have started an application and not linked or copied it
   Given I am logged in as a provider
   And I have created and submitted an application with the application reference 'L-123-456'
-  And the feature flag for linked_applications is enabled
 
   When I complete the non-passported journey as far as check your answers for linking
   And I have neither linked or copied an application

--- a/features/providers/no_nino_flow.feature
+++ b/features/providers/no_nino_flow.feature
@@ -27,6 +27,10 @@ Feature: No national insurance number for applicant
     And I click "Find address"
     And I choose an address 'Transport For London, 98 Petty France, London, SW1H 9EA'
     And I click 'Use this address'
+    Then I should be on a page showing "Do you want to link this application with another one?"
+
+    When I choose "No"
+    And I click "Save and continue"
     Then I should be on a page showing "What does your client want legal aid for?"
 
     When I search for proceeding 'Non-molestation order'

--- a/features/providers/non_means_tested_journey/under_18_application_journey.feature
+++ b/features/providers/non_means_tested_journey/under_18_application_journey.feature
@@ -36,6 +36,10 @@ Feature: Under 18 applicant journey
     And I click find address
     And I choose an address 'Transport For London, 98 Petty France, London, SW1H 9EA'
     And I click 'Use this address'
+    Then I should be on a page showing "Do you want to link this application with another one?"
+
+    When I choose "No"
+    And I click "Save and continue"
     Then I should be on a page showing "What does your client want legal aid for?"
 
     When I search for proceeding 'Non-molestation order'

--- a/features/providers/non_means_tested_journey/with_delegated_functions.feature
+++ b/features/providers/non_means_tested_journey/with_delegated_functions.feature
@@ -36,6 +36,10 @@ Feature: Non-means-tested applicant journey with use of delegation functions
     And I click find address
     And I choose an address 'Transport For London, 98 Petty France, London, SW1H 9EA'
     And I click 'Use this address'
+    Then I should be on a page showing "Do you want to link this application with another one?"
+
+    When I choose "No"
+    And I click "Save and continue"
     Then I should be on a page showing "What does your client want legal aid for?"
 
     When I search for proceeding 'Non-molestation order'

--- a/features/providers/non_means_tested_journey/without_delegated_functions.feature
+++ b/features/providers/non_means_tested_journey/without_delegated_functions.feature
@@ -36,6 +36,10 @@ Feature: Non-means-tested applicant journey without use of delegation functions
     And I click find address
     And I choose an address 'Transport For London, 98 Petty France, London, SW1H 9EA'
     And I click 'Use this address'
+    Then I should be on a page showing "Do you want to link this application with another one?"
+
+    When I choose "No"
+    And I click "Save and continue"
     Then I should be on a page showing "What does your client want legal aid for?"
 
     When I search for proceeding 'Non-molestation order'

--- a/features/providers/partner_means_assessment/review_and_print.feature
+++ b/features/providers/partner_means_assessment/review_and_print.feature
@@ -3,7 +3,6 @@ Feature: Review and print your application
 
   Scenario: For a non-passported bank statement upload journey with a partner
     Given I have completed a non-passported employed with partner application with bank statement uploads
-    And the feature flag for linked_applications is enabled
     When I view the review and print your application page
 
     Then the following sections should exist:
@@ -98,7 +97,6 @@ Feature: Review and print your application
 
   Scenario: For a non-passported truelayer bank transactions journey
     Given I have completed a non-passported with partner application with truelayer
-    And the feature flag for linked_applications is enabled
     When I view the review and print your application page
 
     Then the following sections should exist:
@@ -187,7 +185,6 @@ Feature: Review and print your application
 
   Scenario: For a passported journey
     Given I have completed a passported application with a partner with merits
-    And the feature flag for linked_applications is enabled
     When I view the review and print your application page
 
     Then the following sections should exist:

--- a/features/providers/proceeding_loop.feature
+++ b/features/providers/proceeding_loop.feature
@@ -31,6 +31,10 @@ Feature: Loop through proceeding questions
     Then I click find address
     Then I choose an address 'Transport For London, 98 Petty France, London, SW1H 9EA'
     Then I click 'Use this address'
+    Then I should be on a page showing "Do you want to link this application with another one?"
+
+    When I choose "No"
+    And I click "Save and continue"
     And I should be on a page showing "What does your client want legal aid for?"
 
   @stub_pda_provider_details

--- a/features/providers/regressions/back_button_on_proceedings.feature
+++ b/features/providers/regressions/back_button_on_proceedings.feature
@@ -22,7 +22,10 @@ Feature: Using the back button on proceedings should not lock a user out
     And I click find address
     And I choose an address 'Transport For London, 98 Petty France, London, SW1H 9EA'
     When I click 'Use this address'
+    Then I should be on a page showing "Do you want to link this application with another one?"
 
+    When I choose "No"
+    And I click "Save and continue"
     Then I should be on a page showing "What does your client want legal aid for?"
     When I search for proceeding 'Non-molestation order'
     Then proceeding suggestions has results
@@ -32,7 +35,8 @@ Feature: Using the back button on proceedings should not lock a user out
 
     When I click link "Back"
     And I click link "Back"
+    And I click link "Back"
     Then I should be on a page showing "Select your client's home address"
 
     When I click "Use this address"
-    Then I should be on a page showing 'Do you want to add another proceeding?'
+    Then I should be on a page showing 'Do you want to link this application with another one?'

--- a/features/providers/regressions/scope_limitations.feature
+++ b/features/providers/regressions/scope_limitations.feature
@@ -22,7 +22,10 @@ Feature: Scope limitations not being set
     And I click find address
     And I choose an address 'Transport For London, 98 Petty France, London, SW1H 9EA'
     When I click 'Use this address'
+    Then I should be on a page showing "Do you want to link this application with another one?"
 
+    When I choose "No"
+    And I click "Save and continue"
     Then I should be on a page showing "What does your client want legal aid for?"
     When I search for proceeding 'SE014'
     And proceeding suggestions has results

--- a/features/providers/review_and_print.feature
+++ b/features/providers/review_and_print.feature
@@ -3,7 +3,6 @@ Feature: Review and print your application
 
   Scenario: For a non-passported bank statement upload journey
     Given I have completed a bank statement upload application with merits
-    And the feature flag for linked_applications is enabled
     When I view the review and print your application page
 
     Then the following sections should exist:
@@ -83,7 +82,6 @@ Feature: Review and print your application
 
   Scenario: For a non-passported truelayer bank transactions journey
     Given I have completed truelayer application with merits
-    And the feature flag for linked_applications is enabled
     When I view the review and print your application page
 
     Then the following sections should exist:
@@ -176,7 +174,6 @@ Feature: Review and print your application
 
   Scenario: For a passported journey
     Given I have completed a passported application with merits
-    And the feature flag for linked_applications is enabled
     When I view the review and print your application page
 
     Then the following sections should exist:

--- a/features/providers/search_proceedings.feature
+++ b/features/providers/search_proceedings.feature
@@ -30,6 +30,10 @@ Feature: Search proceedings
     Then I click find address
     Then I choose an address 'Transport For London, 98 Petty France, London, SW1H 9EA'
     Then I click 'Use this address'
+    Then I should be on a page showing "Do you want to link this application with another one?"
+
+    When I choose "No"
+    And I click "Save and continue"
     And I should be on a page showing "What does your client want legal aid for?"
     When I search for proceeding type "cakes"
     Then the proceeding type result list on page returns a "No results found." message
@@ -64,6 +68,10 @@ Feature: Search proceedings
     Then I click find address
     Then I choose an address 'Transport For London, 98 Petty France, London, SW1H 9EA'
     Then I click 'Use this address'
+    Then I should be on a page showing "Do you want to link this application with another one?"
+
+    When I choose "No"
+    And I click "Save and continue"
     And I should be on a page showing "What does your client want legal aid for?"
     And I search for proceeding 'dom'
     Then proceeding suggestions has results

--- a/features/providers/special_children_act/secure_accomodation_order_cit.feature
+++ b/features/providers/special_children_act/secure_accomodation_order_cit.feature
@@ -23,7 +23,10 @@ Feature: Adding an SCA Secure Accommodation Order proceeding sets all client_inv
     And I click find address
     And I choose an address 'Transport For London, 98 Petty France, London, SW1H 9EA'
     When I click 'Use this address'
+    Then I should be on a page showing "Do you want to link this application with another one?"
 
+    When I choose "No"
+    And I click "Save and continue"
     Then I should be on a page showing "What does your client want legal aid for?"
     When I search for proceeding 'Child assessment order SCA'
     Then proceeding suggestions has results

--- a/features/providers/start_page.feature
+++ b/features/providers/start_page.feature
@@ -5,7 +5,6 @@ Feature: Start page
   Scenario: I am able to start the service with all flags enabled
     Given I am logged in as a provider
     And the feature flag for collect_hmrc_data is enabled
-    And the feature flag for linked_applications is enabled
 
     When I visit the application service
     Then I should be on a page with title "Apply for civil legal aid - GOV.UK"

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Setting do
         expect(rec.enable_ccms_submission?).to be true
         expect(rec.bank_transaction_filename).to eq "db/sample_data/bank_transactions.csv"
         expect(rec.alert_via_sentry?).to be true
-        expect(rec.linked_applications?).to be false
         expect(rec.collect_hmrc_data?).to be false
         expect(rec.collect_dwp_data?).to be true
       end
@@ -28,7 +27,6 @@ RSpec.describe Setting do
           enable_ccms_submission: false,
           bank_transaction_filename: "my_special_file.csv",
           alert_via_sentry: false,
-          linked_applications: true,
           collect_hmrc_data: true,
           collect_dwp_data: true,
         )
@@ -42,7 +40,6 @@ RSpec.describe Setting do
         expect(rec.enable_ccms_submission?).to be false
         expect(rec.bank_transaction_filename).to eq "my_special_file.csv"
         expect(rec.alert_via_sentry?).to be false
-        expect(rec.linked_applications?).to be true
         expect(rec.collect_hmrc_data?).to be true
         expect(rec.collect_dwp_data?).to be true
       end
@@ -59,7 +56,6 @@ RSpec.describe Setting do
       expect(described_class.enable_ccms_submission?).to be true
       expect(described_class.bank_transaction_filename).to eq "db/sample_data/bank_transactions.csv"
       expect(described_class.alert_via_sentry?).to be true
-      expect(described_class.linked_applications?).to be false
       expect(described_class.collect_hmrc_data?).to be false
       expect(described_class.collect_dwp_data?).to be true
     end

--- a/spec/requests/admin/settings_controller_spec.rb
+++ b/spec/requests/admin/settings_controller_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe Admin::SettingsController do
           mock_true_layer_data: "true",
           allow_welsh_translation: "true",
           enable_ccms_submission: "true",
-          linked_applications: "true",
           collect_hmrc_data: "true",
           home_address: "true",
           collect_dwp_data: "true",
@@ -57,7 +56,6 @@ RSpec.describe Admin::SettingsController do
       patch_request
       expect(setting.mock_true_layer_data?).to be(true)
       expect(setting.allow_welsh_translation?).to be(true)
-      expect(setting.linked_applications?).to be(true)
       expect(setting.collect_hmrc_data?).to be(true)
       expect(setting.collect_dwp_data?).to be(true)
     end

--- a/spec/requests/providers/start_spec.rb
+++ b/spec/requests/providers/start_spec.rb
@@ -3,26 +3,11 @@ require "rails_helper"
 RSpec.describe "provider start of journey test" do
   describe "GET /providers" do
     before do
-      allow(Setting).to receive_messages(linked_applications?: linked_applications)
       get providers_root_path
     end
 
-    let(:linked_applications) { false }
-
     it "returns http success" do
       expect(response).to have_http_status(:ok)
-    end
-
-    it "does not show the linked_applications list item" do
-      expect(page).to have_no_content("you want to make both a family link and legal link to your application")
-    end
-
-    context "when the linked_applications feature flag is on" do
-      let(:linked_applications) { true }
-
-      it "shows the linked_applications list item" do
-        expect(page).to have_css("li", text: "you want to make both a family link and legal link to your application")
-      end
     end
   end
 end

--- a/spec/services/flow/steps/addresses/home_address_manuals_step_spec.rb
+++ b/spec/services/flow/steps/addresses/home_address_manuals_step_spec.rb
@@ -10,27 +10,9 @@ RSpec.describe Flow::Steps::Addresses::HomeAddressManualsStep, type: :request do
   end
 
   describe "#forward" do
-    subject { described_class.forward.call(legal_aid_application) }
+    subject { described_class.forward }
 
-    context "when the linked_applications feature flag is enabled" do
-      before do
-        allow(Setting).to receive(:linked_applications?).and_return(true)
-      end
-
-      it { is_expected.to eq :link_application_make_links }
-    end
-
-    context "when linked_applications feature flag is disabled" do
-      context "and there are no proceedings on the application" do
-        it { is_expected.to eq :proceedings_types }
-      end
-
-      context "and there are proceedings on the application" do
-        let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings) }
-
-        it { is_expected.to eq :has_other_proceedings }
-      end
-    end
+    it { is_expected.to eq :link_application_make_links }
   end
 
   describe "#check_answers" do

--- a/spec/services/flow/steps/addresses/home_address_selections_step_spec.rb
+++ b/spec/services/flow/steps/addresses/home_address_selections_step_spec.rb
@@ -10,27 +10,9 @@ RSpec.describe Flow::Steps::Addresses::HomeAddressSelectionsStep, type: :request
   end
 
   describe "#forward" do
-    subject { described_class.forward.call(legal_aid_application) }
+    subject { described_class.forward }
 
-    context "when the linked_application feature flag is enabled" do
-      before do
-        allow(Setting).to receive(:linked_applications?).and_return(true)
-      end
-
-      it { is_expected.to eq :link_application_make_links }
-    end
-
-    context "when the linked_application feature flag is disabled" do
-      context "and there are no proceedings on the application" do
-        it { is_expected.to eq :proceedings_types }
-      end
-
-      context "and there are proceedings on the application" do
-        let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings) }
-
-        it { is_expected.to eq :has_other_proceedings }
-      end
-    end
+    it { is_expected.to eq :link_application_make_links }
   end
 
   describe "#check_answers" do

--- a/spec/services/flow/steps/addresses/home_address_statuses_step_spec.rb
+++ b/spec/services/flow/steps/addresses/home_address_statuses_step_spec.rb
@@ -17,25 +17,7 @@ RSpec.describe Flow::Steps::Addresses::HomeAddressStatusesStep, type: :request d
     context "when the applicant has no fixed residence" do
       let(:no_fixed_residence) { true }
 
-      context "and the linked_applications feature flag is enabled" do
-        before do
-          allow(Setting).to receive(:linked_applications?).and_return(true)
-        end
-
-        it { is_expected.to eq :link_application_make_links }
-      end
-
-      context "and the linked_applications feature flag is disabled" do
-        context "and there are no proceedings on the application" do
-          it { is_expected.to eq :proceedings_types }
-        end
-
-        context "and there are proceedings on the application" do
-          let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings, applicant:) }
-
-          it { is_expected.to eq :has_other_proceedings }
-        end
-      end
+      it { is_expected.to eq :link_application_make_links }
     end
 
     context "when the applicant has a fixed address" do

--- a/spec/services/flow/steps/addresses/non_uk_home_addresses_step_spec.rb
+++ b/spec/services/flow/steps/addresses/non_uk_home_addresses_step_spec.rb
@@ -10,27 +10,9 @@ RSpec.describe Flow::Steps::Addresses::NonUkHomeAddressesStep, type: :request do
   end
 
   describe "#forward" do
-    subject { described_class.forward.call(legal_aid_application) }
+    subject { described_class.forward }
 
-    context "when the linked_applications feature flag is enabled" do
-      before do
-        allow(Setting).to receive(:linked_applications?).and_return(true)
-      end
-
-      it { is_expected.to eq :link_application_make_links }
-    end
-
-    context "when linked_applications feature flag is disabled" do
-      context "and there are no proceedings on the application" do
-        it { is_expected.to eq :proceedings_types }
-      end
-
-      context "and there are proceedings on the application" do
-        let(:legal_aid_application) { create(:legal_aid_application, :with_proceedings) }
-
-        it { is_expected.to eq :has_other_proceedings }
-      end
-    end
+    it { is_expected.to eq :link_application_make_links }
   end
 
   describe "#check_answers" do

--- a/spec/system/application_task_list/client_and_case_details_section/check_provider_answers_spec.rb
+++ b/spec/system/application_task_list/client_and_case_details_section/check_provider_answers_spec.rb
@@ -3,8 +3,6 @@ RSpec.describe "Client and case details section - Check your answers", :vcr do
   feature "View check your answers" do
     before do
       login_as_a_provider
-
-      Setting.setting.update!(linked_applications: true)
     end
 
     scenario "I can complete the task list's Check your answers item" do

--- a/spec/system/application_task_list/client_and_case_details_section/client_details_spec.rb
+++ b/spec/system/application_task_list/client_and_case_details_section/client_details_spec.rb
@@ -3,8 +3,6 @@ RSpec.describe "Client and case details section - Client details", :vcr do
   feature "View and amend client details" do
     before do
       login_as_a_provider
-
-      Setting.setting.update!(linked_applications: true)
     end
 
     # TODO: we navigate to the task list directly at time of writing but eventually we should be


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5243)

Remove linked applications feature flag, update tests to reflect changes and remove now obsolete conditionals 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
