### PR TITLE
Security: add idle timeout

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -4,7 +4,7 @@ class Provider < ApplicationRecord
   encrypts :auth_subject_uid, deterministic: true
   encrypts :silas_id, deterministic: true
 
-  devise :trackable
+  devise :trackable, :timeoutable
 
   serialize :roles, coder: YAML
   serialize :offices, coder: YAML

--- a/config/application.rb
+++ b/config/application.rb
@@ -88,6 +88,8 @@ module LaaApplyForLegalAid
 
     config.x.email_domain.suffix = ENV.fetch("APPLY_EMAIL", nil)
 
+    config.x.auth.timeout_in = 30.minutes
+
     config.x.omniauth_entraid.mock_auth_enabled = ENV.fetch("OMNIAUTH_ENTRAID_MOCK_AUTH_ENABLED", "false") == "true"
     config.x.omniauth_entraid.mock_username = ENV.fetch("OMNIAUTH_ENTRAID_MOCK_USERNAME", nil)
     config.x.omniauth_entraid.mock_password = ENV.fetch("OMNIAUTH_ENTRAID_MOCK_PASSWORD", nil)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -178,7 +178,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = Rails.configuration.x.auth.timeout_in
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
## What
Add idle session timeout

Coming out of security audit

> Idle session timeout is not working as expected; sessions remain active after extended inactivity.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
