### PR TITLE
AP-6260: ignore scripts and only used frozen lockfile to install JS dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ references:
   install_js_packages: &install_js_packages
     run:
       name: Install Yarn packages
-      command: yarn --frozen-lockfile
+      command: yarn install --frozen-lockfile --ignore-scripts
 
   update_packages: &update_packages
     run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN gem update --system \
 && bundle install
 
 COPY package.json yarn.lock ./
-RUN yarn --prod
+RUN NODE_ENV=production yarn install --prod --frozen-lockfile --ignore-scripts
 
 ####################
 # DEPENDENCIES END #

--- a/bin/setup
+++ b/bin/setup
@@ -74,7 +74,7 @@ class ApplicationRequirementSetup
 
   def yarn_install
     puts "\n== Installing JavaScript dependencies =="
-    system! 'yarn install'
+    system! 'yarn install --frozen-lockfile --ignore-scripts'
   end
 
   def restart


### PR DESCRIPTION
## What
Ignore scripts and only used frozen lockfile to install JS dependencies

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6260)

Mitgations against the Shai-Hulud attach.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
