### PR TITLE
Add open-ended schedule end date (Y21K bug ;))

### DIFF
--- a/spec/services/pda/provider_details_request_stubs.rb
+++ b/spec/services/pda/provider_details_request_stubs.rb
@@ -151,7 +151,7 @@ def office_schedules_json
         contractStatus: "Open",
         contractAuthorizationStatus: "APPROVED",
         contractStartDate: "2024-09-01",
-        contractEndDate: "2026-06-30",
+        contractEndDate: "2099-12-31",
         areaOfLaw: "LEGAL HELP",
         scheduleType: "Standard",
         scheduleNumber: "0X395U/2024/01",
@@ -160,7 +160,7 @@ def office_schedules_json
         scheduleAuthorizationStatus: "APPROVED",
         scheduleStatus: "Open",
         scheduleStartDate: "2024-09-01",
-        scheduleEndDate: "2025-08-31",
+        scheduleEndDate: "2099-12-31",
         scheduleLines: [
           {
             areaOfLaw: "LEGAL HELP",
@@ -587,7 +587,7 @@ def office_schedules_json
         contractStatus: "Open",
         contractAuthorizationStatus: "APPROVED",
         contractStartDate: "2022-10-01",
-        contractEndDate: "2025-09-30",
+        contractEndDate: "2099-12-31",
         areaOfLaw: "CRIME LOWER",
         scheduleType: "Standard",
         scheduleNumber: "CRM/0X395U/23",
@@ -596,7 +596,7 @@ def office_schedules_json
         scheduleAuthorizationStatus: "APPROVED",
         scheduleStatus: "Open",
         scheduleStartDate: "2023-10-01",
-        scheduleEndDate: "2025-09-30",
+        scheduleEndDate: "2099-12-31",
         scheduleLines: [
           {
             areaOfLaw: "CRIME LOWER",


### PR DESCRIPTION


## What
Add open-ended schedule end date

Schedules expire each year and new renewal. This
prevents office selection of offices with expired
schedules. For testing and UAT purposes we avoid
this by setting a distant schedule expiry date
despite the fact that this is unrealistic.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
