### PR TITLE
ap-6252: update content on sca interrupt pages

### DIFF
--- a/config/locales/en/providers.yml
+++ b/config/locales/en/providers.yml
@@ -2052,7 +2052,7 @@ en:
           proceeding_issue_status: &default
             title_html: You cannot choose a special children act proceeding if it has not been issued
             option_bullets_html:
-              - select a different proceeding or matter type
+              - remove the proceeding and select a new one
               - go back and change your answer
               - use legal help
             options: "You can do one of the following:"
@@ -2069,13 +2069,13 @@ en:
             <<: *default
             title_html: For special children act, a supervision order cannot be varied, discharged or extended
             option_bullets_html:
-              - select a different proceeding or matter type
+              - remove the proceeding and select a new one
               - go back and change your answer
           child_subject:
             <<: *default
-            title_html: For special children act, your client must be the child subject of the proceeding
+            title_html: For special children act, your client must be the child subject of this proceeding
             option_bullets_html:
-              - select a different proceeding or matter type
+              - remove the proceeding and select a new one
               - go back and change your answer
           plf_none_selected:
             <<: *default

--- a/spec/requests/providers/proceedings_sca/interrupts_controller_spec.rb
+++ b/spec/requests/providers/proceedings_sca/interrupts_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Providers::ProceedingsSCA::InterruptsController do
         it "shows the expected interrupt content" do
           expect(page)
             .to have_content("For special children act, a supervision order cannot be varied, discharged or extended")
-            .and have_content("select a different proceeding or matter type")
+            .and have_content("remove the proceeding and select a new one")
             .and have_content("go back and change your answer")
             .and have_content("Remove the proceeding and select a new one")
         end
@@ -57,8 +57,8 @@ RSpec.describe Providers::ProceedingsSCA::InterruptsController do
 
         it "shows the expected interrupt content" do
           expect(page)
-            .to have_content("For special children act, your client must be the child subject of the proceeding")
-            .and have_content("select a different proceeding or matter type")
+            .to have_content("For special children act, your client must be the child subject of this proceeding")
+            .and have_content("remove the proceeding and select a new one")
             .and have_content("go back and change your answer")
             .and have_content("Remove the proceeding and select a new one")
         end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6252)

Updated content on sca interrupt pages.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The [development standards](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/5503385837/Development+standards) and [Git Workflow](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) documentation on Confluence should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
