### PR TITLE
AP-6260: Remove npm from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,25 +25,23 @@ updates:
           - "govuk-components"
           - "view_component"
     open-pull-requests-limit: 10
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: weekly
-      day: tuesday
-      time: "21:15"
-      timezone: Europe/London
-    ignore:
-      - dependency-name: "*frontend*"
-      - dependency-name: "*"
-    groups:
-      moj-frontend:
-        patterns:
-          - "*frontend*"
-      npm:
-        patterns:
-          - "*"
-    open-pull-requests-limit: 10
-    ignore:
-      # REMOVE once a satisfactory solution to https://github.com/jestjs/jest/issues/15674 is found
-      - dependency-name: "jest-environment-jsdom"
-        versions: [ ">=30.0.0" ]
+  # Removed until shai-hulud threat has abated
+  # - package-ecosystem: "npm"
+  #   directory: "/"
+  #   schedule:
+  #     interval: weekly
+  #     day: tuesday
+  #     time: "21:15"
+  #     timezone: Europe/London
+  #   groups:
+  #     moj-frontend:
+  #       patterns:
+  #         - "*frontend*"
+  #     npm:
+  #       patterns:
+  #         - "*"
+  #   open-pull-requests-limit: 10
+  #   ignore:
+  #     # REMOVE once a satisfactory solution to https://github.com/jestjs/jest/issues/15674 is found
+  #     - dependency-name: "jest-environment-jsdom"
+  #       versions: [ ">=30.0.0" ]


### PR DESCRIPTION
## What
Remove npm from dependabot

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6260)

Until threat from shai-hulud has abated.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
