### PR TITLE
AP-6260: Ignore npm based updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,9 @@ updates:
       day: tuesday
       time: "21:15"
       timezone: Europe/London
+    ignore:
+      - dependency-name: "*frontend*"
+      - dependency-name: "*"
     groups:
       moj-frontend:
         patterns:


### PR DESCRIPTION
## What
Ignore npm based updates

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6260)

Due to on-going supply chain attack on npm, termed shai-hulud.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
