### PR TITLE
Chore: separate components into own dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,11 +13,17 @@ updates:
       rubocop:
         patterns:
           - "rubocop*"
+      components:
+        patterns:
+          - "govuk-components"
+          - "view_component"
       bundler:
         patterns:
           - "*"
         exclude-patterns:
           - "rubocop*"
+          - "govuk-components"
+          - "view_component"
     open-pull-requests-limit: 10
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
## What

There's an issue with updating view components and govuk components so these have been separated into their own dependabot group

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
