### PR TITLE
Ap 5620 Add 'When contact was made' question to merits 

### DIFF
--- a/app/controllers/providers/application_merits_task/when_contact_was_made_controller.rb
+++ b/app/controllers/providers/application_merits_task/when_contact_was_made_controller.rb
@@ -1,0 +1,27 @@
+module Providers
+  module ApplicationMeritsTask
+    class WhenContactWasMadeController < ProviderBaseController
+      def show
+        @form = Incidents::WhenContactWasMadeForm.new(model: incident)
+      end
+
+      def update
+        @form = Incidents::WhenContactWasMadeForm.new(form_params)
+        render :show unless update_task_save_continue_or_draft(:application, :when_contact_was_made)
+      end
+
+    private
+
+      def incident
+        legal_aid_application.latest_incident || legal_aid_application.build_latest_incident
+      end
+
+      def form_params
+        merged_params = merge_with_model(incident) do
+          params.expect(application_merits_task_incident: %i[first_contact_date])
+        end
+        convert_date_params(merged_params)
+      end
+    end
+  end
+end

--- a/app/forms/incidents/when_contact_was_made_form.rb
+++ b/app/forms/incidents/when_contact_was_made_form.rb
@@ -1,0 +1,54 @@
+module Incidents
+  class WhenContactWasMadeForm < BaseForm
+    form_for ApplicationMeritsTask::Incident
+
+    attr_accessor :first_contact_date_1i, :first_contact_date_2i, :first_contact_date_3i
+    attr_writer :first_contact_date
+
+    validates :first_contact_date, presence: true, unless: :draft_and_not_partially_complete_first_contact_date?
+    validates :first_contact_date, date: { not_in_the_future: true }, allow_nil: true
+
+    def initialize(*args)
+      super
+      set_instance_variables_for_attributes_if_not_set_but_in_model(
+        attrs: first_contact_date_fields.fields,
+        model_attributes:
+        [
+          first_contact_date_fields.model_attributes,
+        ].compact.reduce(&:merge),
+      )
+    end
+
+    def first_contact_date
+      return @first_contact_date if @first_contact_date.present?
+      return if first_contact_date_fields.blank?
+      return first_contact_date_fields.input_field_values if first_contact_date_incomplete?
+
+      @first_contact_date = attributes[:first_contact_date] = first_contact_date_fields.form_date
+    end
+
+  private
+
+    def first_contact_date_incomplete?
+      first_contact_date_fields.partially_complete? || first_contact_date_fields.form_date_invalid?
+    end
+
+    def exclude_from_model
+      first_contact_date_fields.fields
+    end
+
+    def draft_and_not_partially_complete_first_contact_date?
+      draft? && !first_contact_date_fields.partially_complete?
+    end
+
+    def first_contact_date_fields
+      @first_contact_date_fields ||= DateFieldBuilder.new(
+        form: self,
+        model:,
+        method: :first_contact_date,
+        prefix: :first_contact_date_,
+        suffix: :gov_uk,
+      )
+    end
+  end
+end

--- a/app/services/flow/flows/provider_merits.rb
+++ b/app/services/flow/flows/provider_merits.rb
@@ -7,6 +7,7 @@ module Flow
         has_other_involved_children: Steps::ProviderMerits::HasOtherInvolvedChildrenStep,
         remove_involved_child: Steps::ProviderMerits::RemoveInvolvedChildStep,
         date_client_told_incidents: Steps::ProviderMerits::DateClientToldIncidentsStep,
+        when_contact_was_made: Steps::ProviderMerits::WhenContactWasMadeStep,
         opponent_individuals: Steps::ProviderMerits::OpponentIndividualsStep,
         opponent_existing_organisations: Steps::ProviderMerits::OpponentExistingOrganisationsStep,
         opponent_new_organisations: Steps::ProviderMerits::OpponentNewOrganisationStep,

--- a/app/services/flow/merits_loop.rb
+++ b/app/services/flow/merits_loop.rb
@@ -28,6 +28,7 @@ module Flow
     def convert_task_to_flow_name(task)
       {
         latest_incident_details: :date_client_told_incidents,
+        when_contact_was_made: :when_contact_was_made,
         opponent_name: :start_opponent_task,
         opponent_mental_capacity: :opponents_mental_capacities,
         domestic_abuse_summary: :domestic_abuse_summaries,

--- a/app/services/flow/steps/provider_merits/when_contact_was_made_step.rb
+++ b/app/services/flow/steps/provider_merits/when_contact_was_made_step.rb
@@ -1,0 +1,11 @@
+module Flow
+  module Steps
+    module ProviderMerits
+      WhenContactWasMadeStep = Step.new(
+        path: ->(application) { Steps.urls.providers_legal_aid_application_when_contact_was_made_path(application) },
+        forward: ->(application) { Flow::MeritsLoop.forward_flow(application, :application) },
+        check_answers: :check_merits_answers,
+      )
+    end
+  end
+end

--- a/app/views/providers/application_merits_task/when_contact_was_made/show.html.erb
+++ b/app/views/providers/application_merits_task/when_contact_was_made/show.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(
+      model: @form,
+      url: providers_legal_aid_application_when_contact_was_made_path,
+      method: :patch,
+      local: true,
+    ) do |form| %>
+    <%= page_template(page_title: t(".h1-heading"),
+                      template: :basic,
+                      back_link: {},
+                      form:) do %>
+
+    <%= form.govuk_fieldset legend: { size: "xl", tag: "h1", text: page_title } do %>
+      <%= form.govuk_date_field :first_contact_date,
+                                legend: { text: t("shared.forms.date_input_fields.first_contact_date_label"), hidden: true },
+                                hint: { text: t("shared.forms.date_input_fields.date_hint", options: number_of_days_ago(0)) } %>
+    <% end %>
+
+    <div class="govuk-!-padding-bottom-4"></div>
+
+    <%= next_action_buttons(show_draft: true, form:) %>
+  <% end %>
+<% end %>

--- a/app/views/shared/check_answers/_merits.html.erb
+++ b/app/views/shared/check_answers/_merits.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-l"><%= t(".case-details-heading") %></h2>
 
-<%= render("shared/check_answers/merits/latest_incident_details", read_only:, incident:) if @legal_aid_application.latest_incident %>
+<%= render("shared/check_answers/merits/latest_incident_details", read_only:, incident:) %>
 
 <%= render("shared/check_answers/merits/opponents", opponents:, read_only:) %>
 

--- a/app/views/shared/check_answers/merits/_latest_incident_details.html.erb
+++ b/app/views/shared/check_answers/merits/_latest_incident_details.html.erb
@@ -1,14 +1,14 @@
-<% da_proceedings = incident&.told_on.present? && incident&.occurred_on.present?
-   title = da_proceedings ? t(".latest-incident-heading") : t(".when-contact-was-made-heading") %>
+<% latest_incident_details = incident&.told_on.present? && incident&.occurred_on.present?
+   title = latest_incident_details ? t(".latest-incident-heading") : t(".when-contact-was-made-heading") %>
 <%= govuk_summary_card(title: title, html_attributes: { id: "app-check-your-answers__latest_incident_details" }, heading_level: 3) do |card|
-      url = da_proceedings ? providers_legal_aid_application_date_client_told_incident_path(@legal_aid_application) : providers_legal_aid_application_when_contact_was_made_path(@legal_aid_application)
+      url = latest_incident_details ? providers_legal_aid_application_date_client_told_incident_path(@legal_aid_application) : providers_legal_aid_application_when_contact_was_made_path(@legal_aid_application)
       unless read_only
         card.with_action do
           govuk_link_to(t("generic.change"), url, visually_hidden_text: t(".latest-incident-heading"))
         end
       end
       card.with_summary_list(actions: false) do |summary_list|
-        if da_proceedings
+        if latest_incident_details
           summary_list.with_row(html_attributes: { id: "app-check-your-answers__notification_of_latest_incident" }) do |row|
             row.with_key(text: t(".notification_of_latest_incident"), classes: "govuk-!-width-one-third")
             row.with_value(text: incident&.told_on)

--- a/app/views/shared/check_answers/merits/_latest_incident_details.html.erb
+++ b/app/views/shared/check_answers/merits/_latest_incident_details.html.erb
@@ -1,18 +1,27 @@
-<%= govuk_summary_card(title: t(".latest-incident-heading"), html_attributes: { id: "app-check-your-answers__latest_incident_details" }, heading_level: 3) do |card|
+<% da_proceedings = incident&.told_on.present? && incident&.occurred_on.present?
+   title = da_proceedings ? t(".latest-incident-heading") : t(".when-contact-was-made-heading") %>
+<%= govuk_summary_card(title: title, html_attributes: { id: "app-check-your-answers__latest_incident_details" }, heading_level: 3) do |card|
+      url = da_proceedings ? providers_legal_aid_application_date_client_told_incident_path(@legal_aid_application) : providers_legal_aid_application_when_contact_was_made_path(@legal_aid_application)
       unless read_only
         card.with_action do
-          govuk_link_to(t("generic.change"),
-                        providers_legal_aid_application_date_client_told_incident_path(@legal_aid_application), visually_hidden_text: t(".latest-incident-heading"))
+          govuk_link_to(t("generic.change"), url, visually_hidden_text: t(".latest-incident-heading"))
         end
       end
       card.with_summary_list(actions: false) do |summary_list|
-        summary_list.with_row(html_attributes: { id: "app-check-your-answers__notification_of_latest_incident" }) do |row|
-          row.with_key(text: t(".notification_of_latest_incident"), classes: "govuk-!-width-one-third")
-          row.with_value(text: incident&.told_on)
-        end
-        summary_list.with_row(html_attributes: { id: "app-check-your-answers__date_of_latest_incident" }) do |row|
-          row.with_key(text: t(".date_of_latest_incident"))
-          row.with_value(text: incident&.occurred_on)
+        if da_proceedings
+          summary_list.with_row(html_attributes: { id: "app-check-your-answers__notification_of_latest_incident" }) do |row|
+            row.with_key(text: t(".notification_of_latest_incident"), classes: "govuk-!-width-one-third")
+            row.with_value(text: incident&.told_on)
+          end
+          summary_list.with_row(html_attributes: { id: "app-check-your-answers__date_of_latest_incident" }) do |row|
+            row.with_key(text: t(".date_of_latest_incident"))
+            row.with_value(text: incident&.occurred_on)
+          end
+        else
+          summary_list.with_row(html_attributes: { id: "app-check-your-answers__when_contact_was_made" }) do |row|
+            row.with_key(text: t(".first-contact-date"))
+            row.with_value(text: incident&.first_contact_date)
+          end
         end
       end
     end %>

--- a/config/locales/en/activemodel.yml
+++ b/config/locales/en/activemodel.yml
@@ -208,6 +208,10 @@ en:
               date_is_in_the_future: Date the incident occurred must be in the past
               blank: Enter the date the incident occurred
               invalid_timeline: Date the incident occurred must be before the date your client told you about it
+            first_contact_date:
+              date_not_valid: Enter a valid date for when your client first contacted you about this matter
+              date_is_in_the_future: Date your client first contacted you must be in the past
+              blank: Enter the date your client first contacted you about this matter
             details:
               blank: Enter details of the incident
         application_merits_task/involved_child:

--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -583,6 +583,9 @@ en:
             Select yes if your client is a child subject of the proceeding
       remove_opponent:
         show: *remove_show
+      when_contact_was_made:
+        show:
+          h1-heading: When did your client first contact you about this matter?
       date_client_told_incidents:
         show:
           h1-heading: Latest incident details
@@ -1469,6 +1472,7 @@ en:
         no_more_information_needed: No more information is needed
         # Application level tasks
         latest_incident_details: Latest incident details
+        when_contact_was_made: When contact was made
         opponent_name: Opponents
         opponent_mental_capacity: Mental capacity of all parties
         domestic_abuse_summary: Domestic abuse summary
@@ -1500,6 +1504,7 @@ en:
           complete: Completed
         urls:
           latest_incident_details: date_client_told_incident
+          when_contact_was_made: when_contact_was_made
           opponent_name: opponent_individual
           opponent_type: opponent_type
           has_other_opponent: has_other_opponent

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -462,6 +462,8 @@ en:
           latest-incident-heading: Latest incident details
           date_of_latest_incident: Date of incident
           notification_of_latest_incident: Date your client contacted you about the latest incident
+          when-contact-was-made-heading: When contact was made
+          first-contact-date: Date your client contacted you
         matter_opposition:
           matter_opposed_reason: Reasons why the matter is opposed
           matter_opposed_reason_heading: Why the matter is opposed
@@ -682,6 +684,7 @@ en:
         date_of_birth_label: Date of birth
         occurred_on_label: When did the incident occur?
         told_on_label: When did your client contact you about the latest domestic abuse incident?
+        first_contact_date_label: When did your client first contact you about this matter?
         date_hint: "For example %{options}."
         used_delegated_functions_on_label: Date you used delegated functions
         used_delegated_functions_on_hint: "For example, %{options}."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -283,6 +283,7 @@ Rails.application.routes.draw do
       resource :in_scope_of_laspo, only: %i[show update], controller: "application_merits_task/in_scope_of_laspos"
       resource :nature_of_urgencies, only: %i[show update], controller: "application_merits_task/nature_of_urgencies"
       resource :merits_task_list, only: %i[show update]
+      resource :when_contact_was_made, only: %i[show update], controller: "application_merits_task/when_contact_was_made"
 
       resource :uploaded_evidence_collection, only: %i[show update destroy] do
         get "/list", to: "uploaded_evidence_collections#list"

--- a/db/migrate/20250929104707_add_first_contact_date_to_incidents.rb
+++ b/db/migrate/20250929104707_add_first_contact_date_to_incidents.rb
@@ -1,0 +1,5 @@
+class AddFirstContactDateToIncidents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :incidents, :first_contact_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_25_101154) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_29_104707) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -592,6 +592,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_25_101154) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.date "told_on"
+    t.date "first_contact_date"
     t.index ["legal_aid_application_id"], name: "index_incidents_on_legal_aid_application_id"
   end
 

--- a/features/providers/public_law_family/merits_appeal_question_flow.feature
+++ b/features/providers/public_law_family/merits_appeal_question_flow.feature
@@ -7,6 +7,7 @@ Feature: Public law family merits appeal question flow
 
     Then I should see "About the application"
     And I should see 'Opponents Not started'
+    And I should see 'When contact was made Not started'
     And I should see 'Statement of case Not started'
     And I should see 'Children involved in this application Not started'
     And I should see 'The second appeal Not started'
@@ -32,6 +33,17 @@ Feature: Public law family merits appeal question flow
 
     When I choose "No"
     And I click 'Save and continue'
+
+    ############################
+    # when contact was made
+    ############################
+
+    Then I should be on a page with title "When did your client first contact you about this matter?"
+    Then I fill "application_merits_task_incident_first_contact_date_3i" with "5"
+    Then I fill "application_merits_task_incident_first_contact_date_2i" with "5"
+    Then I fill "application_merits_task_incident_first_contact_date_1i" with "25"
+
+    When I click 'Save and continue'
 
     ############################
     # statement of case

--- a/features/providers/public_law_family/merits_child_care_assessment_question_flow.feature
+++ b/features/providers/public_law_family/merits_child_care_assessment_question_flow.feature
@@ -8,6 +8,7 @@ Feature: Public law family merits appeal question flow
 
     Then I should see "About the application"
     And I should see 'Opponents Not started'
+    And I should see 'When contact was made Not started'
     And I should see 'Statement of case Not started'
     And I should see 'Children involved in this application Not started'
 
@@ -33,6 +34,17 @@ Feature: Public law family merits appeal question flow
 
     When I choose "No"
     And I click 'Save and continue'
+
+    ############################
+    # when contact was made
+    ############################
+
+    Then I should be on a page with title "When did your client first contact you about this matter?"
+    Then I fill "application_merits_task_incident_first_contact_date_3i" with "5"
+    Then I fill "application_merits_task_incident_first_contact_date_2i" with "5"
+    Then I fill "application_merits_task_incident_first_contact_date_1i" with "25"
+
+    When I click 'Save and continue'
 
     ############################
     # statement of case

--- a/spec/factories/incidents.rb
+++ b/spec/factories/incidents.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :incident, class: "ApplicationMeritsTask::Incident" do
     told_on { Faker::Date.backward(days: 90) }
     occurred_on { Faker::Date.backward(days: 90) - 1.year }
+    first_contact_date { Faker::Date.backward(days: 90) }
     details { Faker::Lorem.paragraph }
     legal_aid_application
   end

--- a/spec/factories/legal_framework_serialized_merits_task_list.rb
+++ b/spec/factories/legal_framework_serialized_merits_task_list.rb
@@ -505,6 +505,7 @@ FactoryBot.define do
           request_id: SecureRandom.uuid,
           application: {
             tasks: {
+              when_contact_was_made: [],
               opponent_name: [],
               statement_of_case: [],
               children_application: [],
@@ -530,6 +531,7 @@ FactoryBot.define do
           request_id: SecureRandom.uuid,
           application: {
             tasks: {
+              when_contact_was_made: [],
               opponent_name: [],
               statement_of_case: [],
               children_application: [],
@@ -555,6 +557,7 @@ FactoryBot.define do
           request_id: SecureRandom.uuid,
           application: {
             tasks: {
+              when_contact_was_made: [],
               opponent_name: [],
               statement_of_case: [],
               children_application: [],
@@ -580,6 +583,7 @@ FactoryBot.define do
           request_id: SecureRandom.uuid,
           application: {
             tasks: {
+              when_contact_was_made: [],
               opponent_name: [],
               statement_of_case: [],
               children_application: [],

--- a/spec/forms/incidents/when_contact_was_made_form_spec.rb
+++ b/spec/forms/incidents/when_contact_was_made_form_spec.rb
@@ -1,0 +1,103 @@
+require "rails_helper"
+
+RSpec.describe Incidents::WhenContactWasMadeForm, type: :form do
+  subject(:described_form) { described_class.new(params.merge(model: incident)) }
+
+  let(:incident) { create(:incident) }
+  let(:first_contact_date) { 5.days.ago.to_date }
+  let(:i18n_scope) { "activemodel.errors.models.application_merits_task/incident.attributes" }
+  let(:error_locale) { :defined_in_spec }
+  let(:message) { I18n.t(error_locale, scope: i18n_scope) }
+
+  let(:params) { { first_contact_date: } }
+
+  describe "#save" do
+    before do
+      described_form.save!
+      incident.reload
+    end
+
+    it "updates the incident" do
+      expect(incident.first_contact_date).to eq(first_contact_date)
+    end
+
+    context "when occurred on is invalid" do
+      let(:params) do
+        {
+          first_contact_date_1i: first_contact_date.year.to_s,
+          first_contact_date_2i: "55",
+          first_contact_date_3i: first_contact_date.day.to_s,
+        }
+      end
+      let(:error_locale) { "first_contact_date.date_not_valid" }
+
+      it "is invalid" do
+        expect(described_form).not_to be_valid
+      end
+
+      it "generates an error" do
+        expect(described_form.errors[:first_contact_date].join).to match(message)
+      end
+    end
+
+    context "when first contact date is in the future" do
+      let(:first_contact_date) { 1.day.from_now.to_date }
+      let(:error_locale) { "first_contact_date.date_is_in_the_future" }
+
+      it "is invalid" do
+        expect(described_form).not_to be_valid
+      end
+
+      it "generates an error" do
+        expect(described_form.errors[:first_contact_date].join).to match(message)
+      end
+    end
+
+    context "when first contact date is entered in parts" do
+      let(:params) do
+        {
+          first_contact_date_1i: first_contact_date.year.to_s,
+          first_contact_date_2i: first_contact_date.month.to_s,
+          first_contact_date_3i: first_contact_date.day.to_s,
+        }
+      end
+
+      it "updates the incident" do
+        expect(incident.first_contact_date).to eq(first_contact_date)
+      end
+    end
+
+    context "with no date entered" do
+      let(:first_contact_date) { "" }
+      let(:incident) { create(:incident, first_contact_date: nil) }
+      let(:error_locale) { "first_contact_date.blank" }
+
+      it "is invalid" do
+        expect(described_form).not_to be_valid
+      end
+
+      it "generates an error" do
+        expect(described_form.errors[:first_contact_date].join).to match(message)
+      end
+    end
+
+    context "with an invalid partial occurred on date" do
+      let(:error_locale) { "first_contact_date.date_not_valid" }
+      let(:params) do
+        {
+          first_contact_date_1i: first_contact_date.year.to_s,
+          first_contact_date_2i: "",
+          first_contact_date_3i: first_contact_date.day.to_s,
+        }
+      end
+
+      it "is invalid" do
+        expect(described_form).not_to be_valid
+      end
+
+      it "generates an error" do
+        expect(described_form.errors[:first_contact_date].join).to match(message)
+      end
+    end
+  end
+end

--- a/spec/requests/providers/application_merits_task/when_contact_was_made_controller_spec.rb
+++ b/spec/requests/providers/application_merits_task/when_contact_was_made_controller_spec.rb
@@ -1,0 +1,151 @@
+require "rails_helper"
+
+module Providers
+  module ApplicationMeritsTask
+    RSpec.describe WhenContactWasMadeController do
+      let(:legal_aid_application) { create(:legal_aid_application, :with_public_law_family_appeal) }
+      let(:login_provider) { login_as legal_aid_application.provider }
+      let(:smtl) { create(:legal_framework_merits_task_list, :pbm01a_as_applicant, legal_aid_application:) }
+
+      describe "GET /providers/applications/:legal_aid_application_id/when_contact_was_made" do
+        subject(:get_request) do
+          get providers_legal_aid_application_when_contact_was_made_path(legal_aid_application)
+        end
+
+        before do
+          login_provider
+          get_request
+        end
+
+        it "renders successfully" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        context "when not authenticated" do
+          let(:login_provider) { nil }
+
+          it_behaves_like "a provider not authenticated"
+        end
+
+        context "with an existing incident" do
+          let(:incident) { create(:incident) }
+          let(:legal_aid_application) { create(:legal_aid_application, latest_incident: incident) }
+
+          it "renders successfully" do
+            expect(response).to have_http_status(:ok)
+          end
+
+          it "displays first_contact_date for incident" do
+            expect(response.body).to include(incident.first_contact_date.day.to_s)
+            expect(response.body).to include(incident.first_contact_date.month.to_s)
+            expect(response.body).to include(incident.first_contact_date.year.to_s)
+          end
+        end
+      end
+
+      describe "PATCH /providers/applications/:legal_aid_application_id/when_contact_was_made" do
+        subject(:patch_request) do
+          patch(
+            providers_legal_aid_application_when_contact_was_made_path(legal_aid_application),
+            params: params.merge(button_clicked),
+          )
+        end
+
+        let(:first_contact_date) { 5.days.ago.to_date }
+        let(:first_contact_date_3i) { first_contact_date.day }
+        let(:params) do
+          {
+            application_merits_task_incident: {
+              "first_contact_date(3i)": first_contact_date_3i,
+              "first_contact_date(2i)": first_contact_date.month,
+              "first_contact_date(1i)": first_contact_date.year,
+            },
+          }
+        end
+        let(:draft_button) { { draft_button: "Save as draft" } }
+        let(:button_clicked) { {} }
+        let(:incident) { legal_aid_application.reload.latest_incident }
+
+        before do
+          allow(LegalFramework::MeritsTasksService).to receive(:call).with(legal_aid_application).and_return(smtl)
+          login_provider
+        end
+
+        it "creates a new incident with the values entered" do
+          expect { patch_request }.to change(::ApplicationMeritsTask::Incident, :count).by(1)
+          expect(incident.first_contact_date).to eq(first_contact_date)
+        end
+
+        it "sets the task to complete" do
+          patch_request
+          expect(legal_aid_application.legal_framework_merits_task_list).to have_completed_task(:application, :when_contact_was_made)
+        end
+
+        it "redirects to the next page" do
+          patch_request
+          expect(response).to have_http_status(:redirect)
+        end
+
+        context "when not authenticated" do
+          let(:login_provider) { nil }
+
+          before { patch_request }
+
+          it_behaves_like "a provider not authenticated"
+        end
+
+        context "when incomplete" do
+          let(:first_contact_date_3i) { "" }
+
+          it "renders show" do
+            patch_request
+            expect(response).to have_http_status(:ok)
+          end
+
+          it "does not set the task to complete" do
+            patch_request
+            expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:application, :when_contact_was_made)
+          end
+        end
+
+        context "with alpha-numeric date" do
+          let(:first_contact_date_3i) { "6s2" }
+
+          it "renders show" do
+            patch_request
+            expect(response).to have_http_status(:ok)
+          end
+
+          it "contains error message" do
+            patch_request
+            expect(response.body).to include("govuk-error-summary")
+            expect(response.body).to include(I18n.t("activemodel.errors.models.application_merits_task/incident.attributes.first_contact_date.date_not_valid"))
+          end
+        end
+
+        context "when invalid" do
+          let(:first_contact_date_3i) { "32" }
+
+          it "renders show" do
+            patch_request
+            expect(response).to have_http_status(:ok)
+          end
+        end
+
+        context "when save as draft selected" do
+          let(:button_clicked) { draft_button }
+
+          it "redirects to provider draft endpoint" do
+            patch_request
+            expect(response).to have_http_status(:redirect)
+          end
+
+          it "does not set the task to complete" do
+            patch_request
+            expect(legal_aid_application.legal_framework_merits_task_list).to have_not_started_task(:application, :when_contact_was_made)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/flow/steps/provider_merits/when_contact_was_made_step_spec.rb
+++ b/spec/services/flow/steps/provider_merits/when_contact_was_made_step_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Flow::Steps::ProviderMerits::WhenContactWasMadeStep, type: :request do
+  let(:legal_aid_application) { create(:legal_aid_application) }
+
+  describe "#path" do
+    subject { described_class.path.call(legal_aid_application) }
+
+    it { is_expected.to eq providers_legal_aid_application_when_contact_was_made_path(legal_aid_application) }
+  end
+
+  describe "#forward" do
+    subject { described_class.forward.call(legal_aid_application) }
+
+    before do
+      allow(Flow::MeritsLoop).to receive(:forward_flow).and_return(:merits_task_lists)
+    end
+
+    it { is_expected.to eq :merits_task_lists }
+  end
+
+  describe "#check_answers" do
+    subject { described_class.check_answers }
+
+    it { is_expected.to eq :check_merits_answers }
+  end
+end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5620)

Add a new page 'When client made contact' which will be shown as the first page in the merits task list (at an application level) for all proceeding types except for DA and SCA (so currently for S8 and PLF).

In the case of a combined DA and S8 application, the old latest incident details page should still be shown, not the new page.  

> [!CAUTION]
> Do not merge until the commit to point at a specific LFA branch is removed

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
