### PR TITLE
AP-6214: Amend postgresql chart to use bitnami legacy image repository

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -20,6 +20,8 @@ deploy_branch() {
                 --install --wait \
                 --namespace=${K8S_NAMESPACE} \
                 --values ./helm_deploy/apply-for-legal-aid/values-uat.yaml \
+                --set postgresql.image.repository=bitnamilegacy/postgresql \
+                --set postgresql.global.security.allowInsecureImages=true \
                 --set deploy.host="$RELEASE_HOST" \
                 --set image.repository="${ECR_REGISTRY}/${ECR_REPOSITORY}" \
                 --set image.tag="${CIRCLE_SHA1}" \


### PR DESCRIPTION



## What
Amend postgresql chart to use bitnami legacy image repository

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6214)

Following the deprecation of support for such images by bitnami.

see [bitnami chart issue](https://github.com/bitnami/charts/issues/35164)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
